### PR TITLE
update gdalvector-draft

### DIFF
--- a/vignettes/articles/gdalvector-draft.Rmd
+++ b/vignettes/articles/gdalvector-draft.Rmd
@@ -31,8 +31,8 @@ A  GDAL Dataset for vector is a file or database containing one or more OGR laye
 
 * existing management functions in **gdalraster** that operate on vector datasets: `copyDatasetFiles()`, `deleteDataset()`, `renameDataset()` and `addFilesInZip()` (supports SOZip)
 * existing internal utility functions to be further developed (potentially renamed/refactored): `.ogr_ds_exists()`, `.create_ogr()`, `.ogr_ds_layer_count()`, `.ogr_layer_exists()`, `.ogr_layer_create()`, `.ogr_layer_delete()` `.ogr_field_index()`, `.ogr_field_create()`
-* wrappers `vector_translate()` (`ogr2ogr`) and `vector_info()` (`ogrinfo`) from the gdal_utils.h API (**gdalraster** 1.10 around late March)
-* `ogr_execute_sql()`: execute an SQL statement against the data store for `CREATE INDEX`, `DROP INDEX`, `ALTER TABLE`, `DROP TABLE` (a SQL `SELECT` statement can be used in the constructor for class `GDALVector` described below, to open a layer of features)
+* existing wrappers `ogr2ogr()` and `ogrinfo()` from the gdal_utils.h API (**gdalraster** 1.9.0.9080 dev)
+* add `ogr_execute_sql()`: execute an SQL statement against the data store for `CREATE INDEX`, `DROP INDEX`, `ALTER TABLE`, `DROP TABLE` (a SQL `SELECT` statement can be used in the constructor for class `GDALVector` described below, to open a layer of features)
 * other stand-alone functions TBD
 
 OGR Layer class represents a layer of features within a data source. It will be modeled in R as class `GDALVector`, an exposed C++ class encapsulating an OGR Layer and the GDAL Dataset that owns it. A `GDALVector` object will persist an open connection to the dataset and expose methods for retrieving layer information, setting attribute and spatial filters, reading/writing features, and layer geoprocessing. A draft definition for class `GDALVector` is given below.
@@ -715,6 +715,7 @@ This is a working list of potential issues and design questions that need furthe
 
 * handling of 64-bit integer: OGR FID currently is `GIntBig` (`int64_t`) and integer fields in vector data sources will commonly be `OFTInteger64`. These would likely be handled using **RcppInt64**, with **bit64** on the R side providing S3 class `integer64`.
 * OGR's Arrow C interface: Implement `GDALVector::getArrowStream()` (GDAL >= 3.6) and `GDALVector::writeArrowBatch()` (GDAL >= 3.8), supported on the R side with package **nanoarrow**.
+* potential output vectors of GEOS or OGR pointers, WKB with support by **wk**
 
 ## Document changelog
 
@@ -728,4 +729,12 @@ This is a working list of potential issues and design questions that need furthe
 * add `GDALVector::setNextByIndex()` for cursor positioning (2024-03-03)
 * add `GDALVector::getSpatialFilter()`: get the WKT geometry currently in use as the spatial filter, or `""` (2024-03-03)
 * add section "Further consideration / TBD" (2024-03-03)
+* `ogr2ogr()` and `ogrinfo()` are available in 1.9.0.9080 dev (2024-03-04)
+* add potential output vectors of geos or ogr pointers, or wkb/wkt with support by {wk} (@mdsumner, 2024-03-04)
+* add section "Contributors" (2024-03-04)
+
+## Contributors
+
+* @goergen95 (#205)
+* @mdsumner
 


### PR DESCRIPTION
* `ogr2ogr()` and `ogrinfo()` are available in 1.9.0.9080 dev (2024-03-04)
* add potential output vectors of geos or ogr pointers, or wkb/wkt with support by {wk} (@mdsumner, 2024-03-04)
* add section "Contributors" (2024-03-04)