### PR TITLE
Doc: update example for vsi_get_file_metadata()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2022,9 +2022,11 @@ vsi_clear_path_options <- function(path_prefix) {
 #' if (as.integer(gdal_version()[2]) >= 3070000) {
 #'   zip_file <- tempfile(fileext=".zip")
 #'   addFilesInZip(zip_file, f, full_paths=FALSE, sozip_enabled="YES")
-#'   zip_vsi <- file.path("/vsizip", zip_file)
-#'   vsi_read_dir(zip_vsi)
-#'   vsi_get_file_metadata(zip_vsi, domain="ZIP")
+#'   zip_vsi <- file.path("/vsizip", zip_file
+#'   print("Files in zip archive:")
+#'   print(vsi_read_dir(zip_vsi))
+#'   print("SOZip metadata:")
+#'   print(vsi_get_file_metadata(zip_vsi, domain="ZIP"))
 #'
 #'   vsi_unlink(zip_file)
 #' }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2022,7 +2022,7 @@ vsi_clear_path_options <- function(path_prefix) {
 #' if (as.integer(gdal_version()[2]) >= 3070000) {
 #'   zip_file <- tempfile(fileext=".zip")
 #'   addFilesInZip(zip_file, f, full_paths=FALSE, sozip_enabled="YES")
-#'   zip_vsi <- file.path("/vsizip", zip_file
+#'   zip_vsi <- file.path("/vsizip", zip_file)
 #'   print("Files in zip archive:")
 #'   print(vsi_read_dir(zip_vsi))
 #'   print("SOZip metadata:")

--- a/man/vsi_get_file_metadata.Rd
+++ b/man/vsi_get_file_metadata.Rd
@@ -48,7 +48,7 @@ f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")
 if (as.integer(gdal_version()[2]) >= 3070000) {
   zip_file <- tempfile(fileext=".zip")
   addFilesInZip(zip_file, f, full_paths=FALSE, sozip_enabled="YES")
-  zip_vsi <- file.path("/vsizip", zip_file
+  zip_vsi <- file.path("/vsizip", zip_file)
   print("Files in zip archive:")
   print(vsi_read_dir(zip_vsi))
   print("SOZip metadata:")

--- a/man/vsi_get_file_metadata.Rd
+++ b/man/vsi_get_file_metadata.Rd
@@ -48,9 +48,11 @@ f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")
 if (as.integer(gdal_version()[2]) >= 3070000) {
   zip_file <- tempfile(fileext=".zip")
   addFilesInZip(zip_file, f, full_paths=FALSE, sozip_enabled="YES")
-  zip_vsi <- file.path("/vsizip", zip_file)
-  vsi_read_dir(zip_vsi)
-  vsi_get_file_metadata(zip_vsi, domain="ZIP")
+  zip_vsi <- file.path("/vsizip", zip_file
+  print("Files in zip archive:")
+  print(vsi_read_dir(zip_vsi))
+  print("SOZip metadata:")
+  print(vsi_get_file_metadata(zip_vsi, domain="ZIP"))
 
   vsi_unlink(zip_file)
 }

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -936,7 +936,7 @@ void vsi_clear_path_options(Rcpp::CharacterVector path_prefix) {
 //' if (as.integer(gdal_version()[2]) >= 3070000) {
 //'   zip_file <- tempfile(fileext=".zip")
 //'   addFilesInZip(zip_file, f, full_paths=FALSE, sozip_enabled="YES")
-//'   zip_vsi <- file.path("/vsizip", zip_file
+//'   zip_vsi <- file.path("/vsizip", zip_file)
 //'   print("Files in zip archive:")
 //'   print(vsi_read_dir(zip_vsi))
 //'   print("SOZip metadata:")

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -936,9 +936,11 @@ void vsi_clear_path_options(Rcpp::CharacterVector path_prefix) {
 //' if (as.integer(gdal_version()[2]) >= 3070000) {
 //'   zip_file <- tempfile(fileext=".zip")
 //'   addFilesInZip(zip_file, f, full_paths=FALSE, sozip_enabled="YES")
-//'   zip_vsi <- file.path("/vsizip", zip_file)
-//'   vsi_read_dir(zip_vsi)
-//'   vsi_get_file_metadata(zip_vsi, domain="ZIP")
+//'   zip_vsi <- file.path("/vsizip", zip_file
+//'   print("Files in zip archive:")
+//'   print(vsi_read_dir(zip_vsi))
+//'   print("SOZip metadata:")
+//'   print(vsi_get_file_metadata(zip_vsi, domain="ZIP"))
 //'
 //'   vsi_unlink(zip_file)
 //' }


### PR DESCRIPTION
Add `print()` to display output of functions called within `if` block for GDAL >= 3.7.