### PR TITLE
add GDALRaster::get_pixel_line()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9160
+Version: 1.10.9170
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9160 (dev)
+# gdalraster 1.10.9170 (dev)
+
+* add `GDALRaster::get_pixel_line()`: alternate calling for `get_pixel_line()` on an object of class `GDALRaster` (2024-05-12)
 
 * `get_pixel_line()`: an object of class `GDALRaster` can now be passed for the `gt` parameter, in which case the geotransform will be obtained from the object and bounds checking on the raster extent will be done (original behaviour for `gt` as numeric vector is unchanged) (2024-05-12)
 

--- a/R/gdal_helpers.R
+++ b/R/gdal_helpers.R
@@ -298,12 +298,13 @@ vsi_get_fs_options <- function(filename, as_list = TRUE) {
 #' The upper left corner pixel is the raster origin (0,0) with column, row
 #' increasing left to right, top to bottom.
 #'
-#' @param xy Numeric array of geospatial x,y coordinates in the same
-#' spatial reference system as \code{gt}.
+#' @param xy Numeric matrix of geospatial x,y coordinates in the same spatial
+#' reference system as \code{gt} (or two-column data frame that will be coerced
+#' to numeric matrix).
 #' @param gt Either a numeric vector of length six containing the affine
 #' geotransform for the raster, or an object of class `GDALRaster` from
 #' which the geotransform will be obtained (see Note).
-#' @returns Integer array of raster pixel/line.
+#' @returns Integer matrix of raster pixel/line.
 #'
 #' @note
 #' This function applies the inverse geotranform to the input points. If `gt`
@@ -312,23 +313,40 @@ vsi_get_fs_options <- function(filename, as_list = TRUE) {
 #' the raster x/y size). If `gt` is obtained from an object of class
 #' `GDALRaster`, then `NA` is returned for points that fall outside the
 #' raster extent and a warning emitted giving the number points that were
-#' outside.
+#' outside. This latter case is equivalent to calling the `$get_pixel_line()`
+#' class method on the `GDALRaster` object (see Examples).
 #'
 #' @seealso [`GDALRaster$getGeoTransform()`][GDALRaster], [inv_geotransform()]
 #'
 #' @examples
 #' pt_file <- system.file("extdata/storml_pts.csv", package="gdalraster")
-#' ## id, x, y in NAD83 / UTM zone 12N
+#' # id, x, y in NAD83 / UTM zone 12N
 #' pts <- read.csv(pt_file)
 #' print(pts)
+#'
 #' raster_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
 #' ds <- new(GDALRaster, raster_file)
 #' gt <- ds$getGeoTransform()
-#' get_pixel_line(as.matrix(pts[,-1]), gt)
+#' get_pixel_line(pts[, -1], gt)
+#'
+#' # or, using the class method
+#' ds$get_pixel_line(pts[, -1])
+#'
+#' # add a point outside the raster extent
+#' pts[11, ] <- c(11, 323318, 5105104)
+#' get_pixel_line(pts[, -1], gt)
+#'
+#' # with bounds checking on the raster extent
+#' ds$get_pixel_line(pts[, -1])
+#'
 #' ds$close()
 get_pixel_line <- function(xy, gt) {
-    if (!is.numeric(xy) && !is.matrix(xy))
-        stop("'xy' must be a numeric matrix", call. = FALSE)
+    if (!(is.matrix(xy) || is.data.frame(xy)))
+        stop("'xy' must be a data frame or numeric matrix", call. = FALSE)
+
+    if (ncol(xy) != 2)
+        stop("'xy' must have 2 columns",
+             call. = FALSE)
 
     if (is(gt, "Rcpp_GDALRaster")) {
         return(.get_pixel_line_ds(xy, gt))

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -55,6 +55,7 @@
 #' ds$bbox()
 #' ds$res()
 #' ds$dim()
+#' ds$get_pixel_line(xy)
 #'
 #' ds$getRasterCount()
 #' ds$getDescription(band)
@@ -219,6 +220,14 @@
 #' Returns an integer vector of length three containing the raster dimensions.
 #' Equivalent to:
 #' `c(ds$getRasterXSize(), ds$getRasterYSize(), ds$getRasterCount())`
+#'
+#' \code{$get_pixel_line()}
+#' Converts geospatial coordinates to pixel/line (raster column/row numbers).
+#' `xy` is a numeric matrix of geospatial x,y coordinates in the same spatial
+#' reference system as the raster (or two-column data frame that will be
+#' coerced to numeric matrix). Returns an integer matrix of raster pixel/line.
+#' See the stand-alone function of the same name ([get_pixel_line()]) for more
+#' info and examples.
 #'
 #' \code{$getRasterCount()}
 #' Returns the number of raster bands on this dataset. For the methods

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -73,6 +73,7 @@ ds$setProjection(projection)
 ds$bbox()
 ds$res()
 ds$dim()
+ds$get_pixel_line(xy)
 
 ds$getRasterCount()
 ds$getDescription(band)
@@ -240,6 +241,14 @@ raster.
 Returns an integer vector of length three containing the raster dimensions.
 Equivalent to:
 \code{c(ds$getRasterXSize(), ds$getRasterYSize(), ds$getRasterCount())}
+
+\code{$get_pixel_line()}
+Converts geospatial coordinates to pixel/line (raster column/row numbers).
+\code{xy} is a numeric matrix of geospatial x,y coordinates in the same spatial
+reference system as the raster (or two-column data frame that will be
+coerced to numeric matrix). Returns an integer matrix of raster pixel/line.
+See the stand-alone function of the same name (\code{\link[=get_pixel_line]{get_pixel_line()}}) for more
+info and examples.
 
 \code{$getRasterCount()}
 Returns the number of raster bands on this dataset. For the methods

--- a/man/get_pixel_line.Rd
+++ b/man/get_pixel_line.Rd
@@ -7,15 +7,16 @@
 get_pixel_line(xy, gt)
 }
 \arguments{
-\item{xy}{Numeric array of geospatial x,y coordinates in the same
-spatial reference system as \code{gt}.}
+\item{xy}{Numeric matrix of geospatial x,y coordinates in the same spatial
+reference system as \code{gt} (or two-column data frame that will be coerced
+to numeric matrix).}
 
 \item{gt}{Either a numeric vector of length six containing the affine
 geotransform for the raster, or an object of class \code{GDALRaster} from
 which the geotransform will be obtained (see Note).}
 }
 \value{
-Integer array of raster pixel/line.
+Integer matrix of raster pixel/line.
 }
 \description{
 \code{get_pixel_line()} converts geospatial coordinates to pixel/line (raster
@@ -30,17 +31,30 @@ pixel/line could be less than zero and max pixel/line could be greater than
 the raster x/y size). If \code{gt} is obtained from an object of class
 \code{GDALRaster}, then \code{NA} is returned for points that fall outside the
 raster extent and a warning emitted giving the number points that were
-outside.
+outside. This latter case is equivalent to calling the \verb{$get_pixel_line()}
+class method on the \code{GDALRaster} object (see Examples).
 }
 \examples{
 pt_file <- system.file("extdata/storml_pts.csv", package="gdalraster")
-## id, x, y in NAD83 / UTM zone 12N
+# id, x, y in NAD83 / UTM zone 12N
 pts <- read.csv(pt_file)
 print(pts)
+
 raster_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
 ds <- new(GDALRaster, raster_file)
 gt <- ds$getGeoTransform()
-get_pixel_line(as.matrix(pts[,-1]), gt)
+get_pixel_line(pts[, -1], gt)
+
+# or, using the class method
+ds$get_pixel_line(pts[, -1])
+
+# add a point outside the raster extent
+pts[11, ] <- c(11, 323318, 5105104)
+get_pixel_line(pts[, -1], gt)
+
+# with bounds checking on the raster extent
+ds$get_pixel_line(pts[, -1])
+
 ds$close()
 }
 \seealso{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -182,25 +182,25 @@ BEGIN_RCPP
 END_RCPP
 }
 // _get_pixel_line_gt
-Rcpp::IntegerMatrix _get_pixel_line_gt(const Rcpp::NumericMatrix xy, const std::vector<double> gt);
+Rcpp::IntegerMatrix _get_pixel_line_gt(const Rcpp::RObject& xy, const std::vector<double> gt);
 RcppExport SEXP _gdalraster__get_pixel_line_gt(SEXP xySEXP, SEXP gtSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix >::type xy(xySEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type xy(xySEXP);
     Rcpp::traits::input_parameter< const std::vector<double> >::type gt(gtSEXP);
     rcpp_result_gen = Rcpp::wrap(_get_pixel_line_gt(xy, gt));
     return rcpp_result_gen;
 END_RCPP
 }
 // _get_pixel_line_ds
-Rcpp::IntegerMatrix _get_pixel_line_ds(const Rcpp::NumericMatrix xy, const GDALRaster& ds);
+Rcpp::IntegerMatrix _get_pixel_line_ds(const Rcpp::RObject& xy, const GDALRaster* ds);
 RcppExport SEXP _gdalraster__get_pixel_line_ds(SEXP xySEXP, SEXP dsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::NumericMatrix >::type xy(xySEXP);
-    Rcpp::traits::input_parameter< const GDALRaster& >::type ds(dsSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type xy(xySEXP);
+    Rcpp::traits::input_parameter< const GDALRaster* >::type ds(dsSEXP);
     rcpp_result_gen = Rcpp::wrap(_get_pixel_line_ds(xy, ds));
     return rcpp_result_gen;
 END_RCPP

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -333,6 +333,29 @@ std::vector<int> GDALRaster::dim() const {
     return ret;
 }
 
+Rcpp::IntegerMatrix GDALRaster::get_pixel_line(
+                    const Rcpp::RObject& xy) const {
+
+    _checkAccess(GA_ReadOnly);
+
+    Rcpp::NumericMatrix xy_in;
+    if (Rcpp::is<Rcpp::DataFrame>(xy)) {
+        xy_in = _df_to_matrix(xy);
+    }
+    else if (Rcpp::is<Rcpp::NumericVector>(xy)) {
+        if (Rf_isMatrix(xy))
+            xy_in = Rcpp::as<Rcpp::NumericMatrix>(xy);
+    }
+    else {
+        Rcpp::stop("'xy' must be a two-column data frame or matrix");
+    }
+
+    if (xy_in.nrow() == 0)
+        Rcpp::stop("input matrix is empty");
+
+    return _get_pixel_line_ds(xy_in, this);
+}
+
 std::vector<int> GDALRaster::getBlockSize(int band) const {
     _checkAccess(GA_ReadOnly);
 
@@ -1495,6 +1518,8 @@ RCPP_MODULE(mod_GDALRaster) {
         "Return the resolution (pixel width, pixel height)")
     .const_method("dim", &GDALRaster::dim,
         "Return raster dimensions (xsize, ysize, number of bands)")
+    .const_method("get_pixel_line", &GDALRaster::get_pixel_line,
+        "Convert geospatial coordinates to pixel/line")
     .const_method("getBlockSize", &GDALRaster::getBlockSize,
         "Retrieve the actual block size for a given block offset")
     .const_method("getActualBlockSize", &GDALRaster::getActualBlockSize,

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -107,6 +107,7 @@ class GDALRaster {
     std::vector<double> bbox() const;
     std::vector<double> res() const;
     std::vector<int> dim() const;
+    Rcpp::IntegerMatrix get_pixel_line(const Rcpp::RObject& xy) const;
 
     std::vector<int> getBlockSize(int band) const;
     std::vector<int> getActualBlockSize(int band, int xblockoff,
@@ -244,11 +245,11 @@ double vsi_get_disk_free_space(Rcpp::CharacterVector path);
 Rcpp::NumericVector _apply_geotransform(const std::vector<double> gt,
                                         double pixel, double line);
 Rcpp::NumericVector inv_geotransform(const std::vector<double> gt);
-Rcpp::IntegerMatrix _get_pixel_line_gt(const Rcpp::NumericMatrix xy,
+Rcpp::IntegerMatrix _get_pixel_line_gt(const Rcpp::RObject& xy,
                                        const std::vector<double> gt);
 
-Rcpp::IntegerMatrix _get_pixel_line_ds(const Rcpp::NumericMatrix xy,
-                                       const GDALRaster& ds);
+Rcpp::IntegerMatrix _get_pixel_line_ds(const Rcpp::RObject& xy,
+                                       const GDALRaster* ds);
 
 bool buildVRT(Rcpp::CharacterVector vrt_filename,
               Rcpp::CharacterVector input_rasters,

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -70,9 +70,15 @@ test_that("get_pixel_line gives correct results", {
     raster_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
     ds <- new(GDALRaster, raster_file, read_only=TRUE)
     gt <- ds$getGeoTransform()
-    ds$close()
-    res <- get_pixel_line(as.matrix(pts[,-1]), gt)
+    res <- get_pixel_line(as.matrix(pts[, -1]), gt)
     expect_equal(as.vector(res), pix_line)
+
+    pts[11, ] <- c(11, 323318, 5105104)
+    expect_warning(res2 <- ds$get_pixel_line(pts[, -1]))
+    res <- rbind(res, c(NA, NA))
+    expect_equal(res2, res)
+
+    ds$close()
 })
 
 test_that("_apply_geotransform gives correct result", {


### PR DESCRIPTION
Adds class method for alternate calling for `get_pixel_line()` on an object of class `GDALRaster`

also allows `xy` to be given as a two-column data frame that will be coerced to numeric matrix (originally required matrix input only)
