### PR TITLE
Add `GDALRaster::getActualBlockSize()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9060
+Version: 1.10.9070
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9060 (dev)
+# gdalraster 1.10.9070 (dev)
+
+* add `GDALRaster::getActualBlockSize()`: retrieve the actual block size for a given block offset (2024-04-19)
 
 * add `GDALRaster::getProjection()`: equivalent to `GDALRaster::getProjectionRef()` (consistent with `osgeo.gdal.Dataset.getProjection()` / `osgeo.gdal.Dataset.getProjectionRef()` in the GDAL Python API) (2024-04-14)
 

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -60,6 +60,7 @@
 #' ds$getDescription(band)
 #' ds$setDescription(band)
 #' ds$getBlockSize(band)
+#' ds$getActualBlockSize(band, xblockoff, yblockoff)
 #' ds$getOverviewCount(band)
 #' ds$buildOverviews(resampling, levels, bands)
 #' ds$getDataTypeName(band)
@@ -242,6 +243,15 @@
 #' be the tile size. Note that the X and Y block sizes don't have to divide
 #' the image size evenly, meaning that right and bottom edge blocks may be
 #' incomplete.
+#'
+#' \code{$getActualBlockSize(band, xblockoff, yblockoff)}
+#' Returns an integer vector of length two (xvalid, yvalid) containing the
+#' actual block size for a given block offset in \code{band}. Handles partial
+#' blocks at the edges of the raster and returns the true number of pixels.
+#' `xblockoff` is an integer scalar, the horizontal block offset for which to
+#' calculate the number of valid pixels, with zero indicating the left most
+#' block, 1 the next block, etc. `yblockoff` is likewise the vertical block
+#' offset, with zero indicating the top most block, 1 the next block, etc.
 #'
 #' \code{$getOverviewCount(band)}
 #' Returns the number of overview layers (a.k.a. pyramids) available for

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -78,6 +78,7 @@ ds$getRasterCount()
 ds$getDescription(band)
 ds$setDescription(band)
 ds$getBlockSize(band)
+ds$getActualBlockSize(band, xblockoff, yblockoff)
 ds$getOverviewCount(band)
 ds$buildOverviews(resampling, levels, bands)
 ds$getDataTypeName(band)
@@ -262,6 +263,15 @@ and block ysize is 1. However, for tiled images block size will typically
 be the tile size. Note that the X and Y block sizes don't have to divide
 the image size evenly, meaning that right and bottom edge blocks may be
 incomplete.
+
+\code{$getActualBlockSize(band, xblockoff, yblockoff)}
+Returns an integer vector of length two (xvalid, yvalid) containing the
+actual block size for a given block offset in \code{band}. Handles partial
+blocks at the edges of the raster and returns the true number of pixels.
+\code{xblockoff} is an integer scalar, the horizontal block offset for which to
+calculate the number of valid pixels, with zero indicating the left most
+block, 1 the next block, etc. \code{yblockoff} is likewise the vertical block
+offset, with zero indicating the top most block, 1 the next block, etc.
 
 \code{$getOverviewCount(band)}
 Returns the number of overview layers (a.k.a. pyramids) available for

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -216,12 +216,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // _value_count
-Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band, bool quiet);
+Rcpp::DataFrame _value_count(const GDALRaster& src_ds, int band, bool quiet);
 RcppExport SEXP _gdalraster__value_count(SEXP src_dsSEXP, SEXP bandSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< GDALRaster& >::type src_ds(src_dsSEXP);
+    Rcpp::traits::input_parameter< const GDALRaster& >::type src_ds(src_dsSEXP);
     Rcpp::traits::input_parameter< int >::type band(bandSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(_value_count(src_ds, band, quiet));

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -1,6 +1,7 @@
 /* Exported stand-alone functions for gdalraster
    Chris Toney <chris.toney at usda.gov> */
 
+#include <errno.h>
 #include <cmath>
 #include <unordered_map>
 
@@ -11,8 +12,6 @@
 #include "cpl_vsi.h"
 #include "gdal_alg.h"
 #include "gdal_utils.h"
-
-#include <errno.h>
 
 #include "gdalraster.h"
 #include "cmb_table.h"
@@ -101,8 +100,7 @@ Rcpp::DataFrame gdal_formats(std::string format = "") {
             CPLFetchBool(papszMD, GDAL_DCAP_VECTOR, false) ?
                     vector_fmt.push_back(true) : vector_fmt.push_back(false);
 
-        }
-        else {
+        } else {
             continue;
         }
 
@@ -310,8 +308,7 @@ Rcpp::CharacterVector _check_gdal_filename(Rcpp::CharacterVector filename) {
 
     if (std_filename.find("/vsi") == 0) {
         out_filename[0] = filename[0];
-    }
-    else if (std_filename.find("~") != std_filename.npos) {
+    } else if (std_filename.find("~") != std_filename.npos) {
     /* 	This does not catch an error from normalizePath() in R. But we're
         not using mustWork=TRUE, so only a warning is emitted if path does
         not exist. Leaving as try/catch for now. */
@@ -321,8 +318,7 @@ Rcpp::CharacterVector _check_gdal_filename(Rcpp::CharacterVector filename) {
         catch (...) {
             out_filename[0] = filename[0];
         }
-    }
-    else {
+    } else {
         out_filename[0] = filename[0];
     }
 
@@ -383,7 +379,7 @@ bool create(std::string format, Rcpp::CharacterVector dst_filename,
         int xsize, int ysize, int nbands, std::string dataType,
         Rcpp::Nullable<Rcpp::CharacterVector> options = R_NilValue) {
 
-    GDALDriverH hDriver = GDALGetDriverByName( format.c_str() );
+    GDALDriverH hDriver = GDALGetDriverByName(format.c_str());
     if (hDriver == nullptr)
         Rcpp::stop("failed to get driver for the specified format");
 
@@ -481,7 +477,7 @@ bool createCopy(std::string format, Rcpp::CharacterVector dst_filename,
     dst_filename_in = Rcpp::as<std::string>(_check_gdal_filename(dst_filename));
 
     GDALDatasetH hSrcDS = GDALOpenShared(src_filename_in.c_str(), GA_ReadOnly);
-    if(hSrcDS == nullptr)
+    if (hSrcDS == nullptr)
         Rcpp::stop("open source raster failed");
 
     std::vector<char *> opt_list = {nullptr};
@@ -780,7 +776,7 @@ Rcpp::DataFrame _combine(
     for (std::size_t i = 0; i < nrasters; ++i) {
         src_ds.push_back(GDALRaster(std::string(src_files[i]), true));
         // use the first raster as reference
-        if (i==0) {
+        if (i == 0) {
             nrows = src_ds[i].getRasterYSize();
             ncols = src_ds[i].getRasterXSize();
             gt = src_ds[i].getGeoTransform();
@@ -795,8 +791,7 @@ Rcpp::DataFrame _combine(
                 Rcpp::warning("failed to set output geotransform");
             if (!dst_ds.setProjection(srs))
                 Rcpp::warning("failed to set output projection");
-        }
-        else {
+        } else {
             for (std::size_t i = 0; i < nrasters; ++i)
                 src_ds[i].close();
             Rcpp::stop("failed to create output raster");
@@ -849,7 +844,7 @@ Rcpp::DataFrame _combine(
 //'
 //' @noRd
 // [[Rcpp::export(name = ".value_count")]]
-Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band = 1,
+Rcpp::DataFrame _value_count(const GDALRaster& src_ds, int band = 1,
                              bool quiet = false) {
 
     int nrows = src_ds.getRasterYSize();
@@ -879,7 +874,7 @@ Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band = 1,
         Rcpp::IntegerVector value(tbl.size());
         Rcpp::NumericVector count(tbl.size());
         std::size_t this_idx = 0;
-        for(auto iter = tbl.begin(); iter != tbl.end(); ++iter) {
+        for (auto iter = tbl.begin(); iter != tbl.end(); ++iter) {
             value[this_idx] = iter->first;
             count[this_idx] = iter->second;
             ++this_idx;
@@ -887,8 +882,7 @@ Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band = 1,
 
         df_out.push_back(value, "VALUE");
         df_out.push_back(count, "COUNT");
-    }
-    else {
+    } else {
         // UInt32, Float32, Float64
         // read pixel values as double
         Rcpp::NumericVector rowdata(ncols);
@@ -905,7 +899,7 @@ Rcpp::DataFrame _value_count(GDALRaster& src_ds, int band = 1,
         Rcpp::NumericVector value(tbl.size());
         Rcpp::NumericVector count(tbl.size());
         std::size_t this_idx = 0;
-        for(auto iter = tbl.begin(); iter != tbl.end(); ++iter) {
+        for (auto iter = tbl.begin(); iter != tbl.end(); ++iter) {
             value[this_idx] = iter->first;
             count[this_idx] = iter->second;
             ++this_idx;
@@ -964,8 +958,7 @@ bool _dem_proc(std::string mode,
         hDstDS = GDALDEMProcessing(dst_filename_in.c_str(), src_ds,
                                    mode.c_str(), col_file_in.get_cstring(),
                                    psOptions, nullptr);
-    }
-    else {
+    } else {
         hDstDS = GDALDEMProcessing(dst_filename_in.c_str(), src_ds,
                                    mode.c_str(), nullptr, psOptions, nullptr);
     }
@@ -1519,12 +1512,10 @@ bool _polygonize(Rcpp::CharacterVector src_filename, int src_band,
     if (mask_file_in == "" && nomask == false) {
         // default validity mask
         hMaskBand = GDALGetMaskBand(hSrcBand);
-    }
-    else if (mask_file_in == "" && nomask == true) {
+    } else if (mask_file_in == "" && nomask == true) {
         // do not use default validity mask for source band (such as nodata)
         hMaskBand = nullptr;
-    }
-    else {
+    } else {
         // mask_file specified
         hMaskDS = GDALOpenShared(mask_file_in.c_str(), GA_ReadOnly);
         if (hMaskDS == nullptr) {
@@ -2091,8 +2082,7 @@ bool warp(Rcpp::CharacterVector src_files,
             for (R_xlen_t j = 0; j < i; ++j)
                 GDALClose(src_ds[j]);
             Rcpp::stop("open source raster failed");
-        }
-        else {
+        } else {
             src_ds[i] = hDS;
         }
     }
@@ -2261,7 +2251,7 @@ Rcpp::IntegerMatrix createColorRamp(int start_index,
 
     GDALCreateColorRamp(hColTbl, start_index, &colStart, end_index, &colEnd);
 
-    //int nEntries = GDALGetColorEntryCount(hColTbl);
+    // int nEntries = GDALGetColorEntryCount(hColTbl);
     int nEntries = (end_index - start_index) + 1;
     Rcpp::IntegerMatrix col_tbl(nEntries, 5);
     Rcpp::CharacterVector col_tbl_names;
@@ -2269,16 +2259,13 @@ Rcpp::IntegerMatrix createColorRamp(int start_index,
     if (gpi == GPI_Gray) {
         col_tbl_names = {"value", "gray", "c2", "c3", "c4"};
         Rcpp::colnames(col_tbl) = col_tbl_names;
-    }
-    else if (gpi == GPI_RGB) {
+    } else if (gpi == GPI_RGB) {
         col_tbl_names = {"value", "red", "green", "blue", "alpha"};
         Rcpp::colnames(col_tbl) = col_tbl_names;
-    }
-    else if (gpi == GPI_CMYK) {
+    } else if (gpi == GPI_CMYK) {
         col_tbl_names = {"value", "cyan", "magenta", "yellow", "black"};
         Rcpp::colnames(col_tbl) = col_tbl_names;
-    }
-    else if (gpi == GPI_HLS) {
+    } else if (gpi == GPI_HLS) {
         col_tbl_names = {"value", "hue", "lightness", "saturation", "c4"};
         Rcpp::colnames(col_tbl) = col_tbl_names;
     }
@@ -2460,8 +2447,7 @@ bool deleteDataset(Rcpp::CharacterVector filename, std::string format = "") {
         hDriver = GDALIdentifyDriver(filename_in.c_str(), nullptr);
         if (hDriver == nullptr)
             return false;
-    }
-    else {
+    } else {
         hDriver = GDALGetDriverByName(format.c_str());
         if (hDriver == nullptr)
             return false;
@@ -2535,8 +2521,7 @@ bool renameDataset(Rcpp::CharacterVector new_filename,
         hDriver = GDALIdentifyDriver(old_filename_in.c_str(), nullptr);
         if (hDriver == nullptr)
             return false;
-    }
-    else {
+    } else {
         hDriver = GDALGetDriverByName(format.c_str());
         if (hDriver == nullptr)
             return false;
@@ -2603,8 +2588,7 @@ bool copyDatasetFiles(Rcpp::CharacterVector new_filename,
         hDriver = GDALIdentifyDriver(old_filename_in.c_str(), nullptr);
         if (hDriver == nullptr)
             return false;
-    }
-    else {
+    } else {
         hDriver = GDALGetDriverByName(format.c_str());
         if (hDriver == nullptr)
             return false;
@@ -2654,8 +2638,7 @@ bool _addFileInZip(std::string zip_filename, bool overwrite,
 
     if (overwrite) {
         VSIUnlink(zip_filename.c_str());
-    }
-    else {
+    } else {
         if (VSIStatExL(zip_filename.c_str(), &buf, VSI_STAT_EXISTS_FLAG) == 0)
             opt_zip_create.push_back((char *) "APPEND=TRUE");
     }

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -342,6 +342,18 @@ std::vector<int> GDALRaster::getBlockSize(int band) const {
     return ret;
 }
 
+std::vector<int> GDALRaster::getActualBlockSize(int band, int xblockoff,
+                                                int yblockoff) const {
+    _checkAccess(GA_ReadOnly);
+
+    GDALRasterBandH hBand = _getBand(band);
+    int nXValid, nYValid;
+    GDALGetActualBlockSize(hBand, xblockoff, yblockoff,
+                           &nXValid, &nYValid);
+    std::vector<int> ret = {nXValid, nYValid};
+    return ret;
+}
+
 int GDALRaster::getOverviewCount(int band) const {
     _checkAccess(GA_ReadOnly);
 
@@ -1462,6 +1474,8 @@ RCPP_MODULE(mod_GDALRaster) {
     .const_method("dim", &GDALRaster::dim,
         "Return raster dimensions (xsize, ysize, number of bands)")
     .const_method("getBlockSize", &GDALRaster::getBlockSize,
+        "Retrieve the actual block size for a given block offset")
+    .const_method("getActualBlockSize", &GDALRaster::getActualBlockSize,
         "Get the natural block size of this band")
     .const_method("getOverviewCount", &GDALRaster::getOverviewCount,
         "Return the number of overview layers available")

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -110,6 +110,8 @@ class GDALRaster {
     std::vector<int> dim() const;
 
     std::vector<int> getBlockSize(int band) const;
+    std::vector<int> getActualBlockSize(int band, int xblockoff,
+                                        int yblockoff) const;
     int getOverviewCount(int band) const;
     void buildOverviews(std::string resampling, std::vector<int> levels,
                         std::vector<int> bands);

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -55,6 +55,7 @@ test_that("band-level parameters are correct", {
     evt_file <- system.file("extdata/storml_evt.tif", package="gdalraster")
     ds <- new(GDALRaster, evt_file, TRUE)
     expect_equal(ds$getBlockSize(1), c(143,28))
+    expect_equal(ds$getActualBlockSize(1, 0, 0), c(143,28))
     expect_equal(ds$getOverviewCount(1), 0)
     expect_equal(ds$getDataTypeName(1), "Int16")
     expect_equal(ds$getNoDataValue(1), 32767)


### PR DESCRIPTION
Retrieve the actual block size for a given block offset.  Handles partial blocks at the edges of the raster and returns the true number of pixels. Exposes `GDALGetActualBlockSize()`.