### PR TITLE
Support multiband output in `calc()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9090
+Version: 1.10.9100
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9090 (dev)
+# gdalraster 1.10.9100 (dev)
+
+* support multiband `calc()` (#319) (2024-04-23)
 
 * `vsi_rmdir()`: add argument `recursive`, `TRUE` to delete the directory and its content (2024-04-21)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gdalraster 1.10.9100 (dev)
 
-* support multiband `calc()` (#319) (2024-04-23)
+* support multiband output in `calc()` (#319) (2024-04-23)
 
 * `vsi_rmdir()`: add argument `recursive`, `TRUE` to delete the directory and its content (2024-04-21)
 

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -165,9 +165,9 @@ DEFAULT_DEM_PROC <- list(
 #' band.
 #' @param as_raw Logical. If `TRUE` and the underlying data type is Byte, return output
 #' as R's raw vector type. This maps to the setting `$readByteAsRaw` on the `GDALRaster` object,
-#' which is used to temporarily update that field in this function. To control this behaviour 
-#' in a persisent way on a data set see \code{$readByteAsRaw}  in 
-#' [`GDALRaster-class`][GDALRaster].  
+#' which is used to temporarily update that field in this function. To control this behaviour
+#' in a persisent way on a data set see \code{$readByteAsRaw}  in
+#' [`GDALRaster-class`][GDALRaster].
 #' @returns If `as_list = FALSE` (the default), a `numeric` or `complex` vector
 #' containing the values that were read. It is organized in left to right, top
 #' to bottom pixel order, interleaved by band.
@@ -802,6 +802,7 @@ rasterToVRT <- function(srcfile,
 #' Individual pixel coordinates are also available as variables in the
 #' R expression, as either x/y in the raster projected coordinate system or
 #' inverse projected longitude/latitude.
+#' Multiband output is supported as of {gdalraster} 1.11.0.
 #'
 #' @details
 #' The variables in `expr` are vectors of length raster xsize
@@ -816,7 +817,7 @@ rasterToVRT <- function(srcfile,
 #' which is read from the first input raster). Note that inverse projection
 #' adds computation time.
 #'
-#' To refer to specific bands in a multi-band file, repeat the filename in
+#' To refer to specific bands in a multi-band input file, repeat the filename in
 #' `rasterfiles` and specify corresponding band numbers in `bands`, along with
 #' optional variable names in `var.names`, for example,
 #' \preformatted{
@@ -827,7 +828,16 @@ rasterToVRT <- function(srcfile,
 #'
 #' Output will be written to `dstfile`. To update a file that already
 #' exists, set `write_mode = "update"` and set `out_band` to an existing
-#' band number in `dstfile` (new bands cannot be created in `dstfile`).
+#' band number(s) in `dstfile` (new bands cannot be created in `dstfile`).
+#'
+#' To write multiband output, `expr` must return a vector of values
+#' interleaved by band. This is equivalent to, and can also be returned as,
+#' a matrix `m` with `nrow(m)` equal to `length()` of an input vector, and
+#' `ncol(m)` equal to the number of output bands. In matrix form, each column
+#' contains a vector of output values for a band.
+#' `length(m)` must be equal to the `length()` of an input vector multiplied by
+#' `length(out_band)`. The dimensions described above are assumed and not
+#' read from the return value of `expr`.
 #'
 #' @param expr An R expression as a character string (e.g., `"A + B"`).
 #' @param rasterfiles Character vector of source raster filenames.
@@ -839,7 +849,9 @@ rasterToVRT <- function(srcfile,
 #' to guess from the output filename if not specified.
 #' @param dtName Character name of output data type (e.g., Byte, Int16,
 #' UInt16, Int32, UInt32, Float32).
-#' @param out_band Integer band number in `dstfile` for writing output.
+#' @param out_band Integer band number(s) in `dstfile` for writing output.
+#' Defaults to `1`. Multiband output is supported as of {gdalraster} 1.11.0,
+#' in which case `out_band` would be a vector of band numbers.
 #' @param options Optional list of format-specific creation options in a
 #' vector of "NAME=VALUE" pairs
 #' (e.g., \code{options = c("COMPRESS=LZW")} to set LZW compression
@@ -1004,12 +1016,9 @@ calc <- function(expr,
     if (write_mode == "update") {
         update_mode <- TRUE
     } else if (write_mode == "safe" || write_mode == "overwrite") {
-        if (!is.null(out_band))
-            if (out_band != 1)
-                stop("'out_band' other than 1 requires \"update\" mode",
-                     call. = FALSE)
         update_mode <- FALSE
-        out_band <- 1
+        if (is.null(out_band))
+            out_band <- 1
     } else {
         stop("unknown 'write_mode'", call. = FALSE)
     }
@@ -1085,7 +1094,7 @@ calc <- function(expr,
         rasterFromRaster(rasterfiles[1],
                          dstfile,
                          fmt,
-                         nbands = 1,
+                         nbands = length(out_band),
                          dtName = dtName,
                          options = options,
                          dstnodata = dstnodata)
@@ -1124,6 +1133,10 @@ calc <- function(expr,
         assign("pixelX", x) # nolint: object_usage_linter.
     }
 
+    # expected size of vector returned by expr
+    num_out_bands <- length(out_band)
+    expect_outrow_len <- ncols * num_out_bands
+
     process_row <- function(row) {
         if (usePixelY) {
             y <- rep((ymax - (cellsizeY / 2) - (cellsizeY * row)), ncols)
@@ -1148,7 +1161,7 @@ calc <- function(expr,
         }
 
         outrow <- eval(calc_expr)
-        if (length(outrow) != ncols) {
+        if (length(outrow) != expect_outrow_len) {
             dst_ds$close()
             for (r in 1:nrasters) {
                 ds_list[[r]]$close()
@@ -1156,13 +1169,17 @@ calc <- function(expr,
             stop("result vector is the wrong size", call. = FALSE)
         }
         outrow <- ifelse(is.na(outrow), nodata_value, outrow)
-        dst_ds$write(band = out_band,
-                     offx = 0,
-                     offy = row,
-                     xsize = ncols,
-                     ysize = 1,
-                     outrow)
-
+        dim(outrow) <- c(ncols, num_out_bands)
+        i <- 1
+        for (b in out_band) {
+            dst_ds$write(band = b,
+                         offx = 0,
+                         offy = row,
+                         xsize = ncols,
+                         ysize = 1,
+                         rasterData = outrow[, i])
+            i <- i + 1
+        }
         if (!quiet)
             setTxtProgressBar(pb, row+1)
 

--- a/man/calc.Rd
+++ b/man/calc.Rd
@@ -39,7 +39,9 @@ to guess from the output filename if not specified.}
 \item{dtName}{Character name of output data type (e.g., Byte, Int16,
 UInt16, Int32, UInt32, Float32).}
 
-\item{out_band}{Integer band number in \code{dstfile} for writing output.}
+\item{out_band}{Integer band number(s) in \code{dstfile} for writing output.
+Defaults to \code{1}. Multiband output is supported as of {gdalraster} 1.11.0,
+in which case \code{out_band} would be a vector of band numbers.}
 
 \item{options}{Optional list of format-specific creation options in a
 vector of "NAME=VALUE" pairs
@@ -85,6 +87,7 @@ of inputs.
 Individual pixel coordinates are also available as variables in the
 R expression, as either x/y in the raster projected coordinate system or
 inverse projected longitude/latitude.
+Multiband output is supported as of {gdalraster} 1.11.0.
 }
 \details{
 The variables in \code{expr} are vectors of length raster xsize
@@ -99,7 +102,7 @@ coordinates will be inverse projected to longitude/latitude
 which is read from the first input raster). Note that inverse projection
 adds computation time.
 
-To refer to specific bands in a multi-band file, repeat the filename in
+To refer to specific bands in a multi-band input file, repeat the filename in
 \code{rasterfiles} and specify corresponding band numbers in \code{bands}, along with
 optional variable names in \code{var.names}, for example,
 \preformatted{
@@ -110,7 +113,16 @@ var.names = c("B4", "B5")
 
 Output will be written to \code{dstfile}. To update a file that already
 exists, set \code{write_mode = "update"} and set \code{out_band} to an existing
-band number in \code{dstfile} (new bands cannot be created in \code{dstfile}).
+band number(s) in \code{dstfile} (new bands cannot be created in \code{dstfile}).
+
+To write multiband output, \code{expr} must return a vector of values
+interleaved by band. This is equivalent to, and can also be returned as,
+a matrix \code{m} with \code{nrow(m)} equal to \code{length()} of an input vector, and
+\code{ncol(m)} equal to the number of output bands. In matrix form, each column
+contains a vector of output values for a band.
+\code{length(m)} must be equal to the \code{length()} of an input vector multiplied by
+\code{length(out_band)}. The dimensions described above are assumed and not
+read from the return value of \code{expr}.
 }
 \examples{
 ## Using pixel longitude/latitude

--- a/tests/testthat/test-gdalraster_proc.R
+++ b/tests/testthat/test-gdalraster_proc.R
@@ -64,20 +64,23 @@ test_that("calc writes correct results", {
     # multiband output
     # https://github.com/USDAForestService/gdalraster/issues/319
     # TODO: checksum the output bands once confirmed as correct
-    to_terrainrgb <- function(dtm) {
-        startingvalue <- 10000
-        precision <- 0.1
-        rfactor <- 256*256 * precision
-        gfactor <- 256 * precision
+    expr <- "
+to_terrainrgb <- function(dtm) {
+    startingvalue <- 10000
+    precision <- 0.1
+    rfactor <- 256*256 * precision
+    gfactor <- 256 * precision
 
-        r <- floor((startingvalue +dtm)*(1/precision) / 256 / 256)
-        g <- floor((startingvalue +dtm - r*rfactor)*(1/precision) / 256)
-        b <- floor((startingvalue +dtm - r*rfactor - g*gfactor)*(1/precision))
+    r <- floor((startingvalue +dtm)*(1/precision) / 256 / 256)
+    g <- floor((startingvalue +dtm - r*rfactor)*(1/precision) / 256)
+    b <- floor((startingvalue +dtm - r*rfactor - g*gfactor)*(1/precision))
 
-        return(c(r,g,b))
-    }
+    return(c(r,g,b))
+}
+to_terrainrgb(ELEV)"
+
     out_file <- "/vsimem/multiband-calc.tif"
-    result <- calc(expr = "to_terrainrgb(ELEV)",
+    result <- calc(expr,
                    rasterfiles = elev_file,
                    var.names = "ELEV",
                    dstfile = out_file,


### PR DESCRIPTION
#319 
`out_band` can be a vector of band numbers. Currently in that case, `expr` must return multiband output in a vector or matrix.