### PR TITLE
Add GDALProgressFunc in GDALRaster::getDefaultRAT()

### DIFF
--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -24,15 +24,18 @@
 #' @returns An object of class `GDALRaster` which contains a pointer to the
 #' opened dataset, and methods that operate on the dataset as described in
 #' Details. `GDALRaster` is a C++ class exposed directly to R (via
-#' `RCPP_EXPOSED_CLASS`). Methods of the class are accessed using the
-#' `$` operator.
+#' `RCPP_EXPOSED_CLASS`). Methods and fields of the class are accessed using
+#' the `$` operator.
 #'
 #' @section Usage:
 #' \preformatted{
 #' ## Constructors
-#' ds <- new(GDALRaster, filename, read_only=TRUE)
+#' # read-only by default:
+#' ds <- new(GDALRaster, filename)
+#' # for update access:
+#' ds <- new(GDALRaster, filename, read_only = FALSE)
 #' # or, using dataset open options:
-#' ds <- new(GDALRaster, filename, read_only, open_options)
+#' ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
 #'
 #' ## Fields (see Details)
 #' ds$readByteAsRaw

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -24,8 +24,8 @@ specifying dataset open options.}
 An object of class \code{GDALRaster} which contains a pointer to the
 opened dataset, and methods that operate on the dataset as described in
 Details. \code{GDALRaster} is a C++ class exposed directly to R (via
-\code{RCPP_EXPOSED_CLASS}). Methods of the class are accessed using the
-\code{$} operator.
+\code{RCPP_EXPOSED_CLASS}). Methods and fields of the class are accessed using
+the \code{$} operator.
 }
 \description{
 \code{GDALRaster} provides an interface for accessing a raster dataset via GDAL
@@ -48,9 +48,12 @@ override the default resampling to one of \code{BILINEAR}, \code{CUBIC},
 
 \preformatted{
 ## Constructors
-ds <- new(GDALRaster, filename, read_only=TRUE)
+# read-only by default:
+ds <- new(GDALRaster, filename)
+# for update access:
+ds <- new(GDALRaster, filename, read_only = FALSE)
 # or, using dataset open options:
-ds <- new(GDALRaster, filename, read_only, open_options)
+ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
 
 ## Fields (see Details)
 ds$readByteAsRaw

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -79,6 +79,7 @@ GDALRaster::GDALRaster() :
             open_options_in(Rcpp::CharacterVector::create()),
             hDataset(nullptr),
             eAccess(GA_ReadOnly),
+            quiet(false),
             readByteAsRaw(false) {}
 
 GDALRaster::GDALRaster(Rcpp::CharacterVector filename) :
@@ -98,6 +99,7 @@ GDALRaster::GDALRaster(Rcpp::CharacterVector filename, bool read_only,
                 open_options_in(open_options),
                 hDataset(nullptr),
                 eAccess(GA_ReadOnly),
+                quiet(false),
                 readByteAsRaw(false) {
 
     fname_in = Rcpp::as<std::string>(_check_gdal_filename(filename));
@@ -1153,6 +1155,8 @@ SEXP GDALRaster::getDefaultRAT(int band) const {
     int nCol = GDALRATGetColumnCount(hRAT);
     int nRow = GDALRATGetRowCount(hRAT);
     Rcpp::DataFrame df = Rcpp::DataFrame::create();
+    GDALProgressFunc pfnProgress = GDALTermProgressR;
+    void* pProgressData = nullptr;
 
     for (int i=0; i < nCol; ++i) {
         std::string colName(GDALRATGetNameOfCol(hRAT, i));
@@ -1193,6 +1197,10 @@ SEXP GDALRaster::getDefaultRAT(int band) const {
         }
         else {
             Rcpp::warning("unhandled GDAL field type");
+        }
+
+        if (!quiet) {
+            pfnProgress(i / (nCol-1.0), nullptr, pProgressData);
         }
     }
 

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -82,6 +82,9 @@ class GDALRaster {
     GDALRaster(Rcpp::CharacterVector filename, bool read_only,
                Rcpp::CharacterVector open_options);
 
+    bool quiet;  // not yet exported as read/write field
+    bool readByteAsRaw;
+
     std::string getFilename() const;
     void setFilename(std::string filename);
     void open(bool read_only);
@@ -171,7 +174,6 @@ class GDALRaster {
 
     void close();
 
-    bool readByteAsRaw;
     // methods for internal use not exported to R
     void _checkAccess(GDALAccess access_needed) const;
     GDALRasterBandH _getBand(int band) const;


### PR DESCRIPTION
This PR adds progress reporting in `GDALRaster::getDefaultRAT()`. Retrieving large raster attribute tables can take upward of ~20 seconds, e.g., a 66,468 row x 72 column table in a recent example case. Without a progress bar, it may appear that the method call is hung.

This PR also adds public field `quiet` on the class, set to `false` by default. It is not yet exported to R as a read/write field. The idea is provide a user setting on the object to control the amount of output from its methods, to be implemented later.