### PR TITLE
Add `GDALRaster::getProjection()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9050
+Version: 1.10.9060
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9050 (dev)
+# gdalraster 1.10.9060 (dev)
+
+* add `GDALRaster::getProjection()`: equivalent to `GDALRaster::getProjectionRef()` (consistent with `osgeo.gdal.Dataset.getProjection()` / `.getProjectionRef()`) (2024-04-14)
 
 * `buildRAT()`: if the input raster is an object of class `GDALRaster`, use it by reference rather than instantiating another `GDALRaster` object internally (2024-04-09)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gdalraster 1.10.9060 (dev)
 
-* add `GDALRaster::getProjection()`: equivalent to `GDALRaster::getProjectionRef()` (consistent with `osgeo.gdal.Dataset.getProjection()` / `.getProjectionRef()`) (2024-04-14)
+* add `GDALRaster::getProjection()`: equivalent to `GDALRaster::getProjectionRef()` (consistent with `osgeo.gdal.Dataset.getProjection()` / `osgeo.gdal.Dataset.getProjectionRef()` in the GDAL Python API) (2024-04-14)
 
 * `buildRAT()`: if the input raster is an object of class `GDALRaster`, use it by reference rather than instantiating another `GDALRaster` object internally (2024-04-09)
 

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -49,6 +49,7 @@
 #' ds$getRasterYSize()
 #' ds$getGeoTransform()
 #' ds$setGeoTransform(transform)
+#' ds$getProjection()
 #' ds$getProjectionRef()
 #' ds$setProjection(projection)
 #' ds$bbox()
@@ -186,6 +187,10 @@
 #' \code{transform} is a numeric vector of length six.
 #' Returns logical \code{TRUE} on success or \code{FALSE} if the geotransform
 #' could not be set.
+#'
+#' \code{$getProjection()}
+#' Returns the coordinate reference system of the raster as an OGC WKT
+#' format string. Equivalent to \code{ds$getProjectionRef()}.
 #'
 #' \code{$getProjectionRef()}
 #' Returns the coordinate reference system of the raster as an OGC WKT
@@ -649,7 +654,7 @@
 #' ds$getRasterXSize()
 #' ds$getRasterYSize()
 #' ds$getGeoTransform()
-#' ds$getProjectionRef()
+#' ds$getProjection()
 #' ds$getRasterCount()
 #' ds$bbox()
 #' ds$res()

--- a/R/geom.R
+++ b/R/geom.R
@@ -170,7 +170,7 @@ bbox_union <- function(x, as_wkt = FALSE) {
 #' elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
 #' ds <- new(GDALRaster, elev_file)
 #' ds$bbox()
-#' bbox_transform(ds$bbox(), ds$getProjectionRef(), epsg_to_wkt(4326))
+#' bbox_transform(ds$bbox(), ds$getProjection(), epsg_to_wkt(4326))
 #' ds$close()
 bbox_transform <- function(bbox, srs_from, srs_to) {
     if (!(is.numeric(bbox) && length(bbox) == 4))
@@ -249,7 +249,7 @@ g_buffer <- function(wkt, dist, quad_segs = 30L) {
 #' ds <- new(GDALRaster, elev_file)
 #' # the convenience function bbox_transform() does this:
 #' bbox_to_wkt(ds$bbox()) |>
-#'   g_transform(ds$getProjectionRef(), epsg_to_wkt(4326)) |>
+#'   g_transform(ds$getProjection(), epsg_to_wkt(4326)) |>
 #'   bbox_from_wkt()
 #' ds$close()
 #'

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -67,6 +67,7 @@ ds$getRasterXSize()
 ds$getRasterYSize()
 ds$getGeoTransform()
 ds$setGeoTransform(transform)
+ds$getProjection()
 ds$getProjectionRef()
 ds$setProjection(projection)
 ds$bbox()
@@ -206,6 +207,10 @@ Sets the affine transformation coefficients on this dataset.
 \code{transform} is a numeric vector of length six.
 Returns logical \code{TRUE} on success or \code{FALSE} if the geotransform
 could not be set.
+
+\code{$getProjection()}
+Returns the coordinate reference system of the raster as an OGC WKT
+format string. Equivalent to \code{ds$getProjectionRef()}.
 
 \code{$getProjectionRef()}
 Returns the coordinate reference system of the raster as an OGC WKT
@@ -655,7 +660,7 @@ ds$getFileList()
 ds$getRasterXSize()
 ds$getRasterYSize()
 ds$getGeoTransform()
-ds$getProjectionRef()
+ds$getProjection()
 ds$getRasterCount()
 ds$bbox()
 ds$res()

--- a/man/bbox_transform.Rd
+++ b/man/bbox_transform.Rd
@@ -32,7 +32,7 @@ Numeric vector of length four containing a transformed bounding box
 elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
 ds <- new(GDALRaster, elev_file)
 ds$bbox()
-bbox_transform(ds$bbox(), ds$getProjectionRef(), epsg_to_wkt(4326))
+bbox_transform(ds$bbox(), ds$getProjection(), epsg_to_wkt(4326))
 ds$close()
 }
 \seealso{

--- a/man/g_transform.Rd
+++ b/man/g_transform.Rd
@@ -57,7 +57,7 @@ elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
 ds <- new(GDALRaster, elev_file)
 # the convenience function bbox_transform() does this:
 bbox_to_wkt(ds$bbox()) |>
-  g_transform(ds$getProjectionRef(), epsg_to_wkt(4326)) |>
+  g_transform(ds$getProjection(), epsg_to_wkt(4326)) |>
   bbox_from_wkt()
 ds$close()
 

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -267,6 +267,10 @@ int GDALRaster::getRasterCount() const {
     return GDALGetRasterCount(hDataset);
 }
 
+std::string GDALRaster::getProjection() const {
+    return getProjectionRef();
+}
+
 std::string GDALRaster::getProjectionRef() const {
     _checkAccess(GA_ReadOnly);
 
@@ -1445,6 +1449,8 @@ RCPP_MODULE(mod_GDALRaster) {
         "Set the affine transformation coefficients for this dataset")
     .const_method("getRasterCount", &GDALRaster::getRasterCount,
         "Return the number of raster bands on this dataset")
+    .const_method("getProjection", &GDALRaster::getProjection,
+        "Return the projection (equivalent to getProjectionRef)")
     .const_method("getProjectionRef", &GDALRaster::getProjectionRef,
         "Return the projection definition for this dataset")
     .method("setProjection", &GDALRaster::setProjection,

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -101,6 +101,7 @@ class GDALRaster {
     bool setGeoTransform(std::vector<double> transform);
     int getRasterCount() const;
 
+    std::string getProjection() const;
     std::string getProjectionRef() const;
     bool setProjection(std::string projection);
 


### PR DESCRIPTION
Adds `GDALRaster::getProjection()`, class method exposed to R. Equivalent to the existing `GDALRaster::getProjectionRef()`. 

Consistent with `osgeo.gdal.Dataset.getProjection()` / `osgeo.gdal.Dataset.getProjectionRef()` in the Python API:
https://gdal.org/api/python/raster_api.html#osgeo.gdal.Dataset.GetProjection
