### PR TITLE
Support recursive in `vsi_rmdir()` and `vsi_mkdir()` (also fixing `mode` in `vsi_mkdir()`)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9080
+Version: 1.10.9090
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
-# gdalraster 1.10.9080 (dev)
+# gdalraster 1.10.9090 (dev)
+
+* `vsi_rmdir()`: add argument `recursive`, `TRUE` to delete the directory and its content (2024-04-21)
+
+* `vsi_mkdir()`: add argument `recursive`, `TRUE` to create the directory and its ancestors (2024-04-21)
+
+* fix `vsi_mkdir()`: the file mode was set incorrectly because `mode` was not passed correctly as octal literal. `mode` is now passed as a character string containing the file mode as octal (2024-04-21)
 
 * support I/O of Byte raster as R `raw` type; add the setting `readByteAsRaw` as a field in class `GDALRaster`; add argument `as_raw` in `read_ds()` (#314, thanks to @mdsumner) (2024-04-19)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1539,53 +1539,61 @@ vsi_sync <- function(src, target, show_progress = FALSE, options = NULL) {
 #' (umask). However, some file systems and platforms may not use umask, or
 #' they may ignore the mode completely. So a reasonable cross-platform
 #' default mode value is 0755.
-#' This function is a wrapper for `VSIMkdir()` in the GDAL
-#' Common Portability Library. Analog of the POSIX `mkdir()` function.
+#' With `recursive = TRUE`, creates a directory and all its ancestors.
+#' This function is a wrapper for `VSIMkdir()` and `VSIMkdirRecursive()` in
+#' the GDAL Common Portability Library.
 #'
 #' @param path Character string. The path to the directory to create.
-#' @param mode Integer scalar. The permissions mode.
+#' @param mode Character string. The permissions mode in octal.
+#' @param recursive Logical scalar. `TRUE` to create the directory and its
+#' ancestors. Defaults to `FALSE`.
 #' @returns Invisibly, `0` on success or `-1` on an error.
 #'
 #' @seealso
 #' [vsi_read_dir()], [vsi_rmdir()]
 #'
 #' @examples
-#' # for illustration only
-#' # this would normally be used with GDAL virtual file systems
 #' new_dir <- file.path(tempdir(), "newdir")
 #' result <- vsi_mkdir(new_dir)
 #' print(result)
 #' result <- vsi_rmdir(new_dir)
 #' print(result)
-vsi_mkdir <- function(path, mode = 755L) {
-    invisible(.Call(`_gdalraster_vsi_mkdir`, path, mode))
+vsi_mkdir <- function(path, mode = "0755", recursive = FALSE) {
+    invisible(.Call(`_gdalraster_vsi_mkdir`, path, mode, recursive))
 }
 
 #' Delete a directory
 #'
 #' `vsi_rmdir()` deletes a directory object from the file system. On some
 #' systems the directory must be empty before it can be deleted.
+#' With `recursive = TRUE`, deletes a directory object and its content from
+#' the file system.
 #' This function goes through the GDAL `VSIFileHandler` virtualization and may
 #' work on unusual filesystems such as in memory.
-#' It is a wrapper for `VSIRmdir()` in the GDAL Common Portability Library.
-#' Analog of the POSIX `rmdir()` function.
+#' It is a wrapper for `VSIRmdir()` and `VSIRmdirRecursive()` in the GDAL
+#' Common Portability Library.
 #'
 #' @param path Character string. The path to the directory to be deleted.
+#' @param recursive Logical scalar. `TRUE` to delete the directory and its
+#' content. Defaults to `FALSE`.
 #' @returns Invisibly, `0` on success or `-1` on an error.
+#'
+#' @note
+#' /vsis3/ has an efficient implementation for deleting recursively. Starting
+#' with GDAL 3.4, /vsigs/ has an efficient implementation for deleting
+#' recursively, provided that OAuth2 authentication is used.
 #'
 #' @seealso
 #' [deleteDataset()], [vsi_mkdir()], [vsi_read_dir()], [vsi_unlink()]
 #'
 #' @examples
-#' # for illustration only
-#' # this would normally be used with GDAL virtual file systems
 #' new_dir <- file.path(tempdir(), "newdir")
 #' result <- vsi_mkdir(new_dir)
 #' print(result)
 #' result <- vsi_rmdir(new_dir)
 #' print(result)
-vsi_rmdir <- function(path) {
-    invisible(.Call(`_gdalraster_vsi_rmdir`, path))
+vsi_rmdir <- function(path, recursive = FALSE) {
+    invisible(.Call(`_gdalraster_vsi_rmdir`, path, recursive))
 }
 
 #' Delete a file

--- a/man/vsi_mkdir.Rd
+++ b/man/vsi_mkdir.Rd
@@ -4,12 +4,15 @@
 \alias{vsi_mkdir}
 \title{Create a directory}
 \usage{
-vsi_mkdir(path, mode = 755L)
+vsi_mkdir(path, mode = "0755", recursive = FALSE)
 }
 \arguments{
 \item{path}{Character string. The path to the directory to create.}
 
-\item{mode}{Integer scalar. The permissions mode.}
+\item{mode}{Character string. The permissions mode in octal.}
+
+\item{recursive}{Logical scalar. \code{TRUE} to create the directory and its
+ancestors. Defaults to \code{FALSE}.}
 }
 \value{
 Invisibly, \code{0} on success or \code{-1} on an error.
@@ -20,12 +23,11 @@ For POSIX-style systems, the mode is modified by the file creation mask
 (umask). However, some file systems and platforms may not use umask, or
 they may ignore the mode completely. So a reasonable cross-platform
 default mode value is 0755.
-This function is a wrapper for \code{VSIMkdir()} in the GDAL
-Common Portability Library. Analog of the POSIX \code{mkdir()} function.
+With \code{recursive = TRUE}, creates a directory and all its ancestors.
+This function is a wrapper for \code{VSIMkdir()} and \code{VSIMkdirRecursive()} in
+the GDAL Common Portability Library.
 }
 \examples{
-# for illustration only
-# this would normally be used with GDAL virtual file systems
 new_dir <- file.path(tempdir(), "newdir")
 result <- vsi_mkdir(new_dir)
 print(result)

--- a/man/vsi_rmdir.Rd
+++ b/man/vsi_rmdir.Rd
@@ -4,10 +4,13 @@
 \alias{vsi_rmdir}
 \title{Delete a directory}
 \usage{
-vsi_rmdir(path)
+vsi_rmdir(path, recursive = FALSE)
 }
 \arguments{
 \item{path}{Character string. The path to the directory to be deleted.}
+
+\item{recursive}{Logical scalar. \code{TRUE} to delete the directory and its
+content. Defaults to \code{FALSE}.}
 }
 \value{
 Invisibly, \code{0} on success or \code{-1} on an error.
@@ -15,14 +18,19 @@ Invisibly, \code{0} on success or \code{-1} on an error.
 \description{
 \code{vsi_rmdir()} deletes a directory object from the file system. On some
 systems the directory must be empty before it can be deleted.
+With \code{recursive = TRUE}, deletes a directory object and its content from
+the file system.
 This function goes through the GDAL \code{VSIFileHandler} virtualization and may
 work on unusual filesystems such as in memory.
-It is a wrapper for \code{VSIRmdir()} in the GDAL Common Portability Library.
-Analog of the POSIX \code{rmdir()} function.
+It is a wrapper for \code{VSIRmdir()} and \code{VSIRmdirRecursive()} in the GDAL
+Common Portability Library.
+}
+\note{
+/vsis3/ has an efficient implementation for deleting recursively. Starting
+with GDAL 3.4, /vsigs/ has an efficient implementation for deleting
+recursively, provided that OAuth2 authentication is used.
 }
 \examples{
-# for illustration only
-# this would normally be used with GDAL virtual file systems
 new_dir <- file.path(tempdir(), "newdir")
 result <- vsi_mkdir(new_dir)
 print(result)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -532,25 +532,27 @@ BEGIN_RCPP
 END_RCPP
 }
 // vsi_mkdir
-int vsi_mkdir(Rcpp::CharacterVector path, int mode);
-RcppExport SEXP _gdalraster_vsi_mkdir(SEXP pathSEXP, SEXP modeSEXP) {
+int vsi_mkdir(Rcpp::CharacterVector path, std::string mode, bool recursive);
+RcppExport SEXP _gdalraster_vsi_mkdir(SEXP pathSEXP, SEXP modeSEXP, SEXP recursiveSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type path(pathSEXP);
-    Rcpp::traits::input_parameter< int >::type mode(modeSEXP);
-    rcpp_result_gen = Rcpp::wrap(vsi_mkdir(path, mode));
+    Rcpp::traits::input_parameter< std::string >::type mode(modeSEXP);
+    Rcpp::traits::input_parameter< bool >::type recursive(recursiveSEXP);
+    rcpp_result_gen = Rcpp::wrap(vsi_mkdir(path, mode, recursive));
     return rcpp_result_gen;
 END_RCPP
 }
 // vsi_rmdir
-int vsi_rmdir(Rcpp::CharacterVector path);
-RcppExport SEXP _gdalraster_vsi_rmdir(SEXP pathSEXP) {
+int vsi_rmdir(Rcpp::CharacterVector path, bool recursive);
+RcppExport SEXP _gdalraster_vsi_rmdir(SEXP pathSEXP, SEXP recursiveSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type path(pathSEXP);
-    rcpp_result_gen = Rcpp::wrap(vsi_rmdir(path));
+    Rcpp::traits::input_parameter< bool >::type recursive(recursiveSEXP);
+    rcpp_result_gen = Rcpp::wrap(vsi_rmdir(path, recursive));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1315,8 +1317,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_vsi_curl_clear_cache", (DL_FUNC) &_gdalraster_vsi_curl_clear_cache, 2},
     {"_gdalraster_vsi_read_dir", (DL_FUNC) &_gdalraster_vsi_read_dir, 2},
     {"_gdalraster_vsi_sync", (DL_FUNC) &_gdalraster_vsi_sync, 4},
-    {"_gdalraster_vsi_mkdir", (DL_FUNC) &_gdalraster_vsi_mkdir, 2},
-    {"_gdalraster_vsi_rmdir", (DL_FUNC) &_gdalraster_vsi_rmdir, 1},
+    {"_gdalraster_vsi_mkdir", (DL_FUNC) &_gdalraster_vsi_mkdir, 3},
+    {"_gdalraster_vsi_rmdir", (DL_FUNC) &_gdalraster_vsi_rmdir, 2},
     {"_gdalraster_vsi_unlink", (DL_FUNC) &_gdalraster_vsi_unlink, 1},
     {"_gdalraster_vsi_unlink_batch", (DL_FUNC) &_gdalraster_vsi_unlink_batch, 1},
     {"_gdalraster_vsi_stat", (DL_FUNC) &_gdalraster_vsi_stat, 2},

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -171,7 +171,7 @@ class GDALRaster {
 
     void close();
 
-    bool readByteAsRaw; 
+    bool readByteAsRaw;
     // methods for internal use not exported to R
     void _checkAccess(GDALAccess access_needed) const;
     GDALRasterBandH _getBand(int band) const;
@@ -227,8 +227,8 @@ bool vsi_sync(Rcpp::CharacterVector src,
               Rcpp::CharacterVector target,
               bool show_progess,
               Rcpp::Nullable<Rcpp::CharacterVector> options);
-int vsi_mkdir(Rcpp::CharacterVector path, int mode);
-int vsi_rmdir(Rcpp::CharacterVector path);
+int vsi_mkdir(Rcpp::CharacterVector path, std::string mode, bool recursive);
+int vsi_rmdir(Rcpp::CharacterVector path, bool recursive);
 int vsi_unlink(Rcpp::CharacterVector filename);
 SEXP vsi_unlink_batch(Rcpp::CharacterVector filenames);
 SEXP vsi_stat(Rcpp::CharacterVector filename, std::string info);

--- a/tests/testthat/test-gdal_vsi.R
+++ b/tests/testthat/test-gdal_vsi.R
@@ -53,7 +53,14 @@ test_that("vsi_unlink_batch works", {
 test_that("vsi_mkdir and vsi_rmdir work", {
     new_dir <- file.path(tempdir(), "newdir")
     expect_equal(vsi_mkdir(new_dir), 0)
-    expect_equal(result <- vsi_rmdir(new_dir), 0)
+    expect_equal(vsi_rmdir(new_dir), 0)
+
+    # recursive
+    top_dir <- file.path(tempdir(), "topdir")
+    sub_dir <- file.path(top_dir, "subdir")
+    expect_equal(vsi_mkdir(sub_dir), -1)
+    expect_equal(vsi_mkdir(sub_dir, recursive = TRUE), 0)
+    expect_equal(vsi_rmdir(top_dir, recursive = TRUE), 0)
 })
 
 test_that("vsi_sync works", {


### PR DESCRIPTION
Adds argument `recursive` in `vsi_rmdir()` and `vsi_mkdir()`. Supports deleting the directory and its content, or creating the directory and its ancestors, respectively.

This PR also fixes the `mode` argument in `vsi_mkdir()`. It was not passed correctly as an octal literal so file mode would be wrong. `mode` is now passed as a character string containing the file mode as octal.