### PR TITLE
ogrinfo(): revert to original arg passing in GDALVectorInfoOptions

### DIFF
--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -1424,9 +1424,7 @@ std::string ogrinfo(Rcpp::CharacterVector dsn,
             }
         }
     }
-#if GDAL_VERSION_NUM < 3090000
     argv.push_back((char *) dsn_in.c_str());
-#endif
     if (layers.isNotNull()) {
         Rcpp::CharacterVector layers_in(layers);
         for (R_xlen_t i = 0; i < layers_in.size(); ++i) {


### PR DESCRIPTION
Undo version dependent arg passing to `GDALVectorInfo()` that was added in commit 13d5637. A workaround is no longer needed (and was ineffective anyway for the regression in 3.9.0beta1). See #324. Fixed in GDAL for 3.9.

