### PR TITLE
GDALRaster::getMetadata(): fix for band-level metadata when not in the default domain

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# gdalraster dev
+
+* fix: `GDALRaster$getMetadata()`: requesting band-level metadata for a domain other than the default metadata domain was returning dataset-level metadata instead (2023-05-29)
+
 # gdalraster 1.2.0
 
 * starting at v. 1.2.0, `gdalraster` will require R >= 4.2.0

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -379,7 +379,7 @@ Rcpp::CharacterVector GDALRaster::getMetadata(int band,
 		if (domain == "")
 			papszMetadata = GDALGetMetadata(hBand, NULL);
 		else
-			papszMetadata = GDALGetMetadata(hDataset, domain.c_str());
+			papszMetadata = GDALGetMetadata(hBand, domain.c_str());
 	}
 	
 	int items = CSLCount(papszMetadata);

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -1,5 +1,5 @@
-/* R interface to a subset of the GDAL C API for low level raster I/O
-   See: https://gdal.org/api/raster_c_api.html)
+/* R interface to a subset of the GDAL C API for raster
+   https://gdal.org/api/raster_c_api.html
    Chris Toney <chris.toney at usda.gov> */
 
 #ifndef gdalraster_H


### PR DESCRIPTION
requesting band-level metadata for a domain other than the default domain was returning dataset-level metadata instead