### PR TITLE
Use pkg-config on Windows when available.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -3,9 +3,10 @@ PKG_CPPFLAGS = \
 
 TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 
-LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
 
-PKG_LIBS = \
+  PKG_LIBS = \
 	-fopenmp -lgdal -larmadillo -lopenblas -lgfortran -lquadmath -lpq -lpgcommon \
 	-lpgport -lodbc32 -lodbccp32 -lblosc -lkea -lhdf5_cpp -lhdf5 -lpoppler -llcms2 \
 	-lfreetype -lharfbuzz -lfreetype -llz4 -lpcre2-8 -lxml2 -lopenjp2 -lnetcdf \
@@ -16,6 +17,9 @@ PKG_LIBS = \
 	-lunistring -liconv -lgcrypt -lcrypto -lgpg-error -lws2_32 -ltiff -llzma \
 	-ljpeg -lz -lcfitsio -lzstd -lwebpdecoder -lwebp $(LIBSHARPYUV) -lsbml-static \
 	-lgeotiff -lproj -lsqlite3 -lbz2 -lcrypt32 -lwldap32 -lsecur32
+else
+  PKG_LIBS = $(shell pkg-config --libs gdal)
+endif
 
 	
 all: clean winlibs


### PR DESCRIPTION
This will use pkg-config to establish the libraries to link when pkg-config is available (which will soon be in Rtools). This should reduce the frequency of needed updates to linking when new features are linked/enabled in gdal.