### PR TITLE
Add as_list argument in read_ds() and attach gis attributes

### DIFF
--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -133,10 +133,8 @@ DEFAULT_DEM_PROC <- list(hillshade = c("-z", "1", "-s", "1", "-az", "315",
 #' \preformatted{
 #'   $type = "raster"
 #'   $extent = c(xmin, ymin, xmax, ymax)
-#'   $cellsize = c(pixel_width, pixel_height)
 #'   $dim = c(xsize, ysize, nbands)
 #'   $srs = <projection as WKT2 string>
-#'   $geotransform = <length-6 vector of double>
 #' }
 #' The WKT version used for the projection string can be overridden by setting
 #' the `OSR_WKT_FORMAT` configuration option. See [srs_to_wkt()] for a list of
@@ -241,10 +239,8 @@ read_ds <- function(ds, bands=NULL, xoff=0, yoff=0,
 	attr(r, "gis") <- list(
 						type = "raster",
 						extent = bb,
-						cellsize = ds$res(),
 						dim = c(out_xsize, out_ysize, length(bands)),
-						srs = srs_to_wkt(ds$getProjectionRef()),
-						geotransform = ds$getGeoTransform()
+						srs = srs_to_wkt(ds$getProjectionRef())
 						)
 	set_config_option("OSR_WKT_FORMAT", wkt_fmt_config)
 	

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -123,6 +123,25 @@ DEFAULT_DEM_PROC <- list(hillshade = c("-z", "1", "-s", "1", "-az", "315",
 #' for display with [plot_raster()], or simply for the argument defaults to
 #' read an entire raster into memory (see Note).
 #'
+#' @details
+#' `NA` will be returned in place of the nodata value if the raster dataset has
+#' a nodata value defined for the band. Data are read as R `integer` type when
+#' possible for the raster data type (Byte, Int8, Int16, UInt16, Int32),
+#' otherwise as type `double` (UInt32, Float32, Float64).
+#' 
+#' The output object has attribute `gis`, a list containing:
+#' \preformatted{
+#'   $type = "raster"
+#'   $extent = c(xmin, ymin, xmax, ymax)
+#'   $cellsize = c(pixel_width, pixel_height)
+#'   $dim = c(xsize, ysize, nbands)
+#'   $srs = <projection as WKT2 string>
+#'   $geotransform = <length-6 vector of double>
+#' }
+#' The WKT version used for the projection string can be overridden by setting
+#' the `OSR_WKT_FORMAT` configuration option. See [srs_to_wkt()] for a list of
+#' supported values.
+#'
 #' @param ds An object of class `GDALRaster` in open state.
 #' @param bands Integer vector of band numbers to read. By default all bands
 #' will be read.
@@ -138,13 +157,15 @@ DEFAULT_DEM_PROC <- list(hillshade = c("-z", "1", "-s", "1", "-az", "315",
 #' @param out_ysize Integer. The height in pixels of the output buffer into
 #' which the desired region will be read (e.g., to read a reduced resolution
 #' overview).
-#' @returns Returns a `numeric` or `complex` vector containing the values that
-#' were read. It is organized in left to right, top to bottom pixel order,
-#' interleaved by band.
-#' `NA` will be returned in place of the nodata value if the raster dataset has
-#' a nodata value defined for the band. Data are read as R `integer` type when
-#' possible for the raster data type (Byte, Int8, Int16, UInt16, Int32),
-#' otherwise as type `double` (UInt32, Float32, Float64).
+#' @param as_list Logical. If `TRUE`, return output as a list of band vectors.
+#' If `FALSE` (the default), output is a vector of pixel data interleaved by
+#' band.
+#' @returns If `as_list = FALSE` (the default), a `numeric` or `complex` vector
+#' containing the values that were read. It is organized in left to right, top
+#' to bottom pixel order, interleaved by band.
+#' If `as_list = TRUE`, a list with number of elements equal to the number of
+#' bands read. Each element contains a `numeric` or `complex` vector
+#' containing the pixel data read for the band.
 #'
 #' @note
 #' There is small overhead in calling `read_ds()` compared with
@@ -168,23 +189,64 @@ DEFAULT_DEM_PROC <- list(hillshade = c("-z", "1", "-s", "1", "-az", "315",
 #' lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
 #' ds <- new(GDALRaster, lcp_file)
 #'
+#' # as a vector of pixel data interleaved by band
 #' r <- read_ds(ds, bands=c(6,5,4))
 #' typeof(r)
 #' length(r)
 #' object.size(r)
 #'
+#' # as a list of band vectors
+#' r <- read_ds(ds, bands=c(6,5,4), as_list=TRUE)
+#' typeof(r)
+#' length(r)
+#' object.size(r)
+#'
+#' # gis attribute list
+#' attr(r, "gis")
+#'
 #' ds$close()
 #' @export
 read_ds <- function(ds, bands=NULL, xoff=0, yoff=0,
 					xsize=ds$getRasterXSize(), ysize=ds$getRasterYSize(),
-					out_xsize=xsize, out_ysize=ysize) {
+					out_xsize=xsize, out_ysize=ysize,
+					as_list=FALSE) {
 	
 	if (is.null(bands))
 		bands <- seq_len(ds$getRasterCount())
 
-	r <- NULL
-	for (b in bands)
-		r <- c(r, ds$read(b, xoff, yoff, xsize, ysize, out_xsize, out_ysize))
+	if (as_list)
+		r <- list()
+	else
+		r <- NULL
+	
+	for (b in bands) {
+		if (as_list)
+			r[[b]] <- ds$read(b, xoff, yoff, xsize, ysize,
+							out_xsize, out_ysize)
+		else
+			r <- c(r, ds$read(b, xoff, yoff, xsize, ysize,
+					out_xsize, out_ysize))
+	}
+	
+	gt <- ds$getGeoTransform()
+	ul_xy <- .apply_geotransform(gt, xoff, yoff)
+	lr_xy <- .apply_geotransform(gt, (xoff + xsize), (yoff + ysize))
+	bb <- c(ul_xy[1], lr_xy[2], lr_xy[1], ul_xy[2])
+	
+	# gis: a list with the raster extent, cellsize, dimension, projection, and
+	# geotransform
+	wkt_fmt_config <- get_config_option("OSR_WKT_FORMAT")
+	if (wkt_fmt_config == "")
+		set_config_option("OSR_WKT_FORMAT", "WKT2")
+	attr(r, "gis") <- list(
+						type = "raster",
+						extent = bb,
+						cellsize = ds$res(),
+						dim = c(out_xsize, out_ysize, length(bands)),
+						srs = srs_to_wkt(ds$getProjectionRef()),
+						geotransform = ds$getGeoTransform()
+						)
+	set_config_option("OSR_WKT_FORMAT", wkt_fmt_config)
 	
 	return(r)
 }

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -231,8 +231,7 @@ read_ds <- function(ds, bands=NULL, xoff=0, yoff=0,
 	lr_xy <- .apply_geotransform(gt, (xoff + xsize), (yoff + ysize))
 	bb <- c(ul_xy[1], lr_xy[2], lr_xy[1], ul_xy[2])
 	
-	# gis: a list with the raster extent, cellsize, dimension, projection, and
-	# geotransform
+	# gis: a list with the raster extent, dimensions, projection
 	wkt_fmt_config <- get_config_option("OSR_WKT_FORMAT")
 	if (wkt_fmt_config == "")
 		set_config_option("OSR_WKT_FORMAT", "WKT2")
@@ -240,7 +239,7 @@ read_ds <- function(ds, bands=NULL, xoff=0, yoff=0,
 						type = "raster",
 						extent = bb,
 						dim = c(out_xsize, out_ysize, length(bands)),
-						srs = srs_to_wkt(ds$getProjectionRef())
+						srs = ds$getProjectionRef()
 						)
 	set_config_option("OSR_WKT_FORMAT", wkt_fmt_config)
 	

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -217,13 +217,17 @@ read_ds <- function(ds, bands=NULL, xoff=0, yoff=0,
 	else
 		r <- NULL
 	
+	i = 1
 	for (b in bands) {
-		if (as_list)
-			r[[b]] <- ds$read(b, xoff, yoff, xsize, ysize,
+		if (as_list) {
+			r[[i]] <- ds$read(b, xoff, yoff, xsize, ysize,
 							out_xsize, out_ysize)
-		else
+			i = i + 1
+		}
+		else {
 			r <- c(r, ds$read(b, xoff, yoff, xsize, ysize,
 					out_xsize, out_ysize))
+		}
 	}
 	
 	gt <- ds$getGeoTransform()

--- a/man/plot_raster.Rd
+++ b/man/plot_raster.Rd
@@ -35,7 +35,9 @@ plot_raster(
 \arguments{
 \item{data}{Either a \code{GDALRaster} object from which data will be read, or
 a numeric vector of pixel values arranged in left to right, top to
-bottom order.}
+bottom order, or a list of band vectors. If input is vector or list,
+the information in attribute \code{gis} will be used if present (see \code{\link[=read_ds]{read_ds()}}),
+potentially ignoring values below for \code{xsize}, \code{ysize}, \code{nbands}.}
 
 \item{xsize}{The number of pixels along the x dimension in \code{data}. If \code{data}
 is a \code{GDALRaster} object, specifies the size at which the raster will be

--- a/man/read_ds.Rd
+++ b/man/read_ds.Rd
@@ -12,7 +12,8 @@ read_ds(
   xsize = ds$getRasterXSize(),
   ysize = ds$getRasterYSize(),
   out_xsize = xsize,
-  out_ysize = ysize
+  out_ysize = ysize,
+  as_list = FALSE
 )
 }
 \arguments{
@@ -38,15 +39,18 @@ overview).}
 \item{out_ysize}{Integer. The height in pixels of the output buffer into
 which the desired region will be read (e.g., to read a reduced resolution
 overview).}
+
+\item{as_list}{Logical. If \code{TRUE}, return output as a list of band vectors.
+If \code{FALSE} (the default), output is a vector of pixel data interleaved by
+band.}
 }
 \value{
-Returns a \code{numeric} or \code{complex} vector containing the values that
-were read. It is organized in left to right, top to bottom pixel order,
-interleaved by band.
-\code{NA} will be returned in place of the nodata value if the raster dataset has
-a nodata value defined for the band. Data are read as R \code{integer} type when
-possible for the raster data type (Byte, Int8, Int16, UInt16, Int32),
-otherwise as type \code{double} (UInt32, Float32, Float64).
+If \code{as_list = FALSE} (the default), a \code{numeric} or \code{complex} vector
+containing the values that were read. It is organized in left to right, top
+to bottom pixel order, interleaved by band.
+If \code{as_list = TRUE}, a list with number of elements equal to the number of
+bands read. Each element contains a \code{numeric} or \code{complex} vector
+containing the pixel data read for the band.
 }
 \description{
 \code{read_ds()} will read from a raster dataset that is already open in a
@@ -55,6 +59,25 @@ extent from all bands at full resolution. \code{read_ds()} is sometimes more
 convenient than \code{GDALRaster$read()}, e.g., to read specific multiple bands
 for display with \code{\link[=plot_raster]{plot_raster()}}, or simply for the argument defaults to
 read an entire raster into memory (see Note).
+}
+\details{
+\code{NA} will be returned in place of the nodata value if the raster dataset has
+a nodata value defined for the band. Data are read as R \code{integer} type when
+possible for the raster data type (Byte, Int8, Int16, UInt16, Int32),
+otherwise as type \code{double} (UInt32, Float32, Float64).
+
+The output object has attribute \code{gis}, a list containing:
+\preformatted{
+  $type = "raster"
+  $extent = c(xmin, ymin, xmax, ymax)
+  $cellsize = c(pixel_width, pixel_height)
+  $dim = c(xsize, ysize, nbands)
+  $srs = <projection as WKT2 string>
+  $geotransform = <length-6 vector of double>
+}
+The WKT version used for the projection string can be overridden by setting
+the \code{OSR_WKT_FORMAT} configuration option. See \code{\link[=srs_to_wkt]{srs_to_wkt()}} for a list of
+supported values.
 }
 \note{
 There is small overhead in calling \code{read_ds()} compared with
@@ -75,10 +98,20 @@ approximately (xsize * ysize * number of bands * 4) for data read as
 lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
 ds <- new(GDALRaster, lcp_file)
 
+# as a vector of pixel data interleaved by band
 r <- read_ds(ds, bands=c(6,5,4))
 typeof(r)
 length(r)
 object.size(r)
+
+# as a list of band vectors
+r <- read_ds(ds, bands=c(6,5,4), as_list=TRUE)
+typeof(r)
+length(r)
+object.size(r)
+
+# gis attribute list
+attr(r, "gis")
 
 ds$close()
 }

--- a/man/read_ds.Rd
+++ b/man/read_ds.Rd
@@ -70,10 +70,8 @@ The output object has attribute \code{gis}, a list containing:
 \preformatted{
   $type = "raster"
   $extent = c(xmin, ymin, xmax, ymax)
-  $cellsize = c(pixel_width, pixel_height)
   $dim = c(xsize, ysize, nbands)
   $srs = <projection as WKT2 string>
-  $geotransform = <length-6 vector of double>
 }
 The WKT version used for the projection string can be overridden by setting
 the \code{OSR_WKT_FORMAT} configuration option. See \code{\link[=srs_to_wkt]{srs_to_wkt()}} for a list of

--- a/src/wkt_conv.cpp
+++ b/src/wkt_conv.cpp
@@ -127,6 +127,9 @@ std::string epsg_to_wkt(int epsg, bool pretty = false) {
 // [[Rcpp::export]]
 std::string srs_to_wkt(std::string srs, bool pretty = false) {
 
+	if (srs == "")
+		return "";
+
 	OGRSpatialReferenceH hSRS = OSRNewSpatialReference(NULL);
 	char *pszSRS_WKT = NULL;
 	

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -153,7 +153,9 @@ test_that("floating point I/O works", {
 	z <- runif(10*10)
 	ds$write(band=1, xoff=0, yoff=0, xsize=10, ysize=10, z)
 	ds$open(read_only=TRUE)
-	expect_equal(round(read_ds(ds),5), round(z,5))
+	r <- read_ds(ds)
+	attributes(r) <- NULL
+	expect_equal(round(r,5), round(z,5))
 	ds$open(read_only=FALSE)
 	ds$setNoDataValue(band=1, -99999)
 	ds$write(band=1, xoff=0, yoff=0, xsize=10, ysize=10, rep(-99999, 100))
@@ -162,7 +164,9 @@ test_that("floating point I/O works", {
 	ds$open(read_only=FALSE)
 	ds$deleteNoDataValue(band=1)
 	ds$open(read_only=TRUE)
-	expect_equal(read_ds(ds), rep(-99999, 100))
+	r <- read_ds(ds)
+	attributes(r) <- NULL
+	expect_equal(r, rep(-99999, 100))
 	files <- ds$getFileList()
 	on.exit(unlink(files))
 	ds$close()
@@ -177,7 +181,9 @@ test_that("complex I/O works", {
 	z <- complex(real = stats::rnorm(100), imaginary = stats::rnorm(100))
 	ds$write(band=1, xoff=0, yoff=0, xsize=10, ysize=10, z)
 	ds$open(read_only=TRUE)
-	expect_vector(read_ds(ds), ptype=complex(0), size=100)
+	r <- read_ds(ds)
+	attributes(r) <- NULL
+	expect_vector(r, ptype=complex(0), size=100)
 	files <- ds$getFileList()
 	on.exit(unlink(files))
 	ds$close()

--- a/tests/testthat/test-display.R
+++ b/tests/testthat/test-display.R
@@ -30,11 +30,16 @@ test_that("plot_raster works", {
 	vat <- read.csv(evc_vat)
 	vat <- vat[,c(1,6:8)]
 	ds <- new(GDALRaster, evc_file, read_only=TRUE)
-	dm <- ds$dim()
+	#dm <- ds$dim()
 	r <- read_ds(ds)
 	ds$close()
-	expect_silent(plot_raster(r, xsize=dm[1], ysize=dm[2], col_tbl=vat,
-					interpolate=FALSE))
+	expect_silent(plot_raster(r, col_tbl=vat, interpolate=FALSE))
+	
+	# as_list
+	ds$open(TRUE)
+	r <- read_ds(ds, as_list=TRUE)
+	ds$close()
+	expect_silent(plot_raster(r, col_tbl=vat, interpolate=FALSE))
 
 	# built-in color table
 	tcc_file <- system.file("extdata/storml_tcc.tif", package="gdalraster")

--- a/vignettes/articles/raster-display.Rmd
+++ b/vignettes/articles/raster-display.Rmd
@@ -39,17 +39,16 @@ ds$close()
 ```{r}
 f <- paste0(base_url, "landsat_c2ard_sr_mt_hood_jul2022_utm.tif")
 ds <- new(GDALRaster, f)
-dm <- ds$dim()
 
 # passing a vector of pixel values rather than the open dataset
 r <- read_ds(ds, bands=c(7,5,4))
 ds$close()
 
 # normalizing to ranges derived from the full Landsat scene (2-98 percentiles)
-plot_raster(r, xsize=dm[1], ysize=dm[2], nbands=3,
+plot_raster(r,
             minmax_def=c(7551,7679,7585,14842,24997,12451),
-            main="Mount Hood July 2022 Landsat 7-5-4 (SWIR)")
-
+            main="Mount Hood July 2022 Landsat 7-5-4 (SWIR)"
+           )
 ```
 
 ## Color table
@@ -73,21 +72,18 @@ plot_raster(ds, xsize=dm[1] / 2, ysize=dm[2] / 2,
 ds$close()
 ```
 
-## Label with geospatial coordinates
+## Axis labels
 
 ```{r}
 f <- paste0(base_url, "bl_mrbl_ng_jul2004_rgb_720x360.tif")
-
 ds <- new(GDALRaster, f)
-dm <- ds$dim()
-print(paste("Size is", dm[1], "x",  dm[2], "x", dm[3]))
-
 srs_is_projected(ds$getProjectionRef())
-bb <- ds$bbox()
-
-plot_raster(ds, nbands=3, xlim=c(bb[1],bb[3]), ylim=c(bb[2],bb[4]),
-            xlab="longitude", ylab="latitude",
-            main="NASA Earth Observatory Blue Marble July 2004")
+r <- read_ds(ds)
 ds$close()
+
+plot_raster(r,
+            xlab="longitude", ylab="latitude",
+            main="NASA Earth Observatory Blue Marble July 2004"
+           )
 ```
 


### PR DESCRIPTION
This pull request modifies the function `read_ds()` (convenience wrapper for the class method `GDALRaster$read()`):
* New argument `as_list` can be set to `TRUE` to return band vectors as list elements (default is pixel data as a single vector, interleaved by band).
* The output object (list or vector) now has attribute `gis`, a list with:
```
$type = "raster"
$extent = c(xmin, ymin, xmax, ymax)
$dim = c(xsize, ysize, nbands)
$srs = <projection as WKT2 string>
```
The function `plot_raster()` is also modified to accept the optional list output from `read_ds()` and make use of `gis` attributes if present. This allows using georeferenced coordinates by default instead of pixel/line in the case of raw pixel input (i.e., when input is not an object of class `GDALRaster` but rather a vector or list of pixel data that have already been read).

Some example code in the Raster Display web article is simplified due to `gis` attributes on the output of `read_ds()`.