### PR TITLE
Make `vsi_*()` return values visible and use `integer64` type

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1350,7 +1350,7 @@ copyDatasetFiles <- function(new_filename, old_filename, format = "") {
 #' @param show_progress Logical scalar. If `TRUE`, a progress bar will be
 #' displayed (the size of `src_file` will be retrieved in GDAL with
 #' `VSIStatL()`). Default is `FALSE`.
-#' @returns Invisibly, `0` on success or `-1` on an error.
+#' @returns `0` on success or `-1` on an error.
 #'
 #' @note
 #' If `target_file` has the form /vsizip/foo.zip/bar, the default options
@@ -1373,7 +1373,7 @@ copyDatasetFiles <- function(new_filename, old_filename, format = "") {
 #'   vsi_unlink(tmp_file)
 #' }
 vsi_copy_file <- function(src_file, target_file, show_progress = FALSE) {
-    invisible(.Call(`_gdalraster_vsi_copy_file`, src_file, target_file, show_progress))
+    .Call(`_gdalraster_vsi_copy_file`, src_file, target_file, show_progress)
 }
 
 #' Clean cache associated with /vsicurl/ and related file systems
@@ -1505,7 +1505,7 @@ vsi_read_dir <- function(path, max_files = 0L) {
 #' @param show_progress Logical scalar. If `TRUE`, a progress bar will be
 #' displayed. Defaults to `FALSE`.
 #' @param options Character vector of `NAME=VALUE` pairs (see Details).
-#' @returns Invisibly, `TRUE` on success or `FALSE` on an error.
+#' @returns Logical scalar, `TRUE` on success or `FALSE` on an error.
 #'
 #' @seealso
 #' [copyDatasetFiles()], [vsi_copy_file()]
@@ -1556,7 +1556,7 @@ vsi_read_dir <- function(path, max_files = 0L) {
 #' #> [9] "lf_fbfm40_220_mt_hood_utm.tif"
 #' }
 vsi_sync <- function(src, target, show_progress = FALSE, options = NULL) {
-    invisible(.Call(`_gdalraster_vsi_sync`, src, target, show_progress, options))
+    .Call(`_gdalraster_vsi_sync`, src, target, show_progress, options)
 }
 
 #' Create a directory
@@ -1575,7 +1575,7 @@ vsi_sync <- function(src, target, show_progress = FALSE, options = NULL) {
 #' `0`, e.g., `"0755"` (the default).
 #' @param recursive Logical scalar. `TRUE` to create the directory and its
 #' ancestors. Defaults to `FALSE`.
-#' @returns Invisibly, `0` on success or `-1` on an error.
+#' @returns `0` on success or `-1` on an error.
 #'
 #' @seealso
 #' [vsi_read_dir()], [vsi_rmdir()]
@@ -1587,7 +1587,7 @@ vsi_sync <- function(src, target, show_progress = FALSE, options = NULL) {
 #' result <- vsi_rmdir(new_dir)
 #' print(result)
 vsi_mkdir <- function(path, mode = "0755", recursive = FALSE) {
-    invisible(.Call(`_gdalraster_vsi_mkdir`, path, mode, recursive))
+    .Call(`_gdalraster_vsi_mkdir`, path, mode, recursive)
 }
 
 #' Delete a directory
@@ -1604,7 +1604,7 @@ vsi_mkdir <- function(path, mode = "0755", recursive = FALSE) {
 #' @param path Character string. The path to the directory to be deleted.
 #' @param recursive Logical scalar. `TRUE` to delete the directory and its
 #' content. Defaults to `FALSE`.
-#' @returns Invisibly, `0` on success or `-1` on an error.
+#' @returns `0` on success or `-1` on an error.
 #'
 #' @note
 #' /vsis3/ has an efficient implementation for deleting recursively. Starting
@@ -1621,7 +1621,7 @@ vsi_mkdir <- function(path, mode = "0755", recursive = FALSE) {
 #' result <- vsi_rmdir(new_dir)
 #' print(result)
 vsi_rmdir <- function(path, recursive = FALSE) {
-    invisible(.Call(`_gdalraster_vsi_rmdir`, path, recursive))
+    .Call(`_gdalraster_vsi_rmdir`, path, recursive)
 }
 
 #' Delete a file
@@ -1633,7 +1633,7 @@ vsi_rmdir <- function(path, recursive = FALSE) {
 #' Analog of the POSIX `unlink()` function.
 #'
 #' @param filename Character string. The path of the file to be deleted.
-#' @returns Invisibly, `0` on success or `-1` on an error.
+#' @returns `0` on success or `-1` on an error.
 #'
 #' @seealso
 #' [deleteDataset()], [vsi_rmdir()], [vsi_unlink_batch()]
@@ -1647,7 +1647,7 @@ vsi_rmdir <- function(path, recursive = FALSE) {
 #' result <- vsi_unlink(tmp_file)
 #' print(result)
 vsi_unlink <- function(filename) {
-    invisible(.Call(`_gdalraster_vsi_unlink`, filename))
+    .Call(`_gdalraster_vsi_unlink`, filename)
 }
 
 #' Delete several files in a batch
@@ -1660,8 +1660,8 @@ vsi_unlink <- function(filename) {
 #' Portability Library.
 #'
 #' @param filenames Character vector. The list of files to delete.
-#' @returns Invisibly, a logical vector of `length(filenames)` with values
-#' depending on the success of deletion of the corresponding file.
+#' @returns Logical vector of `length(filenames)` with values depending
+#' on the success of deletion of the corresponding file.
 #' `NULL` might be returned in case of a more general error (for example,
 #' files belonging to different file system handlers).
 #'
@@ -1681,7 +1681,7 @@ vsi_unlink <- function(filename) {
 #' result <- vsi_unlink_batch(c(tmp_elev, tmp_tcc))
 #' print(result)
 vsi_unlink_batch <- function(filenames) {
-    invisible(.Call(`_gdalraster_vsi_unlink_batch`, filenames))
+    .Call(`_gdalraster_vsi_unlink_batch`, filenames)
 }
 
 #' Get filesystem object info
@@ -1701,7 +1701,8 @@ vsi_unlink_batch <- function(filenames) {
 #' object exists, otherwise `FALSE`. If `info = "type"`, returns a character
 #' string with one of `"file"` (regular file), `"dir"` (directory),
 #' `"symlink"` (symbolic link), or empty string (`""`). If `info = "size"`,
-#' returns the file size in bytes, or `-1` if an error occurs.
+#' returns the file size in bytes (as `bit64::integer64` type), or `-1` if an
+#' error occurs.
 #'
 #' @note
 #' For portability, `vsi_stat()` supports a subset of `stat()`-type
@@ -1758,7 +1759,7 @@ vsi_stat <- function(filename, info = "exists") {
 #'
 #' @param oldpath Character string. The name of the file to be renamed.
 #' @param newpath Character string. The name the file should be given.
-#' @returns Invisibly, `0` on success or `-1` on an error.
+#' @returns `0` on success or `-1` on an error.
 #'
 #' @seealso
 #' [renameDataset()], [vsi_copy_file()]
@@ -1774,7 +1775,7 @@ vsi_stat <- function(filename, info = "exists") {
 #' print(result)
 #' vsi_unlink(new_file)
 vsi_rename <- function(oldpath, newpath) {
-    invisible(.Call(`_gdalraster_vsi_rename`, oldpath, newpath))
+    .Call(`_gdalraster_vsi_rename`, oldpath, newpath)
 }
 
 #' Return the list of virtual file system handlers currently registered
@@ -1869,7 +1870,8 @@ vsi_supports_rnd_write <- function(filename, allow_local_tmpfile) {
 #' Portability Library.
 #'
 #' @param path Character string. A directory of the filesystem to query.
-#' @returns Numeric scalar. The free space in bytes, or `-1` in case of error.
+#' @returns Numeric scalar. The free space in bytes (as `bit64::integer64`
+#' type), or `-1` in case of error.
 #'
 #' @examples
 #' tmp_dir <- file.path(tempdir(), "tmpdir")

--- a/man/vsi_copy_file.Rd
+++ b/man/vsi_copy_file.Rd
@@ -16,7 +16,7 @@ displayed (the size of \code{src_file} will be retrieved in GDAL with
 \code{VSIStatL()}). Default is \code{FALSE}.}
 }
 \value{
-Invisibly, \code{0} on success or \code{-1} on an error.
+\code{0} on success or \code{-1} on an error.
 }
 \description{
 \code{vsi_copy_file()} is a wrapper for \code{VSICopyFile()} in the GDAL Common

--- a/man/vsi_get_disk_free_space.Rd
+++ b/man/vsi_get_disk_free_space.Rd
@@ -10,7 +10,8 @@ vsi_get_disk_free_space(path)
 \item{path}{Character string. A directory of the filesystem to query.}
 }
 \value{
-Numeric scalar. The free space in bytes, or \code{-1} in case of error.
+Numeric scalar. The free space in bytes (as \code{bit64::integer64}
+type), or \code{-1} in case of error.
 }
 \description{
 \code{vsi_get_disk_free_space()} returns the free disk space available on the

--- a/man/vsi_mkdir.Rd
+++ b/man/vsi_mkdir.Rd
@@ -16,7 +16,7 @@ vsi_mkdir(path, mode = "0755", recursive = FALSE)
 ancestors. Defaults to \code{FALSE}.}
 }
 \value{
-Invisibly, \code{0} on success or \code{-1} on an error.
+\code{0} on success or \code{-1} on an error.
 }
 \description{
 \code{vsi_mkdir()} creates a new directory with the indicated mode.

--- a/man/vsi_rename.Rd
+++ b/man/vsi_rename.Rd
@@ -12,7 +12,7 @@ vsi_rename(oldpath, newpath)
 \item{newpath}{Character string. The name the file should be given.}
 }
 \value{
-Invisibly, \code{0} on success or \code{-1} on an error.
+\code{0} on success or \code{-1} on an error.
 }
 \description{
 \code{vsi_rename()} renames a file object in the file system. The GDAL

--- a/man/vsi_rmdir.Rd
+++ b/man/vsi_rmdir.Rd
@@ -13,7 +13,7 @@ vsi_rmdir(path, recursive = FALSE)
 content. Defaults to \code{FALSE}.}
 }
 \value{
-Invisibly, \code{0} on success or \code{-1} on an error.
+\code{0} on success or \code{-1} on an error.
 }
 \description{
 \code{vsi_rmdir()} deletes a directory object from the file system. On some

--- a/man/vsi_stat.Rd
+++ b/man/vsi_stat.Rd
@@ -18,7 +18,8 @@ If \code{info = "exists"}, returns logical \code{TRUE} if the file system
 object exists, otherwise \code{FALSE}. If \code{info = "type"}, returns a character
 string with one of \code{"file"} (regular file), \code{"dir"} (directory),
 \code{"symlink"} (symbolic link), or empty string (\code{""}). If \code{info = "size"},
-returns the file size in bytes, or \code{-1} if an error occurs.
+returns the file size in bytes (as \code{bit64::integer64} type), or \code{-1} if an
+error occurs.
 }
 \description{
 \code{vsi_stat()} fetches status information about a filesystem object (file,

--- a/man/vsi_sync.Rd
+++ b/man/vsi_sync.Rd
@@ -17,7 +17,7 @@ displayed. Defaults to \code{FALSE}.}
 \item{options}{Character vector of \code{NAME=VALUE} pairs (see Details).}
 }
 \value{
-Invisibly, \code{TRUE} on success or \code{FALSE} on an error.
+Logical scalar, \code{TRUE} on success or \code{FALSE} on an error.
 }
 \description{
 \code{vsi_sync()} is a wrapper for \code{VSISync()} in the GDAL Common Portability

--- a/man/vsi_unlink.Rd
+++ b/man/vsi_unlink.Rd
@@ -10,7 +10,7 @@ vsi_unlink(filename)
 \item{filename}{Character string. The path of the file to be deleted.}
 }
 \value{
-Invisibly, \code{0} on success or \code{-1} on an error.
+\code{0} on success or \code{-1} on an error.
 }
 \description{
 \code{vsi_unlink()} deletes a file object from the file system.

--- a/man/vsi_unlink_batch.Rd
+++ b/man/vsi_unlink_batch.Rd
@@ -10,8 +10,8 @@ vsi_unlink_batch(filenames)
 \item{filenames}{Character vector. The list of files to delete.}
 }
 \value{
-Invisibly, a logical vector of \code{length(filenames)} with values
-depending on the success of deletion of the corresponding file.
+Logical vector of \code{length(filenames)} with values depending
+on the success of deletion of the corresponding file.
 \code{NULL} might be returned in case of a more general error (for example,
 files belonging to different file system handlers).
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -671,7 +671,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // vsi_get_disk_free_space
-double vsi_get_disk_free_space(Rcpp::CharacterVector path);
+Rcpp::NumericVector vsi_get_disk_free_space(Rcpp::CharacterVector path);
 RcppExport SEXP _gdalraster_vsi_get_disk_free_space(SEXP pathSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -6,6 +6,7 @@
 #include "cpl_string.h"
 #include "cpl_vsi.h"
 
+#include "RcppInt64"
 #include "gdalraster.h"
 
 //' Copy a source file to a target filename
@@ -30,7 +31,7 @@
 //' @param show_progress Logical scalar. If `TRUE`, a progress bar will be
 //' displayed (the size of `src_file` will be retrieved in GDAL with
 //' `VSIStatL()`). Default is `FALSE`.
-//' @returns Invisibly, `0` on success or `-1` on an error.
+//' @returns `0` on success or `-1` on an error.
 //'
 //' @note
 //' If `target_file` has the form /vsizip/foo.zip/bar, the default options
@@ -52,10 +53,10 @@
 //'
 //'   vsi_unlink(tmp_file)
 //' }
-// [[Rcpp::export(invisible = true)]]
+// [[Rcpp::export()]]
 int vsi_copy_file(Rcpp::CharacterVector src_file,
-        Rcpp::CharacterVector target_file,
-        bool show_progress = false) {
+                  Rcpp::CharacterVector target_file,
+                  bool show_progress = false) {
 
 #if GDAL_VERSION_NUM < 3070000
     Rcpp::stop("vsi_copy_file() requires GDAL >= 3.7");
@@ -108,7 +109,7 @@ int vsi_copy_file(Rcpp::CharacterVector src_file,
 //' vsi_curl_clear_cache()
 // [[Rcpp::export()]]
 void vsi_curl_clear_cache(bool partial = false,
-        Rcpp::CharacterVector file_prefix = "") {
+                          Rcpp::CharacterVector file_prefix = "") {
 
     if (!partial) {
         VSICurlClearCache();
@@ -153,7 +154,7 @@ void vsi_curl_clear_cache(bool partial = false,
 //' vsi_read_dir(data_dir)
 // [[Rcpp::export()]]
 Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
-        int max_files = 0) {
+                                   int max_files = 0) {
 
     std::string path_in;
     path_in = Rcpp::as<std::string>(_check_gdal_filename(path));
@@ -244,7 +245,7 @@ Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
 //' @param show_progress Logical scalar. If `TRUE`, a progress bar will be
 //' displayed. Defaults to `FALSE`.
 //' @param options Character vector of `NAME=VALUE` pairs (see Details).
-//' @returns Invisibly, `TRUE` on success or `FALSE` on an error.
+//' @returns Logical scalar, `TRUE` on success or `FALSE` on an error.
 //'
 //' @seealso
 //' [copyDatasetFiles()], [vsi_copy_file()]
@@ -294,11 +295,11 @@ Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
 //' #> [8] "lf_fbfm40_220_metadata.html"
 //' #> [9] "lf_fbfm40_220_mt_hood_utm.tif"
 //' }
-// [[Rcpp::export(invisible = true)]]
+// [[Rcpp::export()]]
 bool vsi_sync(Rcpp::CharacterVector src,
-        Rcpp::CharacterVector target,
-        bool show_progress = false,
-        Rcpp::Nullable<Rcpp::CharacterVector> options = R_NilValue) {
+              Rcpp::CharacterVector target,
+              bool show_progress = false,
+              Rcpp::Nullable<Rcpp::CharacterVector> options = R_NilValue) {
 
     std::string src_file_in;
     src_file_in = Rcpp::as<std::string>(_check_gdal_filename(src));
@@ -342,7 +343,7 @@ bool vsi_sync(Rcpp::CharacterVector src,
 //' `0`, e.g., `"0755"` (the default).
 //' @param recursive Logical scalar. `TRUE` to create the directory and its
 //' ancestors. Defaults to `FALSE`.
-//' @returns Invisibly, `0` on success or `-1` on an error.
+//' @returns `0` on success or `-1` on an error.
 //'
 //' @seealso
 //' [vsi_read_dir()], [vsi_rmdir()]
@@ -353,7 +354,7 @@ bool vsi_sync(Rcpp::CharacterVector src,
 //' print(result)
 //' result <- vsi_rmdir(new_dir)
 //' print(result)
-// [[Rcpp::export(invisible = true)]]
+// [[Rcpp::export()]]
 int vsi_mkdir(Rcpp::CharacterVector path, std::string mode = "0755",
               bool recursive = false) {
 
@@ -383,7 +384,7 @@ int vsi_mkdir(Rcpp::CharacterVector path, std::string mode = "0755",
 //' @param path Character string. The path to the directory to be deleted.
 //' @param recursive Logical scalar. `TRUE` to delete the directory and its
 //' content. Defaults to `FALSE`.
-//' @returns Invisibly, `0` on success or `-1` on an error.
+//' @returns `0` on success or `-1` on an error.
 //'
 //' @note
 //' /vsis3/ has an efficient implementation for deleting recursively. Starting
@@ -399,9 +400,8 @@ int vsi_mkdir(Rcpp::CharacterVector path, std::string mode = "0755",
 //' print(result)
 //' result <- vsi_rmdir(new_dir)
 //' print(result)
-// [[Rcpp::export(invisible = true)]]
+// [[Rcpp::export()]]
 int vsi_rmdir(Rcpp::CharacterVector path, bool recursive = false) {
-
     std::string path_in;
     path_in = Rcpp::as<std::string>(_check_gdal_filename(path));
 
@@ -421,7 +421,7 @@ int vsi_rmdir(Rcpp::CharacterVector path, bool recursive = false) {
 //' Analog of the POSIX `unlink()` function.
 //'
 //' @param filename Character string. The path of the file to be deleted.
-//' @returns Invisibly, `0` on success or `-1` on an error.
+//' @returns `0` on success or `-1` on an error.
 //'
 //' @seealso
 //' [deleteDataset()], [vsi_rmdir()], [vsi_unlink_batch()]
@@ -434,9 +434,8 @@ int vsi_rmdir(Rcpp::CharacterVector path, bool recursive = false) {
 //' file.copy(elev_file,  tmp_file)
 //' result <- vsi_unlink(tmp_file)
 //' print(result)
-// [[Rcpp::export(invisible = true)]]
+// [[Rcpp::export()]]
 int vsi_unlink(Rcpp::CharacterVector filename) {
-
     std::string filename_in;
     filename_in = Rcpp::as<std::string>(_check_gdal_filename(filename));
 
@@ -454,8 +453,8 @@ int vsi_unlink(Rcpp::CharacterVector filename) {
 //' Portability Library.
 //'
 //' @param filenames Character vector. The list of files to delete.
-//' @returns Invisibly, a logical vector of `length(filenames)` with values
-//' depending on the success of deletion of the corresponding file.
+//' @returns Logical vector of `length(filenames)` with values depending
+//' on the success of deletion of the corresponding file.
 //' `NULL` might be returned in case of a more general error (for example,
 //' files belonging to different file system handlers).
 //'
@@ -474,9 +473,8 @@ int vsi_unlink(Rcpp::CharacterVector filename) {
 //' file.copy(tcc_file,  tmp_tcc)
 //' result <- vsi_unlink_batch(c(tmp_elev, tmp_tcc))
 //' print(result)
-// [[Rcpp::export(invisible = true)]]
+// [[Rcpp::export()]]
 SEXP vsi_unlink_batch(Rcpp::CharacterVector filenames) {
-
     std::vector<std::string> filenames_in(filenames.size());
     std::vector<char *> filenames_cstr(filenames.size() + 1);
     for (R_xlen_t i = 0; i < filenames.size(); ++i) {
@@ -519,7 +517,8 @@ SEXP vsi_unlink_batch(Rcpp::CharacterVector filenames) {
 //' object exists, otherwise `FALSE`. If `info = "type"`, returns a character
 //' string with one of `"file"` (regular file), `"dir"` (directory),
 //' `"symlink"` (symbolic link), or empty string (`""`). If `info = "size"`,
-//' returns the file size in bytes, or `-1` if an error occurs.
+//' returns the file size in bytes (as `bit64::integer64` type), or `-1` if an
+//' error occurs.
 //'
 //' @note
 //' For portability, `vsi_stat()` supports a subset of `stat()`-type
@@ -561,7 +560,6 @@ SEXP vsi_unlink_batch(Rcpp::CharacterVector filenames) {
 //' vsi_stat(url_file, "size")
 // [[Rcpp::export()]]
 SEXP vsi_stat(Rcpp::CharacterVector filename, std::string info = "exists") {
-
     std::string filename_in;
     filename_in = Rcpp::as<std::string>(_check_gdal_filename(filename));
     const char *fn = filename_in.c_str();
@@ -593,11 +591,11 @@ SEXP vsi_stat(Rcpp::CharacterVector filename, std::string info = "exists") {
         return Rcpp::CharacterVector(Rcpp::wrap(ret));
     }
     else if (EQUALN(info.c_str(), "size", 4)) {
-        double ret;
+        std::vector<int64_t> ret(1);
         if (VSIStatExL(fn, &sStat, VSI_STAT_SIZE_FLAG) == 0)
-            ret = (double) sStat.st_size;
+            ret[0] = static_cast<int64_t>(sStat.st_size);
         else
-            ret = -1;
+            ret[0] = -1;
 
         return Rcpp::NumericVector(Rcpp::wrap(ret));
     }
@@ -620,7 +618,7 @@ SEXP vsi_stat(Rcpp::CharacterVector filename, std::string info = "exists") {
 //'
 //' @param oldpath Character string. The name of the file to be renamed.
 //' @param newpath Character string. The name the file should be given.
-//' @returns Invisibly, `0` on success or `-1` on an error.
+//' @returns `0` on success or `-1` on an error.
 //'
 //' @seealso
 //' [renameDataset()], [vsi_copy_file()]
@@ -635,9 +633,8 @@ SEXP vsi_stat(Rcpp::CharacterVector filename, std::string info = "exists") {
 //' result <- vsi_rename(tmp_file, new_file)
 //' print(result)
 //' vsi_unlink(new_file)
-// [[Rcpp::export(invisible = true)]]
+// [[Rcpp::export()]]
 int vsi_rename(Rcpp::CharacterVector oldpath, Rcpp::CharacterVector newpath) {
-
     std::string oldpath_in;
     oldpath_in = Rcpp::as<std::string>(_check_gdal_filename(oldpath));
     std::string newpath_in;
@@ -665,7 +662,6 @@ int vsi_rename(Rcpp::CharacterVector oldpath, Rcpp::CharacterVector newpath) {
 //' vsi_get_fs_prefixes()
 // [[Rcpp::export()]]
 Rcpp::CharacterVector vsi_get_fs_prefixes() {
-
     char **papszPrefixes;
     papszPrefixes = VSIGetFileSystemsPrefixes();
 
@@ -692,7 +688,6 @@ Rcpp::CharacterVector vsi_get_fs_prefixes() {
 //' @noRd
 // [[Rcpp::export(name = ".vsi_get_fs_options")]]
 std::string _vsi_get_fs_options(Rcpp::CharacterVector filename) {
-
     std::string filename_in;
     filename_in = Rcpp::as<std::string>(_check_gdal_filename(filename));
     if (VSIGetFileSystemOptions(filename_in.c_str()) != nullptr)
@@ -728,7 +723,7 @@ std::string _vsi_get_fs_options(Rcpp::CharacterVector filename) {
 //'   vsi_supports_seq_write("/vsimem/test-mem-file.gpkg", TRUE)
 // [[Rcpp::export()]]
 bool vsi_supports_seq_write(Rcpp::CharacterVector filename,
-        bool allow_local_tmpfile) {
+                            bool allow_local_tmpfile) {
 
 #if GDAL_VERSION_NUM < 3060000
     Rcpp::stop("vsi_supports_seq_write() requires GDAL >= 3.6");
@@ -771,7 +766,7 @@ bool vsi_supports_seq_write(Rcpp::CharacterVector filename,
 //'   vsi_supports_rnd_write("/vsimem/test-mem-file.gpkg", TRUE)
 // [[Rcpp::export()]]
 bool vsi_supports_rnd_write(Rcpp::CharacterVector filename,
-        bool allow_local_tmpfile) {
+                            bool allow_local_tmpfile) {
 
 #if GDAL_VERSION_NUM < 3060000
     Rcpp::stop("vsi_supports_rnd_write() requires GDAL >= 3.6");
@@ -794,7 +789,8 @@ bool vsi_supports_rnd_write(Rcpp::CharacterVector filename,
 //' Portability Library.
 //'
 //' @param path Character string. A directory of the filesystem to query.
-//' @returns Numeric scalar. The free space in bytes, or `-1` in case of error.
+//' @returns Numeric scalar. The free space in bytes (as `bit64::integer64`
+//' type), or `-1` in case of error.
 //'
 //' @examples
 //' tmp_dir <- file.path(tempdir(), "tmpdir")
@@ -802,12 +798,12 @@ bool vsi_supports_rnd_write(Rcpp::CharacterVector filename,
 //' vsi_get_disk_free_space(tmp_dir)
 //' vsi_rmdir(tmp_dir)
 // [[Rcpp::export()]]
-double vsi_get_disk_free_space(Rcpp::CharacterVector path) {
-
+Rcpp::NumericVector vsi_get_disk_free_space(Rcpp::CharacterVector path) {
     std::string path_in;
     path_in = Rcpp::as<std::string>(_check_gdal_filename(path));
-
-    return static_cast<double>(VSIGetDiskFreeSpace(path_in.c_str()));
+    std::vector<int64_t> ret(1);
+    ret[0] = VSIGetDiskFreeSpace(path_in.c_str());
+    return Rcpp::wrap(ret);
 }
 
 //' Set a path specific option for a given path prefix
@@ -847,7 +843,7 @@ double vsi_get_disk_free_space(Rcpp::CharacterVector path) {
 //' [set_config_option()], [vsi_clear_path_options()]
 // [[Rcpp::export()]]
 void vsi_set_path_option(Rcpp::CharacterVector path_prefix, std::string key,
-                           std::string value) {
+                         std::string value) {
 
 #if GDAL_VERSION_NUM < 3060000
     Rcpp::stop("vsi_set_path_option() requires GDAL >= 3.6");
@@ -884,7 +880,6 @@ void vsi_set_path_option(Rcpp::CharacterVector path_prefix, std::string key,
 //' [vsi_set_path_option()]
 // [[Rcpp::export()]]
 void vsi_clear_path_options(Rcpp::CharacterVector path_prefix) {
-
 #if GDAL_VERSION_NUM < 3060000
     Rcpp::stop("vsi_clear_path_options() requires GDAL >= 3.6");
 

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -242,7 +242,7 @@ bool vsi_supports_seq_write(Rcpp::CharacterVector filename,
                             bool allow_local_tmpfile);
 bool vsi_supports_rnd_write(Rcpp::CharacterVector filename,
                             bool allow_local_tmpfile);
-double vsi_get_disk_free_space(Rcpp::CharacterVector path);
+Rcpp::NumericVector vsi_get_disk_free_space(Rcpp::CharacterVector path);
 
 Rcpp::NumericVector _apply_geotransform(const std::vector<double> gt,
                                         double pixel, double line);

--- a/tests/testthat/test-gdal_vsi.R
+++ b/tests/testthat/test-gdal_vsi.R
@@ -7,11 +7,11 @@ test_that("vsi_stat works", {
     elev_file <- file.path(data_dir, "storml_elev.tif")
     expect_true(vsi_stat(elev_file))
     expect_equal(vsi_stat(elev_file, "type"), "file")
-    expect_equal(vsi_stat(elev_file, "size"), 31152)
+    expect_equal(vsi_stat(elev_file, "size"), bit64::as.integer64(31152))
     nonexistent <- file.path(data_dir, "wrong_filename.tif")
     expect_false(vsi_stat(nonexistent))
     expect_equal(vsi_stat(nonexistent, "type"), "")
-    expect_equal(vsi_stat(nonexistent, "size"), -1)
+    expect_equal(vsi_stat(nonexistent, "size"), bit64::as.integer64(-1))
     expect_error(vsi_stat(elev_file, "invalid"))
 })
 
@@ -118,7 +118,7 @@ test_that("vsi_get_disk_free_space returns length-1 numeric vector", {
     tmp_dir <- file.path(tempdir(), "tmpdir")
     vsi_mkdir(tmp_dir)
     x <- vsi_get_disk_free_space(tmp_dir)
-    expect_vector(x, ptype = numeric(), 1)
+    expect_vector(x, ptype = bit64::integer64(), 1)
     vsi_rmdir(tmp_dir)
 })
 


### PR DESCRIPTION
Several `vsi_*()` functions returned `0` or `-1` invisibly to indicate success/failure consistent with GDAL return values. This PR makes those return values visible to be consistent with return values from `VSIFile` class methods. Also makes `vsi_stat(filename, info = "size")` and `vsi_get_disk_free_space(path)` return as `bit64::integer64` type.