### PR TITLE
VSIFile::write(): remove size param as unneeded

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9190
+Version: 1.10.9200
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# gdalraster 1.10.9190 (dev)
+# gdalraster 1.10.9200 (dev)
 
 * package `bit64` added in Imports, and `RcppInt64` added in LinkingTo (2024-05-19)
 

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -122,19 +122,16 @@ SEEK_END <- "SEEK_END"
 #' `vf$seek(0, SEEK_SET)`. No return value, called for that side effect.
 #'
 #' \code{$read(nbytes)}
-#' Reads `nbytes` bytes from the file at the current offset. Returns a vector
+#' Read `nbytes` bytes from the file at the current offset. Returns a vector
 #' of R `raw` type, or `NULL` if the operation fails.
 #'
-#' \code{$write(object, size)}
-#' Writes objects of `size` bytes to the file at the current offset. `object`
-#' is a `raw` vector. `size` is the number of bytes per element in `object`.
-#' This should normally be `1` (a negative number will be interpreted as `1`).
-#' Some of the information given in base R `?writeBin` is relevant here, but
-#' note that the implementation here is different and has minimal automatic
-#' handling.
-#' Returns the number of objects successfully written, as numeric scalar
+#' \code{$write(object)}
+#' Write bytes to the file at the current offset. `object` is a `raw` vector.
+#' Returns the number of bytes successfully written, as numeric scalar
 #' carrying the `integer64` class attribute.
-#' See also base R `charToRaw()`, convert to or from raw vectors.
+#' See also base R `charToRaw()` / `rawToChar()`, convert to or from raw
+#' vectors, and `readBin()` / `writeBin()` which read binary data from or write
+#' binary data to a raw vector.
 #'
 #' \code{$eof()}
 #' Test for end of file. Returns `TRUE` if an end-of-file condition occurred
@@ -206,11 +203,12 @@ SEEK_END <- "SEEK_END"
 #' # identify a FARSITE v.4 LCP file
 #' # function to check if the first three fields have valid data
 #' # input is the first twelve raw bytes in the file
-#' is_lcp <- function(byte_0_11) {
+#' is_lcp <- function(bytes) {
 #'   # 1-based indexing in R
-#'   if ((as.integer(byte_0_11)[1] == 20 || as.integer(byte_0_11)[1] == 21) &&
-#'       (as.integer(byte_0_11)[5] == 20 || as.integer(byte_0_11)[5] == 21) &&
-#'       (as.integer(byte_0_11)[9] >= -90 && as.integer(byte_0_11)[9] <= 90)) {
+#'   values <- readBin(bytes, "integer", 3)
+#'   if ((values[1] == 20 || values[1] == 21) &&
+#'         (values[2] == 20 || values[2] == 21) &&
+#'         (values[3] >= -90 && values[3] <= 90)) {
 #'
 #'     return(TRUE)
 #'   } else {
@@ -242,6 +240,25 @@ SEEK_END <- "SEEK_END"
 #' vf$rewind()
 #' is_lcp(vf$read(12))
 #'
+#' # read/write an integer field
+#' # write invalid data for the Latitude field and then set back
+#' # save original
+#' vf$seek(8, SEEK_SET)
+#' lat_orig <- vf$read(4)
+#' # latitude -99 out of range
+#' bytes <- writeBin(-99L, raw())
+#' vf$seek(8, SEEK_SET)
+#' vf$write(bytes)
+#' vf$rewind()
+#' is_lcp(vf$read(12))
+#' vf$seek(8, SEEK_SET)
+#' readBin(vf$read(4), "integer")
+#' # set back to original
+#' vf$seek(8, SEEK_SET)
+#' vf$write(lat_orig)
+#' vf$rewind()
+#' is_lcp(vf$read(12))
+#'
 #' # read the Description field
 #' vf$seek(6804, SEEK_SET)
 #' bytes <- vf$read(512)
@@ -253,7 +270,7 @@ SEEK_END <- "SEEK_END"
 #'               "Beaverhead-Deerlodge National Forest, Montana.")
 #'
 #' vf$seek(6804, SEEK_SET)
-#' vf$write(charToRaw(desc), 1)
+#' vf$write(charToRaw(desc))
 #' vf$close()
 #'
 #' ds <- new(GDALRaster, mem_file)

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -228,7 +228,7 @@ SEEK_END <- "SEEK_END"
 #' # write to an in-memory file
 #' mem_file <- "/vsimem/storml_copy.lcp"
 #' vf <- new(VSIFile, mem_file, "w")
-#' vf$write(bytes, 1)
+#' vf$write(bytes)
 #'
 #' vf$tell()
 #' vf$rewind()

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -121,19 +121,16 @@ Rewind the file pointer to the beginning of the file. This is equivalent to
 \code{vf$seek(0, SEEK_SET)}. No return value, called for that side effect.
 
 \code{$read(nbytes)}
-Reads \code{nbytes} bytes from the file at the current offset. Returns a vector
+Read \code{nbytes} bytes from the file at the current offset. Returns a vector
 of R \code{raw} type, or \code{NULL} if the operation fails.
 
-\code{$write(object, size)}
-Writes objects of \code{size} bytes to the file at the current offset. \code{object}
-is a \code{raw} vector. \code{size} is the number of bytes per element in \code{object}.
-This should normally be \code{1} (a negative number will be interpreted as \code{1}).
-Some of the information given in base R \code{?writeBin} is relevant here, but
-note that the implementation here is different and has minimal automatic
-handling.
-Returns the number of objects successfully written, as numeric scalar
+\code{$write(object)}
+Write bytes to the file at the current offset. \code{object} is a \code{raw} vector.
+Returns the number of bytes successfully written, as numeric scalar
 carrying the \code{integer64} class attribute.
