### PR TITLE
Use path.expand() instead of normalizePath() to avoid warning on Windows

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -177,8 +177,10 @@ pop_error_handler <- function() {
 }
 
 #' Check a filename before passing to GDAL and potentially fix.
-#' filename may be a physical file, URL, connection string, file name with
-#' additional parameters, etc. Returned in UTF-8 encoding.
+#' 'filename' may be a physical file, URL, connection string, filename with
+#' additional parameters, etc.
+#' Currently, only checks for leading tilde and does path expasion in that
+#' case. Returns the filename in UTF-8 encoding if possible using R enc2utf8.
 #'
 #' @noRd
 .check_gdal_filename <- function(filename) {
@@ -320,7 +322,7 @@ createCopy <- function(format, dst_filename, src_filename, strict = FALSE, optio
     invisible(.Call(`_gdalraster_createCopy`, format, dst_filename, src_filename, strict, options, quiet))
 }
 
-#' Apply geotransform
+#' Apply geotransform - internal wrapper of GDALApplyGeoTransform()
 #'
 #' `_apply_geotransform()` applies geotransform coefficients to a raster
 #' coordinate in pixel/line space (colum/row), converting into a

--- a/src/rcpp_util.cpp
+++ b/src/rcpp_util.cpp
@@ -23,6 +23,14 @@ Rcpp::IntegerMatrix _df_to_int_matrix(const Rcpp::DataFrame& df) {
     return m;
 }
 
+//' wrapper for base R path.expand()
+//' @noRd
+Rcpp::CharacterVector _path_expand(Rcpp::CharacterVector path) {
+
+    Rcpp::Function f("path.expand");
+    return f(path);
+}
+
 //' wrapper for base R normalizePath()
 //' int must_work should be NA_LOGICAL (the default), 0 or 1
 //' @noRd

--- a/src/rcpp_util.h
+++ b/src/rcpp_util.h
@@ -12,6 +12,7 @@
 
 Rcpp::NumericMatrix _df_to_matrix(const Rcpp::DataFrame& df);
 Rcpp::IntegerMatrix _df_to_int_matrix(const Rcpp::DataFrame& df);
+Rcpp::CharacterVector _path_expand(Rcpp::CharacterVector path);
 Rcpp::CharacterVector _normalize_path(Rcpp::CharacterVector path,
                                       int must_work);
 Rcpp::CharacterVector _normalize_path(Rcpp::CharacterVector path,

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -11,14 +11,14 @@ test_that("gdal_formats returns a data frame", {
     expect_true(nrow(x) > 1)
 })
 
-test_that("_check_gdal_filename works", {
+test_that(".check_gdal_filename works", {
     elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
     b5_file <- system.file("extdata/sr_b5_20200829.tif", package="gdalraster")
     expect_error(.check_gdal_filename(c(elev_file, b5_file)))
     vsifn <- paste0("/vsi/", b5_file)
     expect_equal(vsifn, .check_gdal_filename(vsifn))
     fn <- "~/_r82jRwnT.test"
-    expect_warning(fn_out <- .check_gdal_filename(fn))
+    fn_out <- .check_gdal_filename(fn)
     expect_equal(basename(fn_out), basename(fn))
 })
 


### PR DESCRIPTION
The PR changes `_check_gdal_filename()` so that it uses R `path.expand()` for tilde expansion if needed, instead of `normalizePath()` previously. This avoids having a warning emitted when the filename being checked does not exists yet.