### PR TITLE
add support for Byte<->raw IO

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,7 @@ Version: 1.10.9060
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),
+    person("Michael D.","Sumner", role = c("ctb")),
     person("Frank", "Warmerdam",
             role = c("ctb", "cph"), comment = "GDAL API documentation; src/progress_r.cpp from gdal/port/cpl_progress.cpp"),
     person("Even", "Rouault",

--- a/R/display.R
+++ b/R/display.R
@@ -367,6 +367,9 @@ plot_raster <- function(data, xsize=NULL, ysize=NULL, nbands=1,
             ylim <- c(ysize, 0)
     }
 
+    if (typeof(data_in) == "raw") {
+      data_in <- as.integer(data_in)
+    }
     a <- array(data_in, dim = c(xsize, ysize, nbands))
     r <- .as_raster(a,
                     col_tbl=col_tbl,

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -101,6 +101,8 @@
 #'
 #' ds$getChecksum(band, xoff, yoff, xsize, ysize)
 #'
+#' ds$readByteAsRaw
+#' 
 #' ds$close()
 #' }
 #'
@@ -608,7 +610,14 @@
 #' \emph{Raster row/column offsets use 0-based indexing.}
 #' \code{xsize} is the width in pixels of the window to read.
 #' \code{ysize} is the height in pixels of the window to read.
-#'
+#' 
+#' \code{$readByteAsRaw}
+#' A logical value, `FALSE` by default. This field can be set to `TRUE` which will 
+#' affect the data type returned by `$read()` and [read_ds()]. When the underlying band data type
+#' is 'Byte' and `readByteAsRaw` is `TRUE` the output type will be raw rather than
+#' integer. See also the `as_raw` argument to [read_ds()] to control this in a non-persisent
+#' setting. If the underlying band data type is not Byte this setting has no effect. 
+#' 
 #' \code{$close()}
 #' Closes the GDAL dataset (no return value, called for side effects).
 #' Calling \code{$close()} results in proper cleanup, and flushing of any

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -101,11 +101,11 @@
 #'
 #' ds$getChecksum(band, xoff, yoff, xsize, ysize)
 #'
-#' ds$readByteAsRaw
-#' 
 #' ds$close()
+#' 
+#' ## Fields
+#' ds$readByteAsRaw
 #' }
-#'
 #' @section Details:
 #'
 #' \code{new(GDALRaster, filename, read_only)}
@@ -510,7 +510,8 @@
 #' (`UInt32`, `Float32`, `Float64`).
 #' No rescaling of the data is performed (see \code{$getScale()} and
 #' \code{$getOffset()} above).
-#' An error is raised if the read operation fails.
+#' An error is raised if the read operation fails. See also the setting 
+#' `$readByteAsRaw` below.
 #'
 #' \code{$write(band, xoff, yoff, xsize, ysize, rasterData)}
 #' Writes a region of raster data to \code{band}.
@@ -611,13 +612,6 @@
 #' \code{xsize} is the width in pixels of the window to read.
 #' \code{ysize} is the height in pixels of the window to read.
 #' 
-#' \code{$readByteAsRaw}
-#' A logical value, `FALSE` by default. This field can be set to `TRUE` which will 
-#' affect the data type returned by `$read()` and [read_ds()]. When the underlying band data type
-#' is 'Byte' and `readByteAsRaw` is `TRUE` the output type will be raw rather than
-#' integer. See also the `as_raw` argument to [read_ds()] to control this in a non-persisent
-#' setting. If the underlying band data type is not Byte this setting has no effect. 
-#' 
 #' \code{$close()}
 #' Closes the GDAL dataset (no return value, called for side effects).
 #' Calling \code{$close()} results in proper cleanup, and flushing of any
@@ -627,6 +621,13 @@
 #' The dataset can be re-opened on the existing \code{filename} with
 #' \code{$open(read_only=TRUE)} or \code{$open(read_only=FALSE)}.
 #'
+#' \code{$readByteAsRaw}
+#' A logical value, `FALSE` by default. This field can be set to `TRUE` which will 
+#' affect the data type returned by `$read()` and [read_ds()]. When the underlying band data type
+#' is 'Byte' and `readByteAsRaw` is `TRUE` the output type will be raw rather than
+#' integer. See also the `as_raw` argument to [read_ds()] to control this in a non-persisent
+#' setting. If the underlying band data type is not Byte this setting has no effect. 
+#' 
 #' @note
 #' If a dataset object is opened with update access (`read_only = FALSE`), it
 #' is not recommended to open a new dataset on the same underlying `filename`.

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -164,10 +164,10 @@ DEFAULT_DEM_PROC <- list(
 #' If `FALSE` (the default), output is a vector of pixel data interleaved by
 #' band.
 #' @param as_raw Logical. If `TRUE` and the underlying data type is Byte, return output
-#' as R's raw vector type. This maps to the property `$readByteAsRaw` on `GDALRaster`, which
-#' is used to temporarily update the field in this function. To control  this behaviour 
-#' in a persisent way on a data set see \code{$readByteAsRaw()}  in 
-#' [`GDALRaster-class`][GDALRaster]. 
+#' as R's raw vector type. This maps to the setting `$readByteAsRaw` on the `GDALRaster` object,
+#' which is used to temporarily update that field in this function. To control this behaviour 
+#' in a persisent way on a data set see \code{$readByteAsRaw}  in 
+#' [`GDALRaster-class`][GDALRaster].  
 #' @returns If `as_list = FALSE` (the default), a `numeric` or `complex` vector
 #' containing the values that were read. It is organized in left to right, top
 #' to bottom pixel order, interleaved by band.

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -164,8 +164,10 @@ DEFAULT_DEM_PROC <- list(
 #' If `FALSE` (the default), output is a vector of pixel data interleaved by
 #' band.
 #' @param as_raw Logical. If `TRUE` and the underlying data type is Byte, return output
-#' as R's raw vector type. This maps to the property `readByteAsRaw` on `GDALRaster`, which
-#' is used to temporarily update the field in this function. 
+#' as R's raw vector type. This maps to the property `$readByteAsRaw` on `GDALRaster`, which
+#' is used to temporarily update the field in this function. To control  this behaviour 
+#' in a persisent way on a data set see \code{$readByteAsRaw()}  in 
+#' [`GDALRaster-class`][GDALRaster]. 
 #' @returns If `as_list = FALSE` (the default), a `numeric` or `complex` vector
 #' containing the values that were read. It is organized in left to right, top
 #' to bottom pixel order, interleaved by band.
@@ -227,7 +229,13 @@ read_ds <- function(ds, bands=NULL, xoff=0, yoff=0,
 
     i <- 1
     readByteAsRaw <- ds$readByteAsRaw
-    if (as_raw) ds$readByteAsRaw <- TRUE
+    if (as_raw) {
+      ds$readByteAsRaw <- TRUE
+      dtype <- ds$getDataTypeName(bands[1L])
+      if (!dtype == "Byte") {
+        warning(sprintf("'as_raw' set to 'TRUE' only affects read for band type 'Byte',  current data type: '%s'", dtype))
+      }
+    }
     for (b in bands) {
         if (as_list) {
             r[[i]] <- ds$read(b, xoff, yoff, xsize, ysize,

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -119,6 +119,8 @@ ds$flushCache()
 
 ds$getChecksum(band, xoff, yoff, xsize, ysize)
 
+ds$readByteAsRaw
+
 ds$close()
 }
 }
@@ -631,6 +633,13 @@ components of complex bands influence the result.
 \emph{Raster row/column offsets use 0-based indexing.}
 \code{xsize} is the width in pixels of the window to read.
 \code{ysize} is the height in pixels of the window to read.
+
+\code{$readByteAsRaw}
+A logical value, \code{FALSE} by default. This field can be set to \code{TRUE} which will
+affect the data type returned by \verb{$read()} and \code{\link[=read_ds]{read_ds()}}. When the underlying band data type
+is 'Byte' and \code{readByteAsRaw} is \code{TRUE} the output type will be raw rather than
+integer. See also the \code{as_raw} argument to \code{\link[=read_ds]{read_ds()}} to control this in a non-persisent
+setting. If the underlying band data type is not Byte this setting has no effect.
 
 \code{$close()}
 Closes the GDAL dataset (no return value, called for side effects).

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -119,9 +119,10 @@ ds$flushCache()
 
 ds$getChecksum(band, xoff, yoff, xsize, ysize)
 
-ds$readByteAsRaw
-
 ds$close()
+
+## Fields
+ds$readByteAsRaw
 }
 }
 
@@ -533,7 +534,8 @@ Data are read as R integer type when possible for the raster data type
 (\code{UInt32}, \code{Float32}, \code{Float64}).
 No rescaling of the data is performed (see \code{$getScale()} and
 \code{$getOffset()} above).
-An error is raised if the read operation fails.
+An error is raised if the read operation fails. See also the setting
+\verb{$readByteAsRaw} below.
 
 \code{$write(band, xoff, yoff, xsize, ysize, rasterData)}
 Writes a region of raster data to \code{band}.
@@ -634,13 +636,6 @@ components of complex bands influence the result.
 \code{xsize} is the width in pixels of the window to read.
 \code{ysize} is the height in pixels of the window to read.
 
-\code{$readByteAsRaw}
-A logical value, \code{FALSE} by default. This field can be set to \code{TRUE} which will
-affect the data type returned by \verb{$read()} and \code{\link[=read_ds]{read_ds()}}. When the underlying band data type
-is 'Byte' and \code{readByteAsRaw} is \code{TRUE} the output type will be raw rather than
-integer. See also the \code{as_raw} argument to \code{\link[=read_ds]{read_ds()}} to control this in a non-persisent
-setting. If the underlying band data type is not Byte this setting has no effect.
-
 \code{$close()}
 Closes the GDAL dataset (no return value, called for side effects).
 Calling \code{$close()} results in proper cleanup, and flushing of any
@@ -649,6 +644,13 @@ formats such as GTiff could result in being unable to open it afterwards.
 The \code{GDALRaster} object is still available after calling \code{$close()}.
 The dataset can be re-opened on the existing \code{filename} with
 \code{$open(read_only=TRUE)} or \code{$open(read_only=FALSE)}.
+
+\code{$readByteAsRaw}
+A logical value, \code{FALSE} by default. This field can be set to \code{TRUE} which will
+affect the data type returned by \verb{$read()} and \code{\link[=read_ds]{read_ds()}}. When the underlying band data type
+is 'Byte' and \code{readByteAsRaw} is \code{TRUE} the output type will be raw rather than
+integer. See also the \code{as_raw} argument to \code{\link[=read_ds]{read_ds()}} to control this in a non-persisent
+setting. If the underlying band data type is not Byte this setting has no effect.
 }
 
 \examples{

--- a/man/read_ds.Rd
+++ b/man/read_ds.Rd
@@ -46,9 +46,9 @@ If \code{FALSE} (the default), output is a vector of pixel data interleaved by
 band.}
 
 \item{as_raw}{Logical. If \code{TRUE} and the underlying data type is Byte, return output
-as R's raw vector type. This maps to the property \verb{$readByteAsRaw} on \code{GDALRaster}, which
-is used to temporarily update the field in this function. To control  this behaviour
-in a persisent way on a data set see \code{$readByteAsRaw()}  in
+as R's raw vector type. This maps to the setting \verb{$readByteAsRaw} on the \code{GDALRaster} object,
+which is used to temporarily update that field in this function. To control this behaviour
+in a persisent way on a data set see \code{$readByteAsRaw}  in
 \code{\link[=GDALRaster]{GDALRaster-class}}.}
 }
 \value{

--- a/man/read_ds.Rd
+++ b/man/read_ds.Rd
@@ -13,7 +13,8 @@ read_ds(
   ysize = ds$getRasterYSize(),
   out_xsize = xsize,
   out_ysize = ysize,
-  as_list = FALSE
+  as_list = FALSE,
+  as_raw = FALSE
 )
 }
 \arguments{
@@ -43,6 +44,12 @@ overview).}
 \item{as_list}{Logical. If \code{TRUE}, return output as a list of band vectors.
 If \code{FALSE} (the default), output is a vector of pixel data interleaved by
 band.}
+
+\item{as_raw}{Logical. If \code{TRUE} and the underlying data type is Byte, return output
+as R's raw vector type. This maps to the property \verb{$readByteAsRaw} on \code{GDALRaster}, which
+is used to temporarily update the field in this function. To control  this behaviour
+in a persisent way on a data set see \code{$readByteAsRaw()}  in
+\code{\link[=GDALRaster]{GDALRaster-class}}.}
 }
 \value{
 If \code{as_list = FALSE} (the default), a \code{numeric} or \code{complex} vector

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -79,7 +79,8 @@ GDALRaster::GDALRaster() :
             fname_in(""),
             open_options_in(Rcpp::CharacterVector::create()),
             hDataset(nullptr),
-            eAccess(GA_ReadOnly) {}
+            eAccess(GA_ReadOnly), 
+            readByteAsRaw(false) {}
 
 GDALRaster::GDALRaster(Rcpp::CharacterVector filename) :
             GDALRaster(
@@ -97,7 +98,8 @@ GDALRaster::GDALRaster(Rcpp::CharacterVector filename, bool read_only,
         Rcpp::CharacterVector open_options) :
                 open_options_in(open_options),
                 hDataset(nullptr),
-                eAccess(GA_ReadOnly) {
+                eAccess(GA_ReadOnly), 
+                readByteAsRaw(false) {
 
     fname_in = Rcpp::as<std::string>(_check_gdal_filename(filename));
     open(read_only);

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -835,7 +835,7 @@ SEXP GDALRaster::read(int band, int xoff, int yoff, int xsize, int ysize,
                 )) {
 
           // Byte, use raw
-          if (eDT == GDT_Byte) {
+          if (eDT == GDT_Byte && readByteAsRaw) {
             std::vector<uint8_t> buf(out_xsize * out_ysize); 
             err = GDALRasterIO(hBand, GF_Read, xoff, yoff, xsize, ysize,
                                buf.data(), out_xsize, out_ysize,
@@ -1560,5 +1560,6 @@ RCPP_MODULE(mod_GDALRaster) {
     .method("close", &GDALRaster::close,
         "Close the GDAL dataset for proper cleanup")
 
+    .field("readByteAsRaw", &GDALRaster::readByteAsRaw)
     ;
 }

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -834,6 +834,20 @@ SEXP GDALRaster::read(int band, int xoff, int yoff, int xsize, int ysize,
                 GDALDataTypeIsSigned(eDT))
                 )) {
 
+          // Byte, use raw
+          if (eDT == GDT_Byte) {
+            std::vector<uint8_t> buf(out_xsize * out_ysize); 
+            err = GDALRasterIO(hBand, GF_Read, xoff, yoff, xsize, ysize,
+                               buf.data(), out_xsize, out_ysize,
+                               GDT_Byte, 0, 0);
+            
+            if (err == CE_Failure)
+              Rcpp::stop("read raster failed");
+            
+
+            Rcpp::RawVector v = Rcpp::wrap(buf);
+            return v;            
+          }
             // signed integer <= 32 bits and any integer <= 16 bits
             // use int32 buffer
 
@@ -939,8 +953,18 @@ void GDALRaster::write(int band, int xoff, int yoff, int xsize, int ysize,
         err = GDALRasterIO(hBand, GF_Write, xoff, yoff, xsize, ysize,
                            buf_.data(), xsize, ysize, eBufType, 0, 0);
     }
+    else if (Rcpp::is<Rcpp::RawVector>(rasterData)) {
+      // Byte data type
+      eBufType = GDT_Byte;
+      std::vector<uint8_t> buf_ = Rcpp::as<std::vector<uint8_t>>(rasterData);
+      if (buf_.size() != ((std::size_t) (xsize * ysize)))
+        Rcpp::stop("size of input data is not the same as region size");
+      err = GDALRasterIO(hBand, GF_Write, xoff, yoff, xsize, ysize,
+                         buf_.data(), xsize, ysize, eBufType, 0, 0);
+
+    }
     else {
-        Rcpp::stop("data must be a vector of 'numeric' or 'complex'");
+        Rcpp::stop("data must be a vector of 'numeric' or 'complex' or 'raw'");
     }
 
     if (err == CE_Failure)

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -169,6 +169,7 @@ class GDALRaster {
 
     void close();
 
+    bool readByteAsRaw; 
     // methods for internal use not exported to R
     void _checkAccess(GDALAccess access_needed) const;
     GDALRasterBandH _getBand(int band) const;

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -221,18 +221,37 @@ test_that("Byte I/O works", {
   ds$write(band=1, xoff=0, yoff=0, xsize=10, ysize=10, z)
   
   ds$open(read_only=TRUE)
-  expect_warning(r <- read_ds(ds))
+  expect_false(ds$readByteAsRaw)
+  ## read as raw with the temporary setting
+  expect_warning(r_raw <- read_ds(ds, as_raw = TRUE))
+  ## read with to-integer conversion (as default, not affected by 'as_raw')
+  expect_warning(r_int <- read_ds(ds))
+  ## set and read as raw via field
+  ds$readByteAsRaw <- TRUE
+  expect_warning(r_raw1 <- read_ds(ds, as_raw = TRUE))
+  
   
   deleteDataset(f)
   
-  expect_type(r, "raw")
+  expect_type(r_int, "integer")
 
-  attributes(r) <- NULL
-  expect_equal(r, z)
-  files <- ds$getFileList()
-  on.exit(unlink(files))
+  expect_type(r_raw, "raw")
+  expect_type(r_raw1, "raw")
+  attributes(r_raw) <- NULL
+  expect_equal(r_raw, z)
+  
+  
   ds$close()
 })
+
+test_that("Byte I/O: warn when data type not compatible", {
+  ## expect a warning when data type is not Byte
+  elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
+  ds <- new(GDALRaster, elev_file)
+  expect_warning(read_ds(ds, 1L, 0L, 0L, 2L, 3L, 2L, 3L, as_raw = TRUE))
+  ds$close()
+})
+
 test_that("set unit type, scale and offset works", {
     elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
     mod_file <- paste0(tempdir(), "/", "storml_elev_mod.tif")

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -211,6 +211,28 @@ test_that("complex I/O works", {
     ds$close()
 })
 
+test_that("Byte I/O works", {
+  f <- paste0(tempdir(), "/", "testbyte.tif")
+  create(format="GTiff", dst_filename=f, xsize=10, ysize=10,
+         nbands=1, dataType="Byte")
+  ds <- new(GDALRaster, f, read_only=FALSE)
+  set.seed(42)
+  z <- as.raw(sample(100, 100))
+  ds$write(band=1, xoff=0, yoff=0, xsize=10, ysize=10, z)
+  
+  ds$open(read_only=TRUE)
+  expect_warning(r <- read_ds(ds))
+  
+  deleteDataset(f)
+  
+  expect_type(r, "raw")
+
+  attributes(r) <- NULL
+  expect_equal(r, z)
+  files <- ds$getFileList()
+  on.exit(unlink(files))
+  ds$close()
+})
 test_that("set unit type, scale and offset works", {
     elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
     mod_file <- paste0(tempdir(), "/", "storml_elev_mod.tif")


### PR DESCRIPTION
I'd like to be able to read and write Byte with R's raw vector type. This is unproblematic at the Rcpp level afaics. 

There are implications for the documentation and plotting (there's a failing plot test). 

I consider this a draft until those implications are discussed and dealt with. Thanks!   

The motivation is purely for the size of Byte vs Int32, for workflows that just move pixel data around. 

--------------------------------------------
Longer term motivation: 

It's not particularly  efficient to get raw vectors and then convert them to colours in R, but in time perhaps we can add helpers for that, i.e. I would also like to add a special r-only  type on input that bundles (1, or 3, or 4) raw vectors into Int32 with R's nativeRaster encoding i.e. [vapour::gdal_raster_nara](https://github.com/hypertidy/vapour/blob/5e67be7626051b3f444b7fec49d829cf3ab6444c/inst/include/gdalraster/gdalraster.h#L71), or alternatively to character string colour. nativeRaster is supremely fast for visualization, and we save some memory copying if done before returning to R.  Note also that R now has smaller format allowed for hex string: https://github.com/wch/r-source/commit/0cad8c3fa75f402db464cbfde93284106a12a69f