-See also base R \code{charToRaw()}, convert to or from raw vectors.
+See also base R \code{charToRaw()} / \code{rawToChar()}, convert to or from raw
+vectors, and \code{readBin()} / \code{writeBin()} which read binary data from or write
+binary data to a raw vector.
 
 \code{$eof()}
 Test for end of file. Returns \code{TRUE} if an end-of-file condition occurred
@@ -198,11 +195,12 @@ lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
 # identify a FARSITE v.4 LCP file
 # function to check if the first three fields have valid data
 # input is the first twelve raw bytes in the file
-is_lcp <- function(byte_0_11) {
+is_lcp <- function(bytes) {
   # 1-based indexing in R
-  if ((as.integer(byte_0_11)[1] == 20 || as.integer(byte_0_11)[1] == 21) &&
-      (as.integer(byte_0_11)[5] == 20 || as.integer(byte_0_11)[5] == 21) &&
-      (as.integer(byte_0_11)[9] >= -90 && as.integer(byte_0_11)[9] <= 90)) {
+  values <- readBin(bytes, "integer", 3)
+  if ((values[1] == 20 || values[1] == 21) &&
+        (values[2] == 20 || values[2] == 21) &&
+        (values[3] >= -90 && values[3] <= 90)) {
 
     return(TRUE)
   } else {
@@ -234,6 +232,25 @@ vf$seek(0, SEEK_END)
 vf$rewind()
 is_lcp(vf$read(12))
 
+# read/write an integer field
+# write invalid data for the Latitude field and then set back
+# save original
+vf$seek(8, SEEK_SET)
+lat_orig <- vf$read(4)
+# latitude -99 out of range
+bytes <- writeBin(-99L, raw())
+vf$seek(8, SEEK_SET)
+vf$write(bytes)
+vf$rewind()
+is_lcp(vf$read(12))
+vf$seek(8, SEEK_SET)
+readBin(vf$read(4), "integer")
+# set back to original
+vf$seek(8, SEEK_SET)
+vf$write(lat_orig)
+vf$rewind()
+is_lcp(vf$read(12))
+
 # read the Description field
 vf$seek(6804, SEEK_SET)
 bytes <- vf$read(512)
@@ -245,7 +262,7 @@ desc <- paste(rawToChar(bytes),
               "Beaverhead-Deerlodge National Forest, Montana.")
 
 vf$seek(6804, SEEK_SET)
-vf$write(charToRaw(desc), 1)
+vf$write(charToRaw(desc))
 vf$close()
 
 ds <- new(GDALRaster, mem_file)

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -220,7 +220,7 @@ vf$close()
 # write to an in-memory file
 mem_file <- "/vsimem/storml_copy.lcp"
 vf <- new(VSIFile, mem_file, "w")
-vf$write(bytes, 1)
+vf$write(bytes)
 
 vf$tell()
 vf$rewind()

--- a/src/vsifile.cpp
+++ b/src/vsifile.cpp
@@ -153,42 +153,13 @@ SEXP VSIFile::read(std::size_t nbytes) {
     return raw;
 }
 
-Rcpp::NumericVector VSIFile::write(const Rcpp::RawVector& object, int size) {
+Rcpp::NumericVector VSIFile::write(const Rcpp::RawVector& object) {
     if (fp == nullptr)
         Rcpp::stop("the file is not open");
 
-    // R ?writeBin:
-    // (for info only, not accounting for all of this here, currently)
-    // "Possible sizes are 1, 2, 4 and possibly 8 for integer or logical
-    // vectors, and 4, 8 and possibly 12/16 for numeric vectors.
-    // Note that coercion occurs as signed types ...
-    // ‘Endian-ness’ is relevant for ‘size > 1’, and should always be set
-    // for portable code (the default is only appropriate when writing
-    // and then reading files on the same platform).
-    // Integer read/writes of size 8 will be available if either C type
-    // ‘long’ is of size 8 bytes or C type ‘long long’ exists and is of
-    // size 8 bytes.
-    // Real read/writes of size ‘sizeof(long double)’ (usually 12 or 16
-    // bytes) will be available only if that type is available and
-    // different from ‘double’."
-
-    if (size == 0 || size > 16) {
-        Rcpp::Rcerr << "'size' is invalid, must be in 1:16 or negative\n";
-        return 0;
-    }
-
-    size_t nSize = 1;
-    if (size < 0)
-        nSize = 1;
-    else
-        nSize = static_cast<size_t>(size);
-
     std::vector<int64_t> ret(1);
     ret[0] = static_cast<int64_t>(
-            VSIFWriteL(&object[0],
-                       nSize,
-                       static_cast<size_t>(object.size()),
-                       fp));
+            VSIFWriteL(&object[0], 1, static_cast<size_t>(object.size()), fp));
 
     return Rcpp::wrap(ret);
 }

--- a/src/vsifile.h
+++ b/src/vsifile.h
@@ -53,7 +53,7 @@ class VSIFile {
     Rcpp::NumericVector tell() const;
     void rewind();
     SEXP read(std::size_t nbytes);
-    Rcpp::NumericVector write(const Rcpp::RawVector& object, int size);
+    Rcpp::NumericVector write(const Rcpp::RawVector& object);
     bool eof() const;
     int truncate(Rcpp::NumericVector offset);
     int flush();


### PR DESCRIPTION
This PR removes the `size` parameter from the `write()` method of `VSIFile`. It is unneeded since input can only be a `raw` vector and size of elements will always be 1. Document use of base R `readBin()` and `writeBin()` to read binary data from or write binary data to a raw vector.