### PR TITLE
Add read/write fields `infoOptions` and `quiet` in class `GDALRaster`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9231
+Version: 1.10.9240
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9230
+Version: 1.10.9231
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9230 (dev)
+# gdalraster 1.10.9231 (dev)
+
+* class `GDALRaster`: add read/write fields `infoOptions`, `infoAsJSONOptions` and `quiet`, for applying per-object settings (2024-05-26)
 
 * add some missing null checks, and object destruction on error conditions, in src/geos_wkt.cpp (2024-05-26)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# gdalraster 1.10.9231 (dev)
+# gdalraster 1.10.9240 (dev)
 
-* class `GDALRaster`: add read/write fields `infoOptions`, `infoAsJSONOptions` and `quiet`, for applying per-object settings (2024-05-26)
+* class `GDALRaster`: add read/write fields `infoOptions` and `quiet` for applying per-object settings (2024-05-26)
+
+* Behavior change: `GDALRaster::infoAsJSON()` now uses the command-line arguments set in the `infoOptions` field, with default `c("-norat", "-noct")` (2024-05-26)
 
 * add some missing null checks, and object destruction on error conditions, in src/geos_wkt.cpp (2024-05-26)
 

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -25,7 +25,7 @@
 #' opened dataset, and methods that operate on the dataset as described in
 #' Details. `GDALRaster` is a C++ class exposed directly to R (via
 #' `RCPP_EXPOSED_CLASS`). Methods and fields of the class are accessed using
-#' the `$` operator.
+#' the `$` operator. Read/write fields can be used for per-object settings.
 #'
 #' @section Usage:
 #' \preformatted{
@@ -37,7 +37,10 @@
 #' # or, using dataset open options:
 #' ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
 #'
-#' ## Fields (see Details)
+#' ## Read/write fields (see Details)
+#' ds$infoOptions
+#' ds$infoAsJSONOptions
+#' ds$quiet
 #' ds$readByteAsRaw
 #'
 #' ## Methods (see Details)
@@ -125,6 +128,26 @@
 #'  read-only, or `FALSE` to open with write access.
 #' Returns an object of class `GDALRaster`.
 #'
+#' \code{$infoOptions}
+#' Read/write field.
+#' A character vector of command-line arguments to control the output of
+#' `$info()` (see below). Defaults to `c("-norat", "-noct")`. Set to empty
+#' string (`""`) to use `gdalinfo` defaults.
+#'
+#' \code{$infoAsJSONOptions}
+#' Read/write field.
+#' A character vector of command-line arguments to control the output of
+#' `$infoAsJSON()` (see below). Defaults to `c("-stats", "-hist")` (`"-json"`
+#' is implied and does not need to be specified). Set to empty string (`""`)
+#' to use `gdalinfo` defaults.
+#'
+#' \code{$quiet}
+#' Read/write field.
+#' A logical value, `FALSE` by default. This field can be set to `TRUE` which
+#' will suppress various messages as well as progress reporting for potentially
+#' long-running processes such as building overviews and computation of
+#' statistics and histograms.
+#'
 #' \code{$readByteAsRaw}
 #' Read/write field.
 #' A logical value, `FALSE` by default. This field can be set to `TRUE` which
@@ -160,13 +183,16 @@
 #' Prints various information about the raster dataset to the console (no
 #' return value, called for that side effect only).
 #' Equivalent to the output of the \command{gdalinfo} command-line utility
-#' (\command{gdalinfo -norat -noct filename}). Intended here as an
-#' informational convenience function.
+#' (\command{gdalinfo -norat -noct filename}, if using the default
+#' `infoOptions`).
+#' See the field `$infoOptions` above for setting the arguments to `gdalinfo`.
 #'
 #' \code{$infoAsJSON()}
 #' Returns information about the raster dataset as a JSON-formatted string.
 #' Contains full output of the \command{gdalinfo} command-line utility
-#' (\command{gdalinfo -json -stats -hist filename}).
+#' (\command{gdalinfo -json -stats -hist filename}, if using the default
+#' `infoAsJSONOptions`). See the field `$infoAsJSONOptions` above for setting
+#' the arguments to `gdalinfo`.
 #'
 #' \code{$getDriverShortName()}
 #' Returns the short name of the raster format driver

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -39,7 +39,6 @@
 #'
 #' ## Read/write fields (see Details)
 #' ds$infoOptions
-#' ds$infoAsJSONOptions
 #' ds$quiet
 #' ds$readByteAsRaw
 #'
@@ -131,15 +130,9 @@
 #' \code{$infoOptions}
 #' Read/write field.
 #' A character vector of command-line arguments to control the output of
-#' `$info()` (see below). Defaults to `c("-norat", "-noct")`. Set to empty
-#' string (`""`) to use `gdalinfo` defaults.
-#'
-#' \code{$infoAsJSONOptions}
-#' Read/write field.
-#' A character vector of command-line arguments to control the output of
-#' `$infoAsJSON()` (see below). Defaults to `c("-stats", "-hist")` (`"-json"`
-#' is implied and does not need to be specified). Set to empty string (`""`)
-#' to use `gdalinfo` defaults.
+#' `$info()` and `$infoAsJSON()` (see below).
+#' Defaults to `c("-norat", "-noct")`. Set to empty string (`""`) to use
+#' `gdalinfo` defaults.
 #'
 #' \code{$quiet}
 #' Read/write field.
@@ -189,10 +182,10 @@
 #'
 #' \code{$infoAsJSON()}
 #' Returns information about the raster dataset as a JSON-formatted string.
-#' Contains full output of the \command{gdalinfo} command-line utility
-#' (\command{gdalinfo -json -stats -hist filename}, if using the default
-#' `infoAsJSONOptions`). See the field `$infoAsJSONOptions` above for setting
-#' the arguments to `gdalinfo`.
+#' Equivalent to the output of the \command{gdalinfo} command-line utility
+#' (\command{gdalinfo -json -norat -noct filename}, if using the default
+#' `infoOptions`).
+#' See the field `$infoOptions` above for setting the arguments to `gdalinfo`.
 #'
 #' \code{$getDriverShortName()}
 #' Returns the short name of the raster format driver

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -25,7 +25,7 @@ An object of class \code{GDALRaster} which contains a pointer to the
 opened dataset, and methods that operate on the dataset as described in
 Details. \code{GDALRaster} is a C++ class exposed directly to R (via
 \code{RCPP_EXPOSED_CLASS}). Methods and fields of the class are accessed using
-the \code{$} operator.
+the \code{$} operator. Read/write fields can be used for per-object settings.
 }
 \description{
 \code{GDALRaster} provides an interface for accessing a raster dataset via GDAL
@@ -55,7 +55,10 @@ ds <- new(GDALRaster, filename, read_only = FALSE)
 # or, using dataset open options:
 ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
 
-## Fields (see Details)
+## Read/write fields (see Details)
+ds$infoOptions
+ds$infoAsJSONOptions
+ds$quiet
 ds$readByteAsRaw
 
 ## Methods (see Details)
@@ -146,6 +149,26 @@ vector of \code{NAME=VALUE} pairs.
 read-only, or \code{FALSE} to open with write access.
 Returns an object of class \code{GDALRaster}.
 
+\code{$infoOptions}
+Read/write field.
+A character vector of command-line arguments to control the output of
+\verb{$info()} (see below). Defaults to \code{c("-norat", "-noct")}. Set to empty
+string (\code{""}) to use \code{gdalinfo} defaults.
+
+\code{$infoAsJSONOptions}
+Read/write field.
+A character vector of command-line arguments to control the output of
+\verb{$infoAsJSON()} (see below). Defaults to \code{c("-stats", "-hist")} (\code{"-json"}
+is implied and does not need to be specified). Set to empty string (\code{""})
+to use \code{gdalinfo} defaults.
+
+\code{$quiet}
+Read/write field.
+A logical value, \code{FALSE} by default. This field can be set to \code{TRUE} which
+will suppress various messages as well as progress reporting for potentially
+long-running processes such as building overviews and computation of
+statistics and histograms.
+
 \code{$readByteAsRaw}
 Read/write field.
 A logical value, \code{FALSE} by default. This field can be set to \code{TRUE} which
@@ -181,13 +204,16 @@ paths depending on the path used to originally open the dataset.
 Prints various information about the raster dataset to the console (no
 return value, called for that side effect only).
 Equivalent to the output of the \command{gdalinfo} command-line utility
-(\command{gdalinfo -norat -noct filename}). Intended here as an
-informational convenience function.
+(\command{gdalinfo -norat -noct filename}, if using the default
+\code{infoOptions}).
+See the field \verb{$infoOptions} above for setting the arguments to \code{gdalinfo}.
 
 \code{$infoAsJSON()}
 Returns information about the raster dataset as a JSON-formatted string.
 Contains full output of the \command{gdalinfo} command-line utility
-(\command{gdalinfo -json -stats -hist filename}).
+(\command{gdalinfo -json -stats -hist filename}, if using the default
+\code{infoAsJSONOptions}). See the field \verb{$infoAsJSONOptions} above for setting
+the arguments to \code{gdalinfo}.
 
 \code{$getDriverShortName()}
 Returns the short name of the raster format driver

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -57,7 +57,6 @@ ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
 
 ## Read/write fields (see Details)
 ds$infoOptions
-ds$infoAsJSONOptions
 ds$quiet
 ds$readByteAsRaw
 
@@ -152,15 +151,9 @@ Returns an object of class \code{GDALRaster}.
 \code{$infoOptions}
 Read/write field.
 A character vector of command-line arguments to control the output of
-\verb{$info()} (see below). Defaults to \code{c("-norat", "-noct")}. Set to empty
-string (\code{""}) to use \code{gdalinfo} defaults.
-
-\code{$infoAsJSONOptions}
-Read/write field.
-A character vector of command-line arguments to control the output of
-\verb{$infoAsJSON()} (see below). Defaults to \code{c("-stats", "-hist")} (\code{"-json"}
-is implied and does not need to be specified). Set to empty string (\code{""})
-to use \code{gdalinfo} defaults.
+\verb{$info()} and \verb{$infoAsJSON()} (see below).
+Defaults to \code{c("-norat", "-noct")}. Set to empty string (\code{""}) to use
+\code{gdalinfo} defaults.
 
 \code{$quiet}
 Read/write field.
@@ -210,10 +203,10 @@ See the field \verb{$infoOptions} above for setting the arguments to \code{gdali
 
 \code{$infoAsJSON()}
 Returns information about the raster dataset as a JSON-formatted string.
-Contains full output of the \command{gdalinfo} command-line utility
-(\command{gdalinfo -json -stats -hist filename}, if using the default
-\code{infoAsJSONOptions}). See the field \verb{$infoAsJSONOptions} above for setting
-the arguments to \code{gdalinfo}.
+Equivalent to the output of the \command{gdalinfo} command-line utility
+(\command{gdalinfo -json -norat -noct filename}, if using the default
+\code{infoOptions}).
+See the field \verb{$infoOptions} above for setting the arguments to \code{gdalinfo}.
 
 \code{$getDriverShortName()}
 Returns the short name of the raster format driver

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -173,9 +173,10 @@ void GDALRaster::info() const {
 
     GDALInfoOptions* psOptions = GDALInfoOptionsNew(opt.data(), nullptr);
     if (psOptions == nullptr)
-        Rcpp::stop("creation of GDALInfoOptions failed");
+        Rcpp::stop("creation of GDALInfoOptions failed (check $infoOptions)");
     char *pszGDALInfoOutput = GDALInfo(hDataset, psOptions);
-    Rcpp::Rcout << pszGDALInfoOutput;
+    if (pszGDALInfoOutput != nullptr)
+        Rcpp::Rcout << pszGDALInfoOutput;
     GDALInfoOptionsFree(psOptions);
     CPLFree(pszGDALInfoOutput);
 }
@@ -183,7 +184,7 @@ void GDALRaster::info() const {
 std::string GDALRaster::infoAsJSON() const {
     _checkAccess(GA_ReadOnly);
 
-    const Rcpp::CharacterVector argv = infoAsJSONOptions;
+    const Rcpp::CharacterVector argv = infoOptions;
     std::vector<char *> opt = {nullptr};
     if (argv.size() == 1 && argv[0] == "") {
         opt.resize(2);
@@ -202,7 +203,7 @@ std::string GDALRaster::infoAsJSON() const {
 
     GDALInfoOptions* psOptions = GDALInfoOptionsNew(opt.data(), nullptr);
     if (psOptions == nullptr)
-        Rcpp::stop("creation of GDALInfoOptions failed");
+        Rcpp::stop("creation of GDALInfoOptions failed (check $infoOptions)");
 
     char *pszGDALInfoOutput = GDALInfo(hDataset, psOptions);
     std::string out = "";
@@ -1521,7 +1522,6 @@ RCPP_MODULE(mod_GDALRaster) {
 
     // exposed read/write fields
     .field("infoOptions", &GDALRaster::infoOptions)
-    .field("infoAsJSONOptions", &GDALRaster::infoAsJSONOptions)
     .field("quiet", &GDALRaster::quiet)
     .field("readByteAsRaw", &GDALRaster::readByteAsRaw)
 

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -8,12 +8,12 @@
 #include <complex>
 
 #include "gdal_priv.h"
-#include "cpl_port.h"
 #include "cpl_conv.h"
+#include "cpl_port.h"
 #include "cpl_string.h"
 #include "cpl_vsi.h"
-#include "gdal_utils.h"
 #include "gdal_alg.h"
+#include "gdal_utils.h"
 
 #include "gdalraster.h"
 
@@ -78,9 +78,7 @@ GDALRaster::GDALRaster() :
             fname_in(""),
             open_options_in(Rcpp::CharacterVector::create()),
             hDataset(nullptr),
-            eAccess(GA_ReadOnly),
-            quiet(false),
-            readByteAsRaw(false) {}
+            eAccess(GA_ReadOnly) {}
 
 GDALRaster::GDALRaster(Rcpp::CharacterVector filename) :
             GDALRaster(
@@ -98,9 +96,7 @@ GDALRaster::GDALRaster(Rcpp::CharacterVector filename, bool read_only,
         Rcpp::CharacterVector open_options) :
                 open_options_in(open_options),
                 hDataset(nullptr),
-                eAccess(GA_ReadOnly),
-                quiet(false),
-                readByteAsRaw(false) {
+                eAccess(GA_ReadOnly) {
 
     fname_in = Rcpp::as<std::string>(_check_gdal_filename(filename));
     open(read_only);
@@ -161,12 +157,20 @@ bool GDALRaster::isOpen() const {
 void GDALRaster::info() const {
     _checkAccess(GA_ReadOnly);
 
-    Rcpp::CharacterVector argv = {"-norat", "-noct"};
-    std::vector<char *> opt(argv.size() + 1);
-    for (R_xlen_t i = 0; i < argv.size(); ++i) {
-        opt[i] = (char *) (argv[i]);
+    const Rcpp::CharacterVector argv = infoOptions;
+    std::vector<char *> opt;
+    if (argv.size() == 1 && argv[0] == "") {
+        opt.resize(1);
+        opt[0] = nullptr;
     }
-    opt[argv.size()] = nullptr;
+    else {
+        opt.resize(argv.size() + 1);
+        for (R_xlen_t i = 0; i < argv.size(); ++i) {
+            opt[i] = (char *) (argv[i]);
+        }
+        opt[argv.size()] = nullptr;
+    }
+
     GDALInfoOptions* psOptions = GDALInfoOptionsNew(opt.data(), nullptr);
     if (psOptions == nullptr)
         Rcpp::stop("creation of GDALInfoOptions failed");
@@ -179,21 +183,40 @@ void GDALRaster::info() const {
 std::string GDALRaster::infoAsJSON() const {
     _checkAccess(GA_ReadOnly);
 
-    Rcpp::CharacterVector argv = {"-json", "-stats", "-hist"};
-    std::vector<char *> opt(argv.size() + 1);
-    for (R_xlen_t i = 0; i < argv.size(); ++i) {
-        opt[i] = (char *) (argv[i]);
+    const Rcpp::CharacterVector argv = infoAsJSONOptions;
+    std::vector<char *> opt = {nullptr};
+    if (argv.size() == 1 && argv[0] == "") {
+        opt.resize(2);
+        opt[0] = (char *) "-json";
+        opt[1] = nullptr;
     }
-    opt[argv.size()] = nullptr;
+    else {
+        opt[0] = (char *) "-json";
+        for (R_xlen_t i = 0; i < argv.size(); ++i) {
+            if (EQUAL(argv[i], "-json"))
+                continue;
+            opt.push_back((char *) argv[i]);
+        }
+        opt.push_back(nullptr);
+    }
+
     GDALInfoOptions* psOptions = GDALInfoOptionsNew(opt.data(), nullptr);
     if (psOptions == nullptr)
         Rcpp::stop("creation of GDALInfoOptions failed");
 
     char *pszGDALInfoOutput = GDALInfo(hDataset, psOptions);
-    std::string out = pszGDALInfoOutput;
+    std::string out = "";
+    if (pszGDALInfoOutput != nullptr)
+        out = pszGDALInfoOutput;
+
     GDALInfoOptionsFree(psOptions);
     CPLFree(pszGDALInfoOutput);
-    out.erase(std::remove(out.begin(), out.end(), '\n'), out.cend());
+
+    out.erase(std::remove(out.begin(),
+                          out.end(),
+                          '\n'),
+              out.cend());
+
     return out;
 }
 
@@ -296,12 +319,14 @@ bool GDALRaster::setProjection(std::string projection) {
     _checkAccess(GA_Update);
 
     if (projection.size() == 0 || projection == "") {
-        Rcpp::Rcerr << "setProjection() requires a WKT string\n";
+        if (!quiet)
+            Rcpp::Rcerr << "setProjection() requires a WKT string\n";
         return false;
     }
 
     if (GDALSetProjection(hDataset, projection.c_str()) == CE_Failure) {
-        Rcpp::Rcerr << "set projection failed\n";
+        if (!quiet)
+            Rcpp::Rcerr << "set projection failed\n";
         return false;
     }
     else {
@@ -404,7 +429,8 @@ void GDALRaster::buildOverviews(std::string resampling,
 
     CPLErr err = GDALBuildOverviews(hDataset, resampling.c_str(), nOvr,
                                     panOvrList, nBands, panBandList,
-                                    GDALTermProgressR, nullptr);
+                                    quiet ? nullptr : GDALTermProgressR,
+                                    nullptr);
 
     if (err == CE_Failure)
         Rcpp::stop("build overviews failed");
@@ -443,7 +469,8 @@ bool GDALRaster::setNoDataValue(int band, double nodata_value) {
 
     GDALRasterBandH hBand = _getBand(band);
     if (GDALSetRasterNoDataValue(hBand, nodata_value) == CE_Failure) {
-        Rcpp::Rcerr << "set nodata value failed\n";
+        if (!quiet)
+            Rcpp::Rcerr << "set nodata value failed\n";
         return false;
     }
     else {
@@ -472,7 +499,8 @@ bool GDALRaster::setUnitType(int band, std::string unit_type) {
 
     GDALRasterBandH hBand = _getBand(band);
     if (GDALSetRasterUnitType(hBand, unit_type.c_str()) == CE_Failure) {
-        Rcpp::Rcerr << "set unit type failed\n";
+        if (!quiet)
+            Rcpp::Rcerr << "set unit type failed\n";
         return false;
     }
     else {
@@ -506,7 +534,8 @@ bool GDALRaster::setScale(int band, double scale) {
 
     GDALRasterBandH hBand = _getBand(band);
     if (GDALSetRasterScale(hBand, scale) == CE_Failure) {
-        Rcpp::Rcerr << "set scale failed\n";
+        if (!quiet)
+            Rcpp::Rcerr << "set scale failed\n";
         return false;
     }
     else {
@@ -540,7 +569,8 @@ bool GDALRaster::setOffset(int band, double offset) {
 
     GDALRasterBandH hBand = _getBand(band);
     if (GDALSetRasterOffset(hBand, offset) == CE_Failure) {
-        Rcpp::Rcerr << "set offset failed\n";
+        if (!quiet)
+            Rcpp::Rcerr << "set offset failed\n";
         return false;
     }
     else {
@@ -622,21 +652,25 @@ Rcpp::NumericVector GDALRaster::getStatistics(int band, bool approx_ok,
     GDALRasterBandH hBand = _getBand(band);
     double min, max, mean, sd;
     CPLErr err = CE_None;
+    GDALProgressFunc pfnProgress = nullptr;
+    void *pProgressData = nullptr;
 
     if (!force) {
         err = GDALGetRasterStatistics(hBand, approx_ok, force,
                                       &min, &max, &mean, &sd);
     }
     else {
-        GDALProgressFunc pfnProgress = GDALTermProgressR;
-        void* pProgressData = nullptr;
+        if (!quiet)
+            pfnProgress = GDALTermProgressR;
+
         err = GDALComputeRasterStatistics(hBand, approx_ok,
                                           &min, &max, &mean, &sd,
                                           pfnProgress, pProgressData);
     }
 
     if (err != CE_None) {
-        Rcpp::Rcout << "failed to get statistics, 'NA' returned\n";
+        if (!quiet)
+            Rcpp::Rcout << "failed to get statistics, 'NA' returned\n";
         Rcpp::NumericVector stats(4, NA_REAL);
         return stats;
     }
@@ -667,7 +701,8 @@ std::vector<double> GDALRaster::getHistogram(int band, double min, double max,
     std::vector<GUIntBig> hist(num_buckets);
     CPLErr err = GDALGetRasterHistogramEx(hBand, min, max, num_buckets,
                                           hist.data(), incl_out_of_range,
-                                          approx_ok, GDALTermProgressR,
+                                          approx_ok,
+                                          quiet ? nullptr : GDALTermProgressR,
                                           nullptr);
 
     if (err != CE_None)
@@ -688,7 +723,8 @@ Rcpp::List GDALRaster::getDefaultHistogram(int band, bool force) const {
 
     CPLErr err = GDALGetDefaultHistogramEx(hBand, &min, &max, &num_buckets,
                                            &panHistogram, force,
-                                           GDALTermProgressR, nullptr);
+                                           quiet ? nullptr : GDALTermProgressR,
+                                           nullptr);
 
     if (err == CE_Failure)
         Rcpp::stop("failed to get default histogram");
@@ -1160,8 +1196,10 @@ SEXP GDALRaster::getDefaultRAT(int band) const {
     int nCol = GDALRATGetColumnCount(hRAT);
     int nRow = GDALRATGetRowCount(hRAT);
     Rcpp::DataFrame df = Rcpp::DataFrame::create();
-    GDALProgressFunc pfnProgress = GDALTermProgressR;
-    void* pProgressData = nullptr;
+    GDALProgressFunc pfnProgress = nullptr;
+    if (!quiet)
+        pfnProgress = GDALTermProgressR;
+    void *pProgressData = nullptr;
 
     for (int i=0; i < nCol; ++i) {
         std::string colName(GDALRATGetNameOfCol(hRAT, i));
@@ -1192,8 +1230,10 @@ SEXP GDALRaster::getDefaultRAT(int band) const {
                     CPLCalloc(sizeof(char*), nRow));
             err = GDALRATValuesIOAsString(hRAT, GF_Read, i, 0, nRow,
                                           papszStringList);
-            if (err == CE_Failure)
+            if (err == CE_Failure) {
+                CPLFree(papszStringList);
                 Rcpp::stop("read column failed");
+            }
             std::vector<std::string> str_values(nRow);
             for (int n=0; n < nRow; ++n) {
                 str_values[n] = papszStringList[n];
@@ -1479,6 +1519,12 @@ RCPP_MODULE(mod_GDALRaster) {
     .constructor<Rcpp::CharacterVector, bool, Rcpp::CharacterVector>
         ("Usage: new(GDALRaster, filename, read_only, open_options)")
 
+    // exposed read/write fields
+    .field("infoOptions", &GDALRaster::infoOptions)
+    .field("infoAsJSONOptions", &GDALRaster::infoAsJSONOptions)
+    .field("quiet", &GDALRaster::quiet)
+    .field("readByteAsRaw", &GDALRaster::readByteAsRaw)
+
     // exposed member functions
     .const_method("getFilename", &GDALRaster::getFilename,
         "Return the raster filename")
@@ -1599,6 +1645,5 @@ RCPP_MODULE(mod_GDALRaster) {
     .method("close", &GDALRaster::close,
         "Close the GDAL dataset for proper cleanup")
 
-    .field("readByteAsRaw", &GDALRaster::readByteAsRaw)
     ;
 }

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -82,9 +82,15 @@ class GDALRaster {
     GDALRaster(Rcpp::CharacterVector filename, bool read_only,
                Rcpp::CharacterVector open_options);
 
-    bool quiet;  // not yet exported as read/write field
-    bool readByteAsRaw;
+    // read/write fields exposed in R
+    Rcpp::CharacterVector infoOptions =
+            Rcpp::CharacterVector::create("-norat", "-noct");
+    Rcpp::CharacterVector infoAsJSONOptions =
+            Rcpp::CharacterVector::create("-stats", "-hist");
+    bool quiet = false;
+    bool readByteAsRaw = false;
 
+    // methods exposed in R
     std::string getFilename() const;
     void setFilename(std::string filename);
     void open(bool read_only);

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -85,8 +85,6 @@ class GDALRaster {
     // read/write fields exposed in R
     Rcpp::CharacterVector infoOptions =
             Rcpp::CharacterVector::create("-norat", "-noct");
-    Rcpp::CharacterVector infoAsJSONOptions =
-            Rcpp::CharacterVector::create("-stats", "-hist");
     bool quiet = false;
     bool readByteAsRaw = false;
 


### PR DESCRIPTION
Adds new read/write fields in class `GDALRaster` exposed in R:  `infoOptions` and `quiet`.
Can be used to configure per-object settings (along with the existing field `readByteAsRaw`).