### PR TITLE
odg_ds_create(): fix layer name not passed with layer_defn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9251
+Version: 1.10.9252
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9251 (dev)
+# gdalraster 1.10.9252 (dev)
+
+* fix `ogr_ds_create()`: `layer` name was not passed to the internal create function when `layer_defn` was used (2024-05-27)
 
 * fixes in `ogr_geom_field_create()`: the check for field name already exists was wrong; the `srs` param was not passed to the internal create function (2024-05-27)
 

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -364,7 +364,7 @@ ogr_ds_create <- function(format, dsn, layer = NULL, layer_defn = NULL,
                            dsco, lco, NULL))
     } else {
         return(.create_ogr(format, dsn, 0, 0, 0, "Unknown",
-                           layer = "", geom_type = "", srs = "",
+                           layer = layer, geom_type = "", srs = "",
                            fld_name = "", fld_type = "",
                            dsco = dsco, lco = lco, layer_defn = layer_defn))
     }


### PR DESCRIPTION
Fixes `ogr_ds_create()`: `layer` name was not passed to the internal create function when `layer_defn` was used.