### PR TITLE
add `_g_add_geom()`: add geom object to a container

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1883,6 +1883,11 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_add_geom <- function(sub_geom, container) {
+    .Call(`_gdalraster__g_add_geom`, sub_geom, container)
+}
+
+#' @noRd
 .g_is_valid <- function(geom) {
     .Call(`_gdalraster__g_is_valid`, geom)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -688,6 +688,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// _g_add_geom
+std::string _g_add_geom(std::string sub_geom, std::string container);
+RcppExport SEXP _gdalraster__g_add_geom(SEXP sub_geomSEXP, SEXP containerSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type sub_geom(sub_geomSEXP);
+    Rcpp::traits::input_parameter< std::string >::type container(containerSEXP);
+    rcpp_result_gen = Rcpp::wrap(_g_add_geom(sub_geom, container));
+    return rcpp_result_gen;
+END_RCPP
+}
 // _g_is_valid
 bool _g_is_valid(std::string geom);
 RcppExport SEXP _gdalraster__g_is_valid(SEXP geomSEXP) {
@@ -1268,6 +1280,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster__getGEOSVersion", (DL_FUNC) &_gdalraster__getGEOSVersion, 0},
     {"_gdalraster_has_geos", (DL_FUNC) &_gdalraster_has_geos, 0},
     {"_gdalraster__g_create", (DL_FUNC) &_gdalraster__g_create, 2},
+    {"_gdalraster__g_add_geom", (DL_FUNC) &_gdalraster__g_add_geom, 2},
     {"_gdalraster__g_is_valid", (DL_FUNC) &_gdalraster__g_is_valid, 1},
     {"_gdalraster__g_is_empty", (DL_FUNC) &_gdalraster__g_is_empty, 1},
     {"_gdalraster__g_name", (DL_FUNC) &_gdalraster__g_name, 1},

--- a/src/geos_wkt.h
+++ b/src/geos_wkt.h
@@ -14,6 +14,7 @@ std::vector<int> _getGEOSVersion();
 bool has_geos(); // GDAL built against GEOS is required at gdalraster 1.10
 
 std::string _g_create(Rcpp::NumericMatrix xy, std::string geom_type);
+std::string _g_add_geom(std::string sub_geom, std::string container);
 bool _g_is_valid(std::string geom);
 bool _g_is_empty(std::string geom);
 std::string _g_name(std::string geom);

--- a/tests/testthat/test-geos_wkt.R
+++ b/tests/testthat/test-geos_wkt.R
@@ -1,5 +1,3 @@
-skip_if_not(has_geos())
-
 test_that("geos functions work on wkt geometries", {
     elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
     ds <- new(GDALRaster, elev_file, read_only=TRUE)
@@ -32,14 +30,16 @@ test_that("geos functions work on wkt geometries", {
     x <- c(324467.3, 323909.4, 323794.2, 324970.7, 326420.0, 326389.6, 325298.1, 325298.1, 324467.3)
     y <- c(5104814.2, 5104365.4, 5103455.8, 5102885.8, 5103595.3, 5104747.5, 5104929.4, 5104929.4, 5104814.2)
     pt_xy <- cbind(x, y)
-    expect_true(startsWith(.g_create(pt_xy, "POLYGON"), "POLYGON"))
+
+    expect_true(.g_create(pt_xy, "POLYGON") |> g_is_valid())
+    expect_true((.g_create(pt_xy, "POLYGON") |> g_area()) > 0)
 
     pt_xy <- matrix(c(324171, 5103034.3), nrow=1, ncol=2)
     expect_error(.g_create(pt_xy, "POLYGON"))
     pt <- .g_create(pt_xy, "POINT")
 
     line_xy <- matrix(c(324171, 327711.7, 5103034.3, 5104475.9),
-                        nrow=2, ncol=2)
+                      nrow=2, ncol=2)
     expect_error(.g_create(line_xy, "POINT"))
     line <- .g_create(line_xy, "LINESTRING")
 
@@ -78,7 +78,7 @@ test_that("geos functions work on wkt geometries", {
     expect_error(.g_overlaps(bb, "invalid WKT"))
 
     expect_equal(round(bbox_from_wkt(.g_buffer(bnd, 100))),
-            round(c(323694.2, 5102785.8, 326520.0, 5105029.4)))
+                 round(c(323694.2, 5102785.8, 326520.0, 5105029.4)))
     expect_error(.g_buffer("invalid WKT", 100))
 
     expect_equal(round(.g_area(bnd)), 4039645)


### PR DESCRIPTION
Adds `_g_add_geom()`: add a geometry to a geometry container (operating on WKT). Currently `LINEARRING` (as `POLYGON`) to `POLYGON`, `POINT` to `MULTIPOINT`, `LINESTRING` to `MULTILINESTRING`, or `POLYGON` to `MULTIPOLYGON`.

Also adds support for `MULTIPOINT` in `_g_create()`.