### PR TITLE
DRAFT: add resample method (via RasterIOEx)

### DIFF
--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -470,6 +470,8 @@ Rcpp::DataFrame _combine(
 		std::string dataType = "UInt32",
 		Rcpp::Nullable<Rcpp::CharacterVector> options = R_NilValue) {
 
+  std::string resample; 
+  resample = "nearest"; // placeholder
 	std::size_t nrasters = (std::size_t) src_files.size();
 	
 	std::vector<GDALRaster> src_ds;
@@ -527,7 +529,7 @@ Rcpp::DataFrame _combine(
 		for (std::size_t i = 0; i < nrasters; ++i)
 			rowdata.row(i) = Rcpp::as<Rcpp::IntegerVector>(
 								src_ds[i].read(
-								bands[i], 0, y, ncols, 1, ncols, 1)
+								bands[i], 0, y, ncols, 1, ncols, 1, resample)
 								);
 									
 		cmbid = tbl.updateFromMatrix(rowdata, 1);

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -105,7 +105,7 @@ class GDALRaster {
 			std::string mdi_name, std::string domain) const;
 	
 	SEXP read(int band, int xoff, int yoff, int xsize, int ysize,
-			int out_xsize, int out_ysize) const;
+			int out_xsize, int out_ysize, std::string resample) const;
 				
 	void write(int band, int xoff, int yoff, int xsize, int ysize,
 			Rcpp::RObject rasterData);


### PR DESCRIPTION
I haven't done any documentation or testing. It's a bit cute to use DATAPOINTER, but I had fun with it so here's a way of comparing some of the resampling methods. 

- to pass in resample we need GDALRasterIOEx 
- GDALRasterIOEx uses GSpacing instead int for pixel/line space, and psExtraArg for the method
- very likely the conversion from character `resample` to `GDALRIOResampleAlg` enum constant could be neater, and reused


I've left the resample method as a placeholder in combine() because I've made no effort to explore the implications (or testing or doc).   I learnt a lot and it might be of use, but I completely understand if it's not ready to go as a PR. thanks! 

``` r
 library(gdalraster)
#> GDAL 3.8.0dev-0ae885e6d8-dirty, released 2023/05/10 (debug build)
 ## remotes::install_github("hypertidy/dsn")
 #m <- matrix(c(0:7, 6:0), 5)
 m <- matrix(c(0:9, 9:0), 5)
 
 dsn::mem(m)  ## useful, but tenuous given garbage collection (it eventually degrades so the Open and read should stay close together)
#> [1] "MEM:::DATAPOINTER=\"93893337825024\",PIXELS=5,LINES=4,BANDS=1,DATATYPE=Float64,GEOTRANSFORM=0/1/0/4/0/-1,PIXELOFFSET=0,LINEOFFSET=0,BANDOFFSET=1"
 ds <- new(GDALRaster, dsn::mem(m), read_only = TRUE)
 dm <- c(ds$getRasterXSize(), ds$getRasterYSize())
 nf <- 10
 method <- c("nearest", "bilinear", "cubic", "cubicspline", "lanczos")
op <-  par(mfrow = n2mfrow(length(method)), mar = par("mar")/1.5)
 for (i in seq_along(method)) {
   m2 <- ds$read(1, 0, 0, dm[1L], dm[2L], dm[1L] * nf, dm[2L] * nf, method[i])
  image(m2, main = method[i], asp = 1)
 }
 ds$close()
 ds <- new(GDALRaster, dsn::mem(m2), read_only = TRUE)
 image(ds$read(1, 0, 0, dm[1L] * nf, dm[2L] * nf, dm[1L], dm[2L], "rms"), main = "rms", asp = 1)
```

![](https://i.imgur.com/1xqfFeb.png)<!-- -->

``` r
 par(op)
```

<sup>Created on 2023-05-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
