### PR TITLE
`buildRAT()`: if input is a `GDALRaster` object use it by reference

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9040
+Version: 1.10.9050
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9040 (dev)
+# gdalraster 1.10.9050 (dev)
+
+* `buildRAT()`: if the input raster is an object of class `GDALRaster`, use it by reference rather than instantiating another `GDALRaster` object internally (2024-04-09)
 
 * add `GDALRaster::setFilename()`: set the filename of an unitialized `GDALRaster` object, currently undocumented (2024-04-08)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -443,8 +443,8 @@ buildVRT <- function(vrt_filename, input_rasters, cl_arg = NULL, quiet = FALSE) 
 #' Compute for a raster band the set of unique pixel values and their counts
 #'
 #' @noRd
-.value_count <- function(src_filename, band = 1L, quiet = FALSE) {
-    .Call(`_gdalraster__value_count`, src_filename, band, quiet)
+.value_count <- function(src_ds, band = 1L, quiet = FALSE) {
+    .Call(`_gdalraster__value_count`, src_ds, band, quiet)
 }
 
 #' Wrapper for GDALDEMProcessing in the GDAL Algorithms C API

--- a/R/gdal_rat.R
+++ b/R/gdal_rat.R
@@ -203,13 +203,18 @@ buildRAT <- function(raster,
 
     if (length(raster) != 1)
         stop("'raster' argument must have length 1", call. = FALSE)
-    if (is(raster, "Rcpp_GDALRaster"))
-        f <- raster$getFilename()
-    else if (is(raster, "character"))
-        f <- raster
-    else
+
+    ds <- NULL
+    close_ds <- FALSE
+    if (is(raster, "Rcpp_GDALRaster")) {
+        ds <- raster
+    } else if (is(raster, "character")) {
+        ds <- new(GDALRaster, raster)
+        close_ds <- TRUE
+    } else {
         stop("'raster' must be a 'GDALRaster' object or a filename",
              call. = FALSE)
+    }
 
     if (length(band) != 1)
         stop("'band' must be an integer scalar", call. = FALSE)
@@ -235,7 +240,9 @@ buildRAT <- function(raster,
                  call. = FALSE)
     }
 
-    d <- .value_count(f, band, quiet)
+    d <- .value_count(ds, band, quiet)
+    if (close_ds)
+        ds$close()
     names(d) <- col_names
     if (!is.null(na_value))
         d[is.na(d[, 1]), 1] <- na_value

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -216,15 +216,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // _value_count
-Rcpp::DataFrame _value_count(std::string src_filename, int band, bool quiet);
-RcppExport SEXP _gdalraster__value_count(SEXP src_filenameSEXP, SEXP bandSEXP, SEXP quietSEXP) {
+Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band, bool quiet);
+RcppExport SEXP _gdalraster__value_count(SEXP src_dsSEXP, SEXP bandSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type src_filename(src_filenameSEXP);
+    Rcpp::traits::input_parameter< GDALRaster& >::type src_ds(src_dsSEXP);
     Rcpp::traits::input_parameter< int >::type band(bandSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
-    rcpp_result_gen = Rcpp::wrap(_value_count(src_filename, band, quiet));
+    rcpp_result_gen = Rcpp::wrap(_value_count(src_ds, band, quiet));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -849,10 +849,9 @@ Rcpp::DataFrame _combine(
 //'
 //' @noRd
 // [[Rcpp::export(name = ".value_count")]]
-Rcpp::DataFrame _value_count(std::string src_filename, int band = 1,
+Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band = 1,
                              bool quiet = false) {
 
-    GDALRaster src_ds = GDALRaster(src_filename, true);
     int nrows = src_ds.getRasterYSize();
     int ncols = src_ds.getRasterXSize();
     GDALProgressFunc pfnProgress = nullptr;

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -68,147 +68,6 @@ const std::map<std::string, GDALRATFieldUsage> MAP_GFU{
 };
 #endif
 
-Rcpp::CharacterVector gdal_version();
-int _gdal_version_num();
-Rcpp::DataFrame gdal_formats(std::string fmt);
-std::string get_config_option(std::string key);
-void set_config_option(std::string key, std::string value);
-int get_cache_used();
-void push_error_handler(std::string handler);
-void pop_error_handler();
-
-Rcpp::CharacterVector _check_gdal_filename(Rcpp::CharacterVector filename);
-int _get_physical_RAM();
-
-bool create(std::string format, Rcpp::CharacterVector dst_filename,
-            int xsize, int ysize, int nbands, std::string dataType,
-            Rcpp::Nullable<Rcpp::CharacterVector> options);
-bool createCopy(std::string format, Rcpp::CharacterVector dst_filename,
-                Rcpp::CharacterVector src_filename, bool strict,
-                Rcpp::Nullable<Rcpp::CharacterVector> options, bool quiet);
-std::string _getCreationOptions(std::string format);
-bool copyDatasetFiles(Rcpp::CharacterVector new_filename,
-                      Rcpp::CharacterVector old_filename,
-                      std::string format);
-bool deleteDataset(Rcpp::CharacterVector filename, std::string format);
-bool renameDataset(Rcpp::CharacterVector new_filename,
-                   Rcpp::CharacterVector old_filename,
-                   std::string format);
-bool bandCopyWholeRaster(Rcpp::CharacterVector src_filename, int src_band,
-                         Rcpp::CharacterVector dst_filename, int dst_band,
-                         Rcpp::Nullable<Rcpp::CharacterVector> options,
-                         bool quiet);
-bool _addFileInZip(std::string zip_filename, bool overwrite,
-                   std::string archive_filename, std::string in_filename,
-                   Rcpp::Nullable<Rcpp::CharacterVector> options,
-                   bool quiet);
-int vsi_copy_file(Rcpp::CharacterVector src_file,
-                  Rcpp::CharacterVector target_file,
-                  bool show_progess);
-void vsi_curl_clear_cache(bool partial, Rcpp::CharacterVector file_prefix);
-Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
-                                   int max_files);
-bool vsi_sync(Rcpp::CharacterVector src,
-              Rcpp::CharacterVector target,
-              bool show_progess,
-              Rcpp::Nullable<Rcpp::CharacterVector> options);
-int vsi_mkdir(Rcpp::CharacterVector path, int mode);
-int vsi_rmdir(Rcpp::CharacterVector path);
-int vsi_unlink(Rcpp::CharacterVector filename);
-SEXP vsi_unlink_batch(Rcpp::CharacterVector filenames);
-SEXP vsi_stat(Rcpp::CharacterVector filename, std::string info);
-int vsi_rename(Rcpp::CharacterVector oldpath, Rcpp::CharacterVector newpath);
-std::string _vsi_get_fs_options(Rcpp::CharacterVector filename);
-Rcpp::CharacterVector vsi_get_fs_prefixes();
-bool vsi_supports_seq_write(Rcpp::CharacterVector filename,
-                            bool allow_local_tmpfile);
-bool vsi_supports_rnd_write(Rcpp::CharacterVector filename,
-                            bool allow_local_tmpfile);
-double vsi_get_disk_free_space(Rcpp::CharacterVector path);
-
-Rcpp::NumericVector _apply_geotransform(const std::vector<double> gt,
-                                        double pixel, double line);
-Rcpp::NumericVector inv_geotransform(const std::vector<double> gt);
-Rcpp::IntegerMatrix get_pixel_line(const Rcpp::NumericMatrix xy,
-                                   const std::vector<double> gt);
-
-bool buildVRT(Rcpp::CharacterVector vrt_filename,
-              Rcpp::CharacterVector input_rasters,
-              Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
-              bool quiet);
-
-Rcpp::DataFrame _combine(Rcpp::CharacterVector src_files,
-                         Rcpp::CharacterVector var_names,
-                         std::vector<int> bands,
-                         std::string dst_filename,
-                         std::string fmt,
-                         std::string dataType,
-                         Rcpp::Nullable<Rcpp::CharacterVector> options,
-                         bool quiet);
-
-Rcpp::DataFrame _value_count(std::string src_filename, int band,
-                             bool quiet);
-
-bool _dem_proc(std::string mode,
-               Rcpp::CharacterVector src_filename,
-               Rcpp::CharacterVector dst_filename,
-               Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
-               Rcpp::Nullable<Rcpp::String> col_file,
-               bool quiet);
-
-bool fillNodata(Rcpp::CharacterVector filename, int band,
-                Rcpp::CharacterVector mask_file,
-                double max_dist, int smooth_iterations,
-                bool quiet);
-
-bool footprint(Rcpp::CharacterVector src_filename,
-               Rcpp::CharacterVector dst_filename,
-               Rcpp::Nullable<Rcpp::CharacterVector> cl_arg);
-
-bool ogr2ogr(Rcpp::CharacterVector src_dsn,
-             Rcpp::CharacterVector dst_dsn,
-             Rcpp::Nullable<Rcpp::CharacterVector> src_layers,
-             Rcpp::Nullable<Rcpp::CharacterVector> cl_arg);
-
-std::string ogrinfo(Rcpp::CharacterVector dsn,
-                    Rcpp::Nullable<Rcpp::CharacterVector> layers,
-                    Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
-                    Rcpp::Nullable<Rcpp::CharacterVector> open_options,
-                    bool read_only,
-                    bool cout);
-
-bool _polygonize(Rcpp::CharacterVector src_filename, int src_band,
-                 Rcpp::CharacterVector out_dsn,
-                 std::string out_layer, std::string fld_name,
-                 Rcpp::CharacterVector mask_file, bool nomask,
-                 int connectedness, bool quiet);
-
-bool _rasterize(std::string src_dsn, std::string dst_filename,
-                Rcpp::CharacterVector cl_arg, bool quiet);
-
-bool sieveFilter(Rcpp::CharacterVector src_filename, int src_band,
-                 Rcpp::CharacterVector dst_filename, int dst_band,
-                 int size_threshold, int connectedness,
-                 Rcpp::CharacterVector mask_filename , int mask_band,
-                 Rcpp::Nullable<Rcpp::CharacterVector> options, bool quiet);
-
-bool translate(Rcpp::CharacterVector src_filename,
-               Rcpp::CharacterVector dst_filename,
-               Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
-               bool quiet);
-
-bool warp(Rcpp::CharacterVector src_files,
-          Rcpp::CharacterVector dst_filename,
-          std::string t_srs,
-          Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
-          bool quiet);
-
-Rcpp::IntegerMatrix createColorRamp(int start_index,
-                                    Rcpp::IntegerVector start_color,
-                                    int end_index,
-                                    Rcpp::IntegerVector end_color,
-                                    std::string palette_interp);
-
 class GDALRaster {
 
     private:
@@ -319,5 +178,146 @@ class GDALRaster {
 };
 
 RCPP_EXPOSED_CLASS(GDALRaster)
+
+Rcpp::CharacterVector gdal_version();
+int _gdal_version_num();
+Rcpp::DataFrame gdal_formats(std::string fmt);
+std::string get_config_option(std::string key);
+void set_config_option(std::string key, std::string value);
+int get_cache_used();
+void push_error_handler(std::string handler);
+void pop_error_handler();
+
+Rcpp::CharacterVector _check_gdal_filename(Rcpp::CharacterVector filename);
+int _get_physical_RAM();
+
+bool create(std::string format, Rcpp::CharacterVector dst_filename,
+            int xsize, int ysize, int nbands, std::string dataType,
+            Rcpp::Nullable<Rcpp::CharacterVector> options);
+bool createCopy(std::string format, Rcpp::CharacterVector dst_filename,
+                Rcpp::CharacterVector src_filename, bool strict,
+                Rcpp::Nullable<Rcpp::CharacterVector> options, bool quiet);
+std::string _getCreationOptions(std::string format);
+bool copyDatasetFiles(Rcpp::CharacterVector new_filename,
+                      Rcpp::CharacterVector old_filename,
+                      std::string format);
+bool deleteDataset(Rcpp::CharacterVector filename, std::string format);
+bool renameDataset(Rcpp::CharacterVector new_filename,
+                   Rcpp::CharacterVector old_filename,
+                   std::string format);
+bool bandCopyWholeRaster(Rcpp::CharacterVector src_filename, int src_band,
+                         Rcpp::CharacterVector dst_filename, int dst_band,
+                         Rcpp::Nullable<Rcpp::CharacterVector> options,
+                         bool quiet);
+bool _addFileInZip(std::string zip_filename, bool overwrite,
+                   std::string archive_filename, std::string in_filename,
+                   Rcpp::Nullable<Rcpp::CharacterVector> options,
+                   bool quiet);
+int vsi_copy_file(Rcpp::CharacterVector src_file,
+                  Rcpp::CharacterVector target_file,
+                  bool show_progess);
+void vsi_curl_clear_cache(bool partial, Rcpp::CharacterVector file_prefix);
+Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
+                                   int max_files);
+bool vsi_sync(Rcpp::CharacterVector src,
+              Rcpp::CharacterVector target,
+              bool show_progess,
+              Rcpp::Nullable<Rcpp::CharacterVector> options);
+int vsi_mkdir(Rcpp::CharacterVector path, int mode);
+int vsi_rmdir(Rcpp::CharacterVector path);
+int vsi_unlink(Rcpp::CharacterVector filename);
+SEXP vsi_unlink_batch(Rcpp::CharacterVector filenames);
+SEXP vsi_stat(Rcpp::CharacterVector filename, std::string info);
+int vsi_rename(Rcpp::CharacterVector oldpath, Rcpp::CharacterVector newpath);
+std::string _vsi_get_fs_options(Rcpp::CharacterVector filename);
+Rcpp::CharacterVector vsi_get_fs_prefixes();
+bool vsi_supports_seq_write(Rcpp::CharacterVector filename,
+                            bool allow_local_tmpfile);
+bool vsi_supports_rnd_write(Rcpp::CharacterVector filename,
+                            bool allow_local_tmpfile);
+double vsi_get_disk_free_space(Rcpp::CharacterVector path);
+
+Rcpp::NumericVector _apply_geotransform(const std::vector<double> gt,
+                                        double pixel, double line);
+Rcpp::NumericVector inv_geotransform(const std::vector<double> gt);
+Rcpp::IntegerMatrix get_pixel_line(const Rcpp::NumericMatrix xy,
+                                   const std::vector<double> gt);
+
+bool buildVRT(Rcpp::CharacterVector vrt_filename,
+              Rcpp::CharacterVector input_rasters,
+              Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
+              bool quiet);
+
+Rcpp::DataFrame _combine(Rcpp::CharacterVector src_files,
+                         Rcpp::CharacterVector var_names,
+                         std::vector<int> bands,
+                         std::string dst_filename,
+                         std::string fmt,
+                         std::string dataType,
+                         Rcpp::Nullable<Rcpp::CharacterVector> options,
+                         bool quiet);
+
+Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band,
+                             bool quiet);
+
+bool _dem_proc(std::string mode,
+               Rcpp::CharacterVector src_filename,
+               Rcpp::CharacterVector dst_filename,
+               Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
+               Rcpp::Nullable<Rcpp::String> col_file,
+               bool quiet);
+
+bool fillNodata(Rcpp::CharacterVector filename, int band,
+                Rcpp::CharacterVector mask_file,
+                double max_dist, int smooth_iterations,
+                bool quiet);
+
+bool footprint(Rcpp::CharacterVector src_filename,
+               Rcpp::CharacterVector dst_filename,
+               Rcpp::Nullable<Rcpp::CharacterVector> cl_arg);
+
+bool ogr2ogr(Rcpp::CharacterVector src_dsn,
+             Rcpp::CharacterVector dst_dsn,
+             Rcpp::Nullable<Rcpp::CharacterVector> src_layers,
+             Rcpp::Nullable<Rcpp::CharacterVector> cl_arg);
+
+std::string ogrinfo(Rcpp::CharacterVector dsn,
+                    Rcpp::Nullable<Rcpp::CharacterVector> layers,
+                    Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
+                    Rcpp::Nullable<Rcpp::CharacterVector> open_options,
+                    bool read_only,
+                    bool cout);
+
+bool _polygonize(Rcpp::CharacterVector src_filename, int src_band,
+                 Rcpp::CharacterVector out_dsn,
+                 std::string out_layer, std::string fld_name,
+                 Rcpp::CharacterVector mask_file, bool nomask,
+                 int connectedness, bool quiet);
+
+bool _rasterize(std::string src_dsn, std::string dst_filename,
+                Rcpp::CharacterVector cl_arg, bool quiet);
+
+bool sieveFilter(Rcpp::CharacterVector src_filename, int src_band,
+                 Rcpp::CharacterVector dst_filename, int dst_band,
+                 int size_threshold, int connectedness,
+                 Rcpp::CharacterVector mask_filename , int mask_band,
+                 Rcpp::Nullable<Rcpp::CharacterVector> options, bool quiet);
+
+bool translate(Rcpp::CharacterVector src_filename,
+               Rcpp::CharacterVector dst_filename,
+               Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
+               bool quiet);
+
+bool warp(Rcpp::CharacterVector src_files,
+          Rcpp::CharacterVector dst_filename,
+          std::string t_srs,
+          Rcpp::Nullable<Rcpp::CharacterVector> cl_arg,
+          bool quiet);
+
+Rcpp::IntegerMatrix createColorRamp(int start_index,
+                                    Rcpp::IntegerVector start_color,
+                                    int end_index,
+                                    Rcpp::IntegerVector end_color,
+                                    std::string palette_interp);
 
 #endif

--- a/tests/testthat/test-gdal_rat.R
+++ b/tests/testthat/test-gdal_rat.R
@@ -4,7 +4,7 @@ test_that("buildRAT/displayRAT work", {
     evt_tbl <- read.csv(evt_csv)
     evt_tbl <- evt_tbl[,1:7]
     rat <- buildRAT(evt_file, table_type="thematic", na_value=-9999,
-            join_df=evt_tbl)
+                    join_df=evt_tbl)
     expect_equal(nrow(rat), 24)
     expect_equal(ncol(rat), 8)
     expect_equal(attr(rat, "GDALRATTableType"), "thematic")
@@ -19,6 +19,16 @@ test_that("buildRAT/displayRAT work", {
     attr(rat$A, "GFU") <- "Alpha"
     tbl <- displayRAT(rat)
     expect_true(is(tbl, "gt_tbl"))
+
+    # pass as an object of class GDALRaster
+    rat <- NULL
+    ds <- new(GDALRaster, evt_file)
+    rat <- buildRAT(ds, table_type="thematic", na_value=-9999,
+                    join_df=evt_tbl)
+    expect_equal(nrow(rat), 24)
+    expect_equal(ncol(rat), 8)
+    expect_equal(sum(rat$COUNT), 15301)
+    ds$close()
 
     # uint32 raster
     lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")


### PR DESCRIPTION
Previously, a second `GDALRaster` object was instantiated internally from the passed object's filename, so open options on the passed object's dataset may not have been honored.