### PR TITLE
Improve the check for `-json` as a possible `cl_arg` in `ogrinfo()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9100
+Version: 1.10.9110
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9100 (dev)
+# gdalraster 1.10.9110 (dev)
+
+* improve the check for `"-json"` as a `cl_arg` to `ogrinfo()` (2024-04-23)
 
 * support multiband output in `calc()` (#319) (2024-04-23)
 

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -1414,12 +1414,14 @@ std::string ogrinfo(Rcpp::CharacterVector dsn,
         Rcpp::stop("failed to open the source dataset");
 
     bool have_args_in = false;
-    Rcpp::CharacterVector cl_arg_in;
+    bool as_json = false;
     std::vector<char *> argv;
     if (cl_arg.isNotNull()) {
-        cl_arg_in = cl_arg;
+        Rcpp::CharacterVector cl_arg_in(cl_arg);
         for (R_xlen_t i = 0; i < cl_arg_in.size(); ++i) {
             argv.push_back((char *) cl_arg_in[i]);
+            if (EQUAL(cl_arg_in[i], "-json"))
+                as_json = true;
         }
         have_args_in = true;
     }
@@ -1451,17 +1453,11 @@ std::string ogrinfo(Rcpp::CharacterVector dsn,
     if (cout)
         Rcpp::Rcout << info_out;
 
-    if (have_args_in) {
-        Rcpp::CharacterVector::iterator i;
-        for (i = cl_arg_in.begin(); i != cl_arg_in.end(); ++i) {
-            if (EQUAL(*i, "-json")) {
-                info_out.erase(std::remove(info_out.begin(),
-                                           info_out.end(),
-                                           '\n'),
-                               info_out.cend());
-                break;
-            }
-        }
+    if (as_json) {
+        info_out.erase(std::remove(info_out.begin(),
+                                   info_out.end(),
+                                   '\n'),
+                       info_out.cend());
     }
 
     return info_out;

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -342,6 +342,9 @@ test_that("ogrinfo works", {
     expect_vector(info, ptype = character(), size = 1)
     expect_false(info[1] == "")
 
+    json <- ogrinfo(src, "mtbs_perims", cl_arg = c("-json", "-so", "-nomd"))
+    expect_true(nchar(json) > 1000)
+
     src_mem <- paste0("/vsimem/", basename(src))
     vsi_copy_file(src, src_mem)
 


### PR DESCRIPTION
`ogrinfo()` checks for the argument `-json` in the character vector of arguments given in `cl_arg`. If present, it returns a JSON-formatted string.

This PR refactors the handling of `-json`, but also changes to the usual way of casting `Rcpp::Nullable` to the underlying type:
`Rcpp::CharacterVector cl_arg_in(cl_arg);`

This hopefully fixes:
`Error: ogrinfo() failed (could not create options struct)`
with GDAL 3.9.0beta1