### PR TITLE
plot_raster(): data argument can be a GDALRaster object to read from

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,20 +18,20 @@ Description: Interface to the raster API of the 'Geospatial Data Abstraction
     Library' ('GDAL') supporting manual creation of uninitialized datasets,
     creation from existing raster as template, low level I/O, configuration of
     virtual raster (VRT), coordinate transformation, and access to 'gdalwarp'
-    for reprojection. Convenience functions facilitate working with spatial
-    reference systems. Calling signatures resemble the native C, C++ and
-    Python APIs provided by the 'GDAL' project (<https://gdal.org>).
-    Bindings to 'GDAL' are implemented in class 'GDALRaster' along with
-    several stand-alone functions. Additional functionality includes: class
-    'RunningStats' for efficient summary statistics on large data streams;
-    class 'CmbTable' for counting unique combinations of integer values with a
-    hash table; a raster overlay utility to identify and count unique
-    combinations across multiple inputs; and a calculation utility for
-    evaluating an R expression on raster layers with pixel coordinates
-    available as variables. 'gdalraster' may be suitable for applications that
-    primarily need low-level raster I/O or prefer native 'GDAL'-like calling.
-    Additional functionality is somewhat aimed at thematic data analysis but
-    may have other utility.
+    for reprojection. Includes selected 'GDAL' algorithms and functions for
+    working with spatial reference systems. Calling signatures resemble the
+    native C, C++ and Python APIs provided by the 'GDAL' project
+    (<https://gdal.org>). Bindings are implemented via an exposed C++
+    class and several stand-alone functions. Additional functionality includes:
+    class 'RunningStats' for efficient summary statistics on large data
+    streams; class 'CmbTable' for counting unique combinations of integers with
+    a hash table; raster overlay to identify and count unique pixel
+    combinations across multiple inputs; raster calculate by evaluating
+    any R expression on a stack of layers with pixel coordinates available as
+    variables; and display using base 'graphics'. 'gdalraster' may be suitable
+    for applications that primarily need low-level raster I/O or prefer
+    'GDAL'-like calling. Additional functionality is somewhat aimed at thematic
+    data analysis but may have other utility.
 License: MIT + file LICENSE
 Copyright: See file inst/COPYRIGHTS for details.
 URL: https://usdaforestservice.github.io/gdalraster/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gdalraster 1.3.1 (dev)
 
+* `plot_raster()` now accepts a `GDALRaster` object for the `data` argument. Previously `data` could only be a vector of pixel values that had already been read in (2023-07-15)
+
 * add test suite and codecov reporting (2023-07-02)
 
 * add `GDALRaster$dim()`: returns a vector of xsize, ysize, nbands (2023-06-29)

--- a/R/display.R
+++ b/R/display.R
@@ -31,40 +31,32 @@
 	nbands <- dim(a)[3]
 	
 	if ( !(nbands %in% c(1,3)) )
-		stop("Number of bands must be 1 or 3")
-	
-	has_na <- logical(0)
-	nas <- array()
+		stop("Number of bands must be 1 or 3", call.=FALSE)
+
 	r <- array()
 	
 	if (!is.null(col_tbl)) {
 		# map to a color table
-		
 		if(nbands != 1)
-			stop("A color table can only be used with single-band data.")
+			stop("A color table can only be used with single-band data.",
+					call.=FALSE)
 			
 		if(!is.data.frame(ct <- as.data.frame(col_tbl)))
-			stop("Color table must be a matrix or data frame.")
+			stop("Color table must be a matrix or data frame.", call.=FALSE)
 		
 		if(ncol(ct) != 4)
-			stop("Color table must have four columns.")
-
-		nas <- is.na(a)
-		has_na <- any(nas)
-		if (has_na) {
-			dim(nas) <- dim(nas)[1:2]
-			nas <- t(nas)
-		}
+			stop("Color table must have four columns.", call.=FALSE)
 		
 		ct[,5] <- rgb(ct[,2], ct[,3], ct[,4])
 		f <- function(x) { ct[ct[,1]==x, 5][1] }
 		r <- vapply(a, FUN=f, FUN.VALUE="#000000", USE.NAMES=FALSE)
+		if (anyNA(r))
+			r[is.na(r)] <- na_col
 		dim(r) <- dim(a)[2:1]
 		class(r) <- "raster"
 	}
 	else {
 		# gray/rgb color scaling
-		
 		if (normalize) {
 			if (!is.null(minmax_def)) {
 				for (b in 1:nbands) {
@@ -90,9 +82,11 @@
 		if (is.null(col_map_fn))
 			col_map_fn <- ifelse(nbands==1, grDevices::gray, grDevices::rgb)
 		
-		nas <- is.na(a)
-		has_na <- any(nas)
-		if (has_na) {
+		has_na <- FALSE
+		nas <- array()
+		if (anyNA(a)) {
+			has_na <- TRUE
+			nas <- is.na(a)
 			a[nas] <- 0
 			if (dim(nas)[3] == 3)
 				nas <- nas[,,1] | nas[,,2] | nas[,,3]
@@ -113,31 +107,41 @@
 			dim(r) <- dim(a)[2:1]
 			class(r) <- "raster"
 		}
+		
+		if (has_na)
+        	r[nas] <- na_col
 	}
-	
-	if (has_na)
-        r[nas] <- na_col
 	
 	return(r)
 }
 
-#' Display raster data that have been read into a vector
+#' Display raster data
 #'
-#' `plot_raster()` displays raster data using base graphics.
+#' `plot_raster()` displays raster data using base `graphics`.
 #'
-#' @param data A numeric vector of pixel data to display, arranged in left to
-#' right, top to bottom pixel order.
-#' @param xsize The number of pixels along the x dimension in `data`.
-#' @param ysize The number of pixels along the y dimension in `data`.
+#' @param data Either a `GDALRaster` object from which data will be read, or
+#' a numeric vector of pixel values arranged in left to right, top to
+#' bottom order.
+#' @param xsize The number of pixels along the x dimension in `data`. If `data`
+#' is a `GDALRaster` object, specifies the size at which the raster will be
+#' read (used for argument `out_xsize` in `GDALRaster$read()`). By default,
+#' the entire raster will be read at full resolution.
+#' @param ysize The number of pixels along the y dimension in `data`. If `data`
+#' is a `GDALRaster` object, specifies the size at which the raster will be
+#' read (used for argument `out_ysize` in `GDALRaster$read()`). By default,
+#' the entire raster will be read at full resolution.
 #' @param nbands The number of bands in `data`. Must be either 1 (grayscale) or
 #' 3 (RGB). For RGB, `data` are interleaved by band.
+#' @param max_pixels The maximum number of pixels that the function will
+#' use for display (per band). An error is raised if `(xsize * ysize)` exceeds
+#' this value. Setting to `NULL` turns off this check.
 #' @param col_tbl A color table as a matrix or data frame with four columns.
 #' Column 1 contains the numeric raster values, columns 2:4 contain the
 #' intensities (between 0 and 1) of the red, green and blue primaries.
 #' @param normalize Logical. `TRUE` to rescale pixel values so that their
 #' range is `[0,1]`, normalized to the full range of the pixel data by default
 #' (`min(data)`, `max(data)`, per band). Ignored if `col_tbl` is used.
-#' `normalize=FALSE` if a custom color mapping function is used that
+#' Set `normalize` to `FALSE` if a color map function is used that
 #' operates on raw pixel values (see `col_map_fn` below).
 #' @param minmax_def Normalize to user-defined min/max values (in terms of
 #' the pixel data, per band). For single-band grayscale, a numeric vector of
@@ -146,11 +150,11 @@
 #' @param minmax_pct_cut Normalize to a truncated range of the pixel data using
 #' percentile cutoffs (removes outliers). A numeric vector of length two giving
 #' the percentiles to use (e.g., `c(2, 98)`). Applied per band. Ignored if
-#' `minmax_def` is used. Set `normalize=FALSE` if using a color mapping
-#' function that operates on raw pixel values.
+#' `minmax_def` is used.
 #' @param col_map_fn An optional color map function (default is 
 #' `grDevices::gray` for single-band data or `grDevices::rgb` for 3-band).
-#' Ignored if `col_tbl` is used.
+#' Ignored if `col_tbl` is used. Set `normalize` to `FALSE` if using a color
+#' map function that operates on raw pixel values.
 #' @param xlim Numeric vector of length two giving the x coordinate range. The
 #' default uses pixel/line coordinates (`c(0, xsize)`).
 #' @param ylim Numeric vector of length two giving the y coordinate range. The
@@ -167,7 +171,7 @@
 #' @param axes Logical. `TRUE` to draw axes (the default).
 #' @param main The main title (on top).
 #' @param legend Logical indicating whether to include a legend on the plot.
-#' By deafult, a legend will be included if plotting single-band data without
+#' By default, a legend will be included if plotting single-band data without
 #' `col_tbl` specified. Legend is not currently supported for color tables or
 #' with 3-band RGB data.
 #' @param na_col Color to use for `NA` as a 7- or 9-character hexadecimal code.
@@ -179,12 +183,25 @@
 #' `plot_raster()` uses the function `graphics::rasterImage()` for plotting
 #' which is not supported on some devices (see `?rasterImage`).
 #'
-#' A reduced resolution overview for display can be read by setting `out_xsize`
-#' and `out_ysize` smaller than the raster region specified by `xsize`, `ysize`
-#' in calls to `GDALRaster$read()` or `read_ds()`.
-#' The GDAL_RASTERIO_RESAMPLING configuration option can be defined to 
-#' override the default resampling to one of BILINEAR, CUBIC, CUBICSPLINE, 
-#' LANCZOS, AVERAGE or MODE.
+#' If `data` is an object of class `GDALRaster`, then `plot_raster()` will
+#' attempt to read the entire raster into memory by default (unless the number
+#' of pixels per band would exceed `max_pixels`).
+#' A reduced resolution overview can be read by setting `xsize`, `ysize`
+#' smaller than the raster size on disk.
+#' (If `data` is instead specified as a vector of pixel values, a reduced
+#' resolution overview would be read by setting `out_xsize` and `out_ysize`
+#' smaller than the raster region defined by `xsize`, `ysize` in a call to
+#' `GDALRaster$read()`).
+#' The GDAL_RASTERIO_RESAMPLING configuration option can be
+#' defined to override the default resampling to one of BILINEAR, CUBIC,
+#' CUBICSPLINE, LANCZOS, AVERAGE or MODE, for example:
+#' \preformatted{
+#' set_config_option("GDAL_RASTERIO_RESAMPLING", "BILINEAR")
+#' }
+#' Display may be slow for large pixel counts when applying a color table.
+#' Reading the raster at reduced resolution will improve performance in that
+#' case (use default resampling NEAREST, or possibly MODE, for thematic
+#' data).
 #'
 #' @seealso
 #' [`GDALRaster$read()`][GDALRaster], [read_ds()], [set_config_option()]
@@ -193,39 +210,33 @@
 #' ## Elevation
 #' elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
 #' ds <- new(GDALRaster, elev_file, read_only=TRUE)
-#' ncols <- ds$getRasterXSize()
-#' nrows <- ds$getRasterYSize()
-#' r <- read_ds(ds)
-#' ds$close()
 #'
 #' # grayscale
-#' plot_raster(r, xsize=ncols, ysize=nrows, main="Storm Lake elevation (m)")
+#' plot_raster(ds, main="Storm Lake elevation (m)")
 #'
 #' # color ramp
-#' elev_pal <- c("#008435","#B4E34F","#F5D157","#CF983B","#B08153","#FFFFFF")
+#' elev_pal <- c("#00A60E","#63C600","#E6E600","#E9BD3B",
+#'               "#ECB176","#EFC2B3","#F2F2F2")
 #' ramp <- scales::colour_ramp(elev_pal, alpha=FALSE)
-#' plot_raster(r, xsize=ncols, ysize=nrows, col_map_fn=ramp,
-#'             main="Storm Lake elevation (m)")
+#' plot_raster(ds, col_map_fn=ramp, main="Storm Lake elevation (m)")
+#'
+#' ds$close()
 #'
 #' ## Landsat band combination
 #' b4_file <- system.file("extdata/sr_b4_20200829.tif", package="gdalraster")
 #' b5_file <- system.file("extdata/sr_b5_20200829.tif", package="gdalraster")
 #' b6_file <- system.file("extdata/sr_b6_20200829.tif", package="gdalraster")
 #' band_files <- c(b6_file, b5_file, b4_file)
-#' 
-#' ds <- new(GDALRaster, b5_file, read_only=TRUE)
-#' ncols <- ds$getRasterXSize()
-#' nrows <- ds$getRasterYSize()
-#' ds$close()
 #'
 #' r <- vector("integer")
 #' for (f in band_files) {
 #'   ds <- new(GDALRaster, f, read_only=TRUE)
+#'   dm <- ds$dim()
 #'   r <- c(r, read_ds(ds))
 #'   ds$close()
 #' }
 #'
-#' plot_raster(r, xsize=ncols, ysize=nrows, nbands=3,
+#' plot_raster(r, xsize=dm[1], ysize=dm[2], nbands=3,
 #'             main="Landsat 6-5-4 (vegetative analysis)")
 #'
 #' ## LANDFIRE existing veg cover with colors from the CSV attribute table
@@ -236,36 +247,56 @@
 #' vat <- vat[,c(1,6:8)]
 #' 
 #' ds <- new(GDALRaster, evc_file, read_only=TRUE)
-#' ncols <- ds$getRasterXSize()
-#' nrows <- ds$getRasterYSize()
-#' 
-#' r <- read_ds(ds)
-#' ds$close()
-#' plot_raster(r, xsize=ncols, ysize=nrows, col_tbl=vat, interpolate=FALSE,
+#' plot_raster(ds, col_tbl=vat, interpolate=FALSE,
 #'             main="Storm Lake Existing Vegetation Cover")
+#'
+#' ds$close()
 #' @export
-plot_raster <- function(data, xsize, ysize, nbands=1,
-						col_tbl=NULL, normalize=TRUE, minmax_def=NULL,
-						minmax_pct_cut=NULL, col_map_fn=NULL,
+plot_raster <- function(data, xsize=NULL, ysize=NULL, nbands=1,
+						max_pixels=2.5e7, col_tbl=NULL, normalize=TRUE,
+						minmax_def=NULL, minmax_pct_cut=NULL, col_map_fn=NULL,
 						xlim=c(0, xsize), ylim=c(ysize, 0),
 						interpolate=TRUE, asp=1, axes=TRUE, main="",
 						xlab="x", ylab="y", xaxs="i", yaxs="i", 
 						legend=NULL, na_col=rgb(0,0,0,0), ...) {
 
-	if ( !(nbands %in% c(1,3)) )
-		stop("Number of bands must be 1 or 3")
-		
 	if (isTRUE((grDevices::dev.capabilities()$rasterImage == "no"))) {
 		message("Device does not support rasterImage().")
 		return()
 	}
 	
-	if (length(data) == 0)
-		stop("length(data) is 0.")
+	if ( !(nbands %in% c(1,3)) )
+		stop("Number of bands must be 1 or 3", call.=FALSE)
 		
-	if (xsize < 1 || ysize < 1)
-		stop("Invalid x/y dimensions.")
-		
+	if (is.null(max_pixels))
+		max_pixels = Inf
+	
+	if (is(data, "Rcpp_GDALRaster")) {
+		dm <- data$dim()
+		if (is.null(xsize))
+			xsize <- out_xsize <- dm[1]
+		else
+			out_xsize <- xsize
+		if (is.null(ysize))
+			ysize <- out_ysize <- dm[2]
+		else
+			out_ysize <- ysize
+
+		if ((out_xsize*out_ysize) > max_pixels)
+			stop("xsize * ysize exceeds max_pixels.", call.=FALSE)
+			
+		data_in <- read_ds(data, bands=1:nbands, xoff=0, yoff=0,
+							xsize=dm[1], ysize=dm[2],
+							out_xsize=out_xsize, out_ysize=out_ysize)
+	}
+	else {
+		if (is.null(xsize) || is.null(ysize))
+			stop("xsize and ysize of data must be specified.", call.=FALSE)
+		if ((xsize*ysize) > max_pixels)
+			stop("xsize * ysize exceeds max_pixels.", call.=FALSE)
+		data_in <- data
+	}
+
 	if (is.null(legend)) {
 		if (nbands==1 && is.null(col_tbl))
 			legend <- TRUE
@@ -273,7 +304,7 @@ plot_raster <- function(data, xsize, ysize, nbands=1,
 			legend <- FALSE
 	}
 
-	a <- array(data, dim = c(xsize, ysize, nbands))
+	a <- array(data_in, dim = c(xsize, ysize, nbands))
 	r <- .as_raster(a,
 					col_tbl=col_tbl,
 					normalize=normalize,
@@ -306,22 +337,25 @@ plot_raster <- function(data, xsize, ysize, nbands=1,
 							xaxs=xaxs, yaxs=yaxs, ...)
 	graphics::rasterImage(r, xlim[1], ylim[1], xlim[2], ylim[2],
 							interpolate=interpolate)
-	graphics::title(main=main, xlab=xlab, ylab=ylab)
 	if (axes) {
+		graphics::title(main=main, xlab=xlab, ylab=ylab)
 		graphics::axis(1)
 		graphics::axis(2)
+	}
+	else {
+		graphics::title(main=main)
 	}
 	if (legend) {
 		mm <- NULL
 		if (!is.null(minmax_def))
 			mm <- minmax_def
 		else if (!is.null(minmax_pct_cut))
-			mm <- stats::quantile(data,
+			mm <- stats::quantile(data_in,
 									probs=c(minmax_pct_cut[1] / 100,
 											minmax_pct_cut[2] / 100),
 									na.rm = TRUE, names=FALSE)
 		else
-			mm <- c(min(data, na.rm=TRUE), max(data, na.rm=TRUE))
+			mm <- c(min(data_in, na.rm=TRUE), max(data_in, na.rm=TRUE))
 
 		leg_data <- .normalize(seq(mm[1], mm[2], length.out=100))
 		leg_img <- grDevices::as.raster(matrix(rev(col_map_fn(leg_data)),
@@ -329,9 +363,15 @@ plot_raster <- function(data, xsize, ysize, nbands=1,
 		graphics::par(mar=c(6, 0.5, 6, 2) + 0.1)
 		graphics::plot(c(0,2), c(0,1), type="n", axes=FALSE,
 						xlab="", ylab="", main="")
-		graphics::text(x=1.5, y=seq(0, 1, length.out=5),
-						labels=seq(mm[1], mm[2], length.out=5),
-						adj=c(0, NA), xpd=TRUE)
+		if (is(data_in, "integer"))
+			leg_lab <- round(seq(mm[1], mm[2], length.out=5))
+		else
+			leg_lab <- seq(mm[1], mm[2], length.out=5)
+		graphics::text(x=1.5,
+						y=seq(0, 1, length.out=5),
+						labels=leg_lab,
+						adj=c(0, NA),
+						xpd=TRUE)
 		graphics::rasterImage(leg_img, 0, 0, 1, 1)
 		graphics::par(op)  # reset to original
 	}

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -474,14 +474,13 @@
 #' \donttest{
 #' ## using a GDAL Virtual File System handler '/vsicurl/'
 #' ## see: https://gdal.org/user/virtual_file_systems.html
+#' url <- "/vsicurl/https://raw.githubusercontent.com/"
+#' url <- paste0(url, "usdaforestservice/gdalraster/main/sample-data/")
+#' url <- paste0(url, "lf_elev_220_mt_hood_utm.tif")
 #'
-#' web_file <- "/vsicurl/https://raw.githubusercontent.com"
-#' web_file <- paste0(web_file, "/django/django/main/tests/gis_tests/")
-#' web_file <- paste0(web_file, "data/rasters/raster.tif")
-#'
-#' ds_url <- new(GDALRaster, web_file, read_only=TRUE)
-#' ds_url$info()
-#' ds_url$close()
+#' ds <- new(GDALRaster, url, read_only=TRUE)
+#' plot_raster(ds, main="Mount Hood elevation (m)")
+#' ds$close()
 #' }
 NULL
 

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -478,14 +478,13 @@ ds$close()
 \donttest{
 ## using a GDAL Virtual File System handler '/vsicurl/'
 ## see: https://gdal.org/user/virtual_file_systems.html
+url <- "/vsicurl/https://raw.githubusercontent.com/"
+url <- paste0(url, "usdaforestservice/gdalraster/main/sample-data/")
+url <- paste0(url, "lf_elev_220_mt_hood_utm.tif")
 
-web_file <- "/vsicurl/https://raw.githubusercontent.com"
-web_file <- paste0(web_file, "/django/django/main/tests/gis_tests/")
-web_file <- paste0(web_file, "data/rasters/raster.tif")
-
-ds_url <- new(GDALRaster, web_file, read_only=TRUE)
-ds_url$info()
-ds_url$close()
+ds <- new(GDALRaster, url, read_only=TRUE)
+plot_raster(ds, main="Mount Hood elevation (m)")
+ds$close()
 }
 }
 \seealso{

--- a/man/gdalraster-package.Rd
+++ b/man/gdalraster-package.Rd
@@ -14,9 +14,9 @@
   Core functionality is contained in the \code{GDALRaster} class and several 
   GDAL related stand-alone functions:
   \itemize{
-  \item class \code{\link{GDALRaster}} allows opening a raster dataset and 
-  calling methods on the Dataset, Driver and RasterBand objects in the 
-  underlying API (get/set parameters, read/write pixel data).
+  \item \code{\link{GDALRaster}} exposes a C++ class that allows opening a
+  raster dataset and calling methods on the Dataset, Driver and RasterBand
+  objects in the underlying API (get/set parameters, read/write pixel data).
   
   \item raster creation: \code{\link{create}}, \code{\link{createCopy}}, 
   \code{\link{rasterFromRaster}}
@@ -68,7 +68,8 @@
   coordinate system or inverse projected longitude/latitude.
   
   \item \code{\link{plot_raster}} displays raster data using base R
-  graphics.
+  \code{graphics}. Supports single-band grayscale, RGB, color tables and color
+  map functions (e.g., color ramp).
   }
 }
 \author{

--- a/man/plot_raster.Rd
+++ b/man/plot_raster.Rd
@@ -2,13 +2,14 @@
 % Please edit documentation in R/display.R
 \name{plot_raster}
 \alias{plot_raster}
-\title{Display raster data that have been read into a vector}
+\title{Display raster data}
 \usage{
 plot_raster(
   data,
-  xsize,
-  ysize,
+  xsize = NULL,
+  ysize = NULL,
   nbands = 1,
+  max_pixels = 2.5e+07,
   col_tbl = NULL,
   normalize = TRUE,
   minmax_def = NULL,
@@ -30,15 +31,26 @@ plot_raster(
 )
 }
 \arguments{
-\item{data}{A numeric vector of pixel data to display, arranged in left to
-right, top to bottom pixel order.}
+\item{data}{Either a \code{GDALRaster} object from which data will be read, or
+a numeric vector of pixel values arranged in left to right, top to
+bottom order.}
 
-\item{xsize}{The number of pixels along the x dimension in \code{data}.}
+\item{xsize}{The number of pixels along the x dimension in \code{data}. If \code{data}
+is a \code{GDALRaster} object, specifies the size at which the raster will be
+read (used for argument \code{out_xsize} in \code{GDALRaster$read()}). By default,
+the entire raster will be read at full resolution.}
 
-\item{ysize}{The number of pixels along the y dimension in \code{data}.}
+\item{ysize}{The number of pixels along the y dimension in \code{data}. If \code{data}
+is a \code{GDALRaster} object, specifies the size at which the raster will be
+read (used for argument \code{out_ysize} in \code{GDALRaster$read()}). By default,
+the entire raster will be read at full resolution.}
 
 \item{nbands}{The number of bands in \code{data}. Must be either 1 (grayscale) or
 3 (RGB). For RGB, \code{data} are interleaved by band.}
+
+\item{max_pixels}{The maximum number of pixels that the function will
+use for display (per band). An error is raised if \code{(xsize * ysize)} exceeds
+this value. Setting to \code{NULL} turns off this check.}
 
 \item{col_tbl}{A color table as a matrix or data frame with four columns.
 Column 1 contains the numeric raster values, columns 2:4 contain the
@@ -47,7 +59,7 @@ intensities (between 0 and 1) of the red, green and blue primaries.}
 \item{normalize}{Logical. \code{TRUE} to rescale pixel values so that their
 range is \verb{[0,1]}, normalized to the full range of the pixel data by default
 (\code{min(data)}, \code{max(data)}, per band). Ignored if \code{col_tbl} is used.
-\code{normalize=FALSE} if a custom color mapping function is used that
+Set \code{normalize} to \code{FALSE} if a color map function is used that
 operates on raw pixel values (see \code{col_map_fn} below).}
 
 \item{minmax_def}{Normalize to user-defined min/max values (in terms of
@@ -58,12 +70,12 @@ six containing b1_min, b2_min, b3_min, b1_max, b2_max, b3_max.}
 \item{minmax_pct_cut}{Normalize to a truncated range of the pixel data using
 percentile cutoffs (removes outliers). A numeric vector of length two giving
 the percentiles to use (e.g., \code{c(2, 98)}). Applied per band. Ignored if
-\code{minmax_def} is used. Set \code{normalize=FALSE} if using a color mapping
-function that operates on raw pixel values.}
+\code{minmax_def} is used.}
 
 \item{col_map_fn}{An optional color map function (default is
 \code{grDevices::gray} for single-band data or \code{grDevices::rgb} for 3-band).
-Ignored if \code{col_tbl} is used.}
+Ignored if \code{col_tbl} is used. Set \code{normalize} to \code{FALSE} if using a color
+map function that operates on raw pixel values.}
 
 \item{xlim}{Numeric vector of length two giving the x coordinate range. The
 default uses pixel/line coordinates (\code{c(0, xsize)}).}
@@ -91,7 +103,7 @@ to the image when drawing (default \code{TRUE}).}
 (see \code{?par}).}
 
 \item{legend}{Logical indicating whether to include a legend on the plot.
-By deafult, a legend will be included if plotting single-band data without
+By default, a legend will be included if plotting single-band data without
 \code{col_tbl} specified. Legend is not currently supported for color tables or
 with 3-band RGB data.}
 
@@ -102,36 +114,47 @@ The default is transparent (\code{"#00000000"}, the return value of
 \item{...}{Other parameters to be passed to \code{plot.default()}.}
 }
 \description{
-\code{plot_raster()} displays raster data using base graphics.
+\code{plot_raster()} displays raster data using base \code{graphics}.
 }
 \note{
 \code{plot_raster()} uses the function \code{graphics::rasterImage()} for plotting
 which is not supported on some devices (see \code{?rasterImage}).
 
-A reduced resolution overview for display can be read by setting \code{out_xsize}
-and \code{out_ysize} smaller than the raster region specified by \code{xsize}, \code{ysize}
-in calls to \code{GDALRaster$read()} or \code{read_ds()}.
-The GDAL_RASTERIO_RESAMPLING configuration option can be defined to
-override the default resampling to one of BILINEAR, CUBIC, CUBICSPLINE,
-LANCZOS, AVERAGE or MODE.
+If \code{data} is an object of class \code{GDALRaster}, then \code{plot_raster()} will
+attempt to read the entire raster into memory by default (unless the number
+of pixels per band would exceed \code{max_pixels}).
+A reduced resolution overview can be read by setting \code{xsize}, \code{ysize}
+smaller than the raster size on disk.
+(If \code{data} is instead specified as a vector of pixel values, a reduced
+resolution overview would be read by setting \code{out_xsize} and \code{out_ysize}
+smaller than the raster region defined by \code{xsize}, \code{ysize} in a call to
+\code{GDALRaster$read()}).
+The GDAL_RASTERIO_RESAMPLING configuration option can be
+defined to override the default resampling to one of BILINEAR, CUBIC,
+CUBICSPLINE, LANCZOS, AVERAGE or MODE, for example:
+\preformatted{
+set_config_option("GDAL_RASTERIO_RESAMPLING", "BILINEAR")
+}
+Display may be slow for large pixel counts when applying a color table.
+Reading the raster at reduced resolution will improve performance in that
+case (use default resampling NEAREST, or possibly MODE, for thematic
+data).
 }
 \examples{
 ## Elevation
 elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
 ds <- new(GDALRaster, elev_file, read_only=TRUE)
-ncols <- ds$getRasterXSize()
-nrows <- ds$getRasterYSize()
-r <- read_ds(ds)
-ds$close()
 
 # grayscale
-plot_raster(r, xsize=ncols, ysize=nrows, main="Storm Lake elevation (m)")
+plot_raster(ds, main="Storm Lake elevation (m)")
 
 # color ramp
-elev_pal <- c("#008435","#B4E34F","#F5D157","#CF983B","#B08153","#FFFFFF")
+elev_pal <- c("#00A60E","#63C600","#E6E600","#E9BD3B",
+              "#ECB176","#EFC2B3","#F2F2F2")
 ramp <- scales::colour_ramp(elev_pal, alpha=FALSE)
-plot_raster(r, xsize=ncols, ysize=nrows, col_map_fn=ramp,
-            main="Storm Lake elevation (m)")
+plot_raster(ds, col_map_fn=ramp, main="Storm Lake elevation (m)")
+
+ds$close()
 
 ## Landsat band combination
 b4_file <- system.file("extdata/sr_b4_20200829.tif", package="gdalraster")
@@ -139,19 +162,15 @@ b5_file <- system.file("extdata/sr_b5_20200829.tif", package="gdalraster")
 b6_file <- system.file("extdata/sr_b6_20200829.tif", package="gdalraster")
 band_files <- c(b6_file, b5_file, b4_file)
 
-ds <- new(GDALRaster, b5_file, read_only=TRUE)
-ncols <- ds$getRasterXSize()
-nrows <- ds$getRasterYSize()
-ds$close()
-
 r <- vector("integer")
 for (f in band_files) {
   ds <- new(GDALRaster, f, read_only=TRUE)
+  dm <- ds$dim()
   r <- c(r, read_ds(ds))
   ds$close()
 }
 
-plot_raster(r, xsize=ncols, ysize=nrows, nbands=3,
+plot_raster(r, xsize=dm[1], ysize=dm[2], nbands=3,
             main="Landsat 6-5-4 (vegetative analysis)")
 
 ## LANDFIRE existing veg cover with colors from the CSV attribute table
@@ -162,13 +181,10 @@ head(vat)
 vat <- vat[,c(1,6:8)]
 
 ds <- new(GDALRaster, evc_file, read_only=TRUE)
-ncols <- ds$getRasterXSize()
-nrows <- ds$getRasterYSize()
-
-r <- read_ds(ds)
-ds$close()
-plot_raster(r, xsize=ncols, ysize=nrows, col_tbl=vat, interpolate=FALSE,
+plot_raster(ds, col_tbl=vat, interpolate=FALSE,
             main="Storm Lake Existing Vegetation Cover")
+
+ds$close()
 }
 \seealso{
 \code{\link[=GDALRaster]{GDALRaster$read()}}, \code{\link[=read_ds]{read_ds()}}, \code{\link[=set_config_option]{set_config_option()}}

--- a/vignettes/articles/raster-display.Rmd
+++ b/vignettes/articles/raster-display.Rmd
@@ -9,47 +9,43 @@ knitr::opts_chunk$set(
 )
 ```
 
-`gdalraster::plot_raster()` displays raster data that have been read into a vector.
+`plot_raster()` displays data using base R `graphics`. The function will read from an open dataset, or use pixel values that have already been read into a vector.
 
 ```{r setup}
 library(gdalraster)
 
-url_dir <- "/vsicurl/https://raw.githubusercontent.com/usdaforestservice/gdalraster/main/sample-data/"
+base_url <- "/vsicurl/https://raw.githubusercontent.com/usdaforestservice/gdalraster/main/sample-data/"
 ```
 
 ## Single-band grayscale or color ramp
 
 ```{r}
-f <- paste0(url_dir, "lf_elev_220_mt_hood_utm.tif")
+f <- paste0(base_url, "lf_elev_220_mt_hood_utm.tif")
 ds <- new(GDALRaster, f, read_only=TRUE)
-dm <- ds$dim()
-
-r <- read_ds(ds)
-ds$close()
 
 # gray
-plot_raster(r, xsize=dm[1], ysize=dm[2],
-            main="Mount Hood elevation (m)")
+plot_raster(ds, main="Mount Hood elevation (m)")
 
 # color ramp
-elev_pal <- c("#008435", "#B4E34F", "#F5D157", "#CF983B", "#B08153", "#FFFFFF")
+elev_pal <- c("#00A60E","#63C600","#E6E600","#E9BD3B","#ECB176","#EFC2B3","#F2F2F2")
 ramp <- scales::colour_ramp(elev_pal, alpha=FALSE)
-plot_raster(r, xsize=dm[1], ysize=dm[2], col_map_fn=ramp,
-            main="Mount Hood elevation (m)")
 
+plot_raster(ds, col_map_fn=ramp, main="Mount Hood elevation (m)")
+ds$close()
 ```
 
 ## RGB
 
 ```{r}
-f <- paste0(url_dir, "landsat_c2ard_sr_mt_hood_jul2022_utm.tif")
+f <- paste0(base_url, "landsat_c2ard_sr_mt_hood_jul2022_utm.tif")
 ds <- new(GDALRaster, f, read_only=TRUE)
 dm <- ds$dim()
 
+# passing a vector of pixel values rather than the open dataset
 r <- read_ds(ds, bands=c(7,5,4))
 ds$close()
 
-# normalize to ranges derived from the full Landsat scene (2-98 percentiles)
+# normalizing to ranges derived from the full Landsat scene (2-98 percentiles)
 plot_raster(r, xsize=dm[1], ysize=dm[2], nbands=3,
             minmax_def=c(7551,7679,7585,14842,24997,12451),
             main="Mount Hood July 2022 Landsat 7-5-4 (SWIR)")
@@ -59,31 +55,28 @@ plot_raster(r, xsize=dm[1], ysize=dm[2], nbands=3,
 ## Color table
 
 ```{r}
-f <- paste0(url_dir, "lf_fbfm40_220_mt_hood_utm.tif")
+f <- paste0(base_url, "lf_fbfm40_220_mt_hood_utm.tif")
 ds <- new(GDALRaster, f, read_only=TRUE)
 dm <- ds$dim()
-print(paste("Size is", dm[1], "x",  dm[2]))
+print(paste("Size is", dm[1], "x",  dm[2], "x", dm[3]))
 
-# use CSV attribute table distributed by LANDFIRE
+# using the CSV attribute table distributed by LANDFIRE
 fbfm_csv <- system.file("extdata/LF20_F40_220.csv", package="gdalraster")
 vat <- read.csv(fbfm_csv)
 head(vat)
 vat <- vat[,c(1,6:8)]
 
 # read at reduced resolution for display
-r <- read_ds(ds, out_xsize=507, out_ysize=400)
-ds$close()
-
-plot_raster(r, xsize=507, ysize=400, col_tbl=vat,
-            interpolate=FALSE,
+plot_raster(ds, xsize=dm[1] / 2, ysize=dm[2] / 2,
+			col_tbl=vat, interpolate=FALSE,
             main="LANDFIRE surface fuel class (FBFM40)")
- 
+ds$close()
 ```
 
 ## Label with geospatial coordinates
 
 ```{r}
-f <- paste0(url_dir, "bl_mrbl_ng_jul2004_rgb_720x360.tif")
+f <- paste0(base_url, "bl_mrbl_ng_jul2004_rgb_720x360.tif")
 
 ds <- new(GDALRaster, f, read_only=TRUE)
 dm <- ds$dim()
@@ -92,13 +85,9 @@ print(paste("Size is", dm[1], "x",  dm[2], "x", dm[3]))
 srs_is_projected(ds$getProjectionRef())
 bb <- ds$bbox()
 
-r <- read_ds(ds)
-ds$close()
-
-plot_raster(r, xsize=dm[1], ysize=dm[2], nbands=3,
-            xlim=c(bb[1],bb[3]), ylim=c(bb[2],bb[4]),
+plot_raster(ds, nbands=3, xlim=c(bb[1],bb[3]), ylim=c(bb[2],bb[4]),
             xlab="longitude", ylab="latitude",
             main="NASA Earth Observatory Blue Marble July 2004")
-
+ds$close()
 ```
 


### PR DESCRIPTION
Previously, `data`  was a vector of pixel values. It can now be either a vector of data, or a  `GDALRaster` object to read from.