### PR TITLE
gdal_formats(): return a data frame for raster and vector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.9.0.9060 (dev)
+# gdalraster 1.9.0.9070 (dev)
+
+* `gdal_formats()` now returns a data frame with the supported raster and vector formats, and information about the capabilities of each format driver (2024-03-04)
 
 * GDAL built with GEOS is now a system requirement, add test in configure.ac (2024-03-03)
 
@@ -10,7 +12,7 @@
 
 * add calls to `OGRCoordinateTransformation::DestroyCT()` in src/geos_wkt.cpp and src/transform.cpp - no known issues but fixes potential memory leak (2024-02-27)
 
-* free *phGeometry with `OGR_G_DestroyGeometry()` in src/geos_wkt.cpp and src/wkt_conv.cpp - no known issues but fixes potential memory leak (2024-02-27)
+* free `*phGeometry` with `OGR_G_DestroyGeometry()` in src/geos_wkt.cpp and src/wkt_conv.cpp - no known issues but fixes potential memory leak (2024-02-27)
 
 * add `g_transform()`: apply a coordinate transformation to a WKT geometry (2024-02-26)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -23,16 +23,29 @@ gdal_version <- function() {
     .Call(`_gdalraster__gdal_version_num`)
 }
 
-#' Report all configured GDAL drivers for raster formats
+#' Retrieve information on GDAL format drivers for raster and vector
 #'
-#' `gdal_formats()` prints to the console a list of the supported raster
-#' formats.
+#' `gdal_formats()` returns a table of the supported raster and vector
+#' formats, with information about the capabilities of each format driver.
 #'
-#' @returns No return value, called for reporting only.
+#' @param fmt A character string containing a driver short name. By default,
+#' information for all configured raster and vector format drivers will be
+#' returned.
+#' @returns A data frame containing the format short name, long name, raster
+#' (logical), vector (logical), read/write flag (`ro` is read-only,
+#' `w` supports CreateCopy, `w+` supports Create), virtual I/O supported
+#' (logical), and subdatasets (logical).
+#'
+#' @note
+#' Virtual I/O refers to operations on GDAL Virtual File Systems. See
+#' \url{https://gdal.org/user/virtual_file_systems.html#virtual-file-systems}.
+#'
 #' @examples
-#' gdal_formats()
-gdal_formats <- function() {
-    invisible(.Call(`_gdalraster_gdal_formats`))
+#' head(gdal_formats())
+#'
+#' gdal_formats("GPKG")
+gdal_formats <- function(fmt = "") {
+    .Call(`_gdalraster_gdal_formats`, fmt)
 }
 
 #' Get GDAL configuration option

--- a/man/gdal_formats.Rd
+++ b/man/gdal_formats.Rd
@@ -2,17 +2,31 @@
 % Please edit documentation in R/RcppExports.R
 \name{gdal_formats}
 \alias{gdal_formats}
-\title{Report all configured GDAL drivers for raster formats}
+\title{Retrieve information on GDAL format drivers for raster and vector}
 \usage{
-gdal_formats()
+gdal_formats(fmt = "")
+}
+\arguments{
+\item{fmt}{A character string containing a driver short name. By default,
+information for all configured raster and vector format drivers will be
+returned.}
 }
 \value{
-No return value, called for reporting only.
+A data frame containing the format short name, long name, raster
+(logical), vector (logical), read/write flag (\code{ro} is read-only,
+\code{w} supports CreateCopy, \verb{w+} supports Create), virtual I/O supported
+(logical), and subdatasets (logical).
 }
 \description{
-\code{gdal_formats()} prints to the console a list of the supported raster
-formats.
+\code{gdal_formats()} returns a table of the supported raster and vector
+formats, with information about the capabilities of each format driver.
+}
+\note{
+Virtual I/O refers to operations on GDAL Virtual File Systems. See
+\url{https://gdal.org/user/virtual_file_systems.html#virtual-file-systems}.
 }
 \examples{
-gdal_formats()
+head(gdal_formats())
+
+gdal_formats("GPKG")
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -32,12 +32,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // gdal_formats
-void gdal_formats();
-RcppExport SEXP _gdalraster_gdal_formats() {
+Rcpp::DataFrame gdal_formats(std::string fmt);
+RcppExport SEXP _gdalraster_gdal_formats(SEXP fmtSEXP) {
 BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    gdal_formats();
-    return R_NilValue;
+    Rcpp::traits::input_parameter< std::string >::type fmt(fmtSEXP);
+    rcpp_result_gen = Rcpp::wrap(gdal_formats(fmt));
+    return rcpp_result_gen;
 END_RCPP
 }
 // get_config_option
@@ -1089,7 +1091,7 @@ RcppExport SEXP _rcpp_module_boot_mod_running_stats();
 static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_gdal_version", (DL_FUNC) &_gdalraster_gdal_version, 0},
     {"_gdalraster__gdal_version_num", (DL_FUNC) &_gdalraster__gdal_version_num, 0},
-    {"_gdalraster_gdal_formats", (DL_FUNC) &_gdalraster_gdal_formats, 0},
+    {"_gdalraster_gdal_formats", (DL_FUNC) &_gdalraster_gdal_formats, 1},
     {"_gdalraster_get_config_option", (DL_FUNC) &_gdalraster_get_config_option, 1},
     {"_gdalraster_set_config_option", (DL_FUNC) &_gdalraster_set_config_option, 2},
     {"_gdalraster_get_cache_used", (DL_FUNC) &_gdalraster_get_cache_used, 0},

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -70,7 +70,7 @@ const std::map<std::string, GDALRATFieldUsage> MAP_GFU{
 
 Rcpp::CharacterVector gdal_version();
 int _gdal_version_num();
-void gdal_formats();
+Rcpp::DataFrame gdal_formats(std::string fmt);
 std::string get_config_option(std::string key);
 void set_config_option(std::string key, std::string value);
 int get_cache_used();

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -6,7 +6,9 @@ test_that("gdal_version returns vector", {
 })
 
 test_that("gdal_formats returns a data frame", {
-	expect_s3_class(gdal_formats(), "data.frame")
+	x <- gdal_formats()
+	expect_s3_class(x, "data.frame")
+	expect_true(nrow(x) > 1)
 })
 
 test_that("_check_gdal_filename works", {

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -5,8 +5,8 @@ test_that("gdal_version returns vector", {
 	expect_length(gdal_version(), 4)
 })
 
-test_that("gdal_formats prints output", {
-	expect_output(gdal_formats())
+test_that("gdal_formats returns a data frame", {
+	expect_s3_class(gdal_formats(), "data.frame")
 })
 
 test_that("_check_gdal_filename works", {


### PR DESCRIPTION
`gdal_formats()` now returns a data frame with the supported raster and vector formats, and information about the capabilities of each format driver