### PR TITLE
add GDALRaster::getDefaultRAT()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gdalraster 1.5.1 (dev)
 
+* add `GDALRaster$getDefaultRAT()`: return Raster Attribute Table as a data frame (2023-10-04)
+
 * add `GDALRaster$getDefaultHistogram()`: fetch default raster histogram (2023-10-02)
 
 * add `GDALRaster$getHistogram()`: compute raster histogram for a band (2023-10-01)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -472,10 +472,10 @@ warp <- function(src_files, dst_filename, t_srs, cl_arg = NULL) {
 #' @param end_color Integer vector of length three or four.
 #' A color entry value to end the ramp (e.g., RGB values).
 #' @param palette_interp One of "Gray", "RGB" (the default), "CMYK" or "HLS"
-#' descibing interpretation of `start_color` and `end_color` values
+#' describing interpretation of `start_color` and `end_color` values
 #' (see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL 
 #' Color Table}).
-#' @returns Intger matrix with five columns containing the color ramp from
+#' @returns Integer matrix with five columns containing the color ramp from
 #' `start_index` to `end_index`, with raster index values in column 1 and
 #' color entries in columns 2:5).
 #'

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -89,6 +89,8 @@
 #' ds$getPaletteInterp(band)
 #' ds$setColorTable(band, col_tbl, palette_interp)
 #'
+#' ds$getDefaultRAT(band)
+#'
 #' ds$flushCache()
 #'
 #' ds$getChecksum(band, xoff, yoff, xsize, ysize)
@@ -538,6 +540,10 @@
 #' \code{$getPaletteInterp()} above).
 #' Returns logical \code{TRUE} on success or \code{FALSE} if the color table
 #' could not be set.
+#'
+#' \code{$getDefaultRAT(band)}
+#' Returns the Raster Attribute Table for \code{band} as a data frame,
+#' or \code{NULL} if there is no associated Raster Attribute Table.
 #'
 #' \code{$flushCache()}
 #' Flush all write cached data to disk. Any raster data written via GDAL calls,

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -103,6 +103,8 @@ ds$getColorTable(band)
 ds$getPaletteInterp(band)
 ds$setColorTable(band, col_tbl, palette_interp)
 
+ds$getDefaultRAT(band)
+
 ds$flushCache()
 
 ds$getChecksum(band, xoff, yoff, xsize, ysize)
@@ -558,6 +560,10 @@ opaque).
 \code{$getPaletteInterp()} above).
 Returns logical \code{TRUE} on success or \code{FALSE} if the color table
 could not be set.
+
+\code{$getDefaultRAT(band)}
+Returns the Raster Attribute Table for \code{band} as a data frame,
+or \code{NULL} if there is no associated Raster Attribute Table.
 
 \code{$flushCache()}
 Flush all write cached data to disk. Any raster data written via GDAL calls,

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -167,6 +167,8 @@ class GDALRaster {
 	bool setColorTable(int band, Rcpp::RObject &col_tbl,
 			std::string palette_interp);
 	
+	SEXP getDefaultRAT(int band) const;
+	
 	void flushCache();
 	
 	int getChecksum(int band, int xoff, int yoff, int xsize, int ysize) const;


### PR DESCRIPTION
Returns the default Raster Attribute Table as a data frame, or NULL if there is no attribute table.