### PR TITLE
Include gdal.h instead of gdal_priv.h and copy ARE_REAL_EQUAL from GDAL

### DIFF
--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -10,17 +10,17 @@ https://gdal.org/license.html
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal
-in the Software without restriction, including without limitation the rights 
+in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is furnished
 to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
@@ -28,10 +28,37 @@ SOFTWARE.
 
 =====file: src/progress_r.cpp =================================================
 File src/progress_r.cpp:
-This file is a slightly modified version of /gdal/port/cpl_progress.cpp, to 
+This file is a slightly modified version of gdal/port/cpl_progress.cpp, to
 work in R on Windows and Linux.
 
 Copyright (c) 2013, Frank Warmerdam
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+ *
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+ *
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+===============================================================================
+
+=====file: src/gdalraster.h ===================================================
+Function: ARE_REAL_EQUAL
+This function was copied from gdal/gcore/gdal_priv.h since that header is
+otherwise not needed. We include gdal.h instead for the C API.
+
+Copyright (c) 1998, Frank Warmerdam
+Copyright (c) 2007-2014, Even Rouault <even dot rouault at spatialys.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -91,10 +118,10 @@ Copyright (c) 2018-2019 Marius Appel
 License: MIT
 
 =====All other files ==========================================================
-All files in this package other than those referred to above, were prepared by 
-Chris Toney, a U.S. Government employee working on official time, and are in 
+All files in this package other than those referred to above, were prepared by
+Chris Toney, a U.S. Government employee working on official time, and are in
 the public domain in the United States of America. Copyright and related rights
-in the work are also waived worldwide through the CC0 1.0 Universal public 
+in the work are also waived worldwide through the CC0 1.0 Universal public
 domain dedication.
 
 The software is provided "as is" without warranty of any kind, either expressed

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -10,7 +10,7 @@
 #include <cmath>
 #include <complex>
 
-#include "gdal_priv.h"
+#include "gdal.h"
 #include "cpl_conv.h"
 #include "cpl_port.h"
 #include "cpl_string.h"
@@ -949,9 +949,9 @@ SEXP GDALRaster::read(int band, int xoff, int yoff, int xsize, int ysize,
                 double nodata_value = getNoDataValue(band);
                 if (GDALDataTypeIsFloating(eDT)) {
                     for (double& val : buf) {
-                        if (ARE_REAL_EQUAL(val, nodata_value))
+                        if (CPLIsNan(val))
                             val = NA_REAL;
-                        else if (CPLIsNan(val))
+                        else if (ARE_REAL_EQUAL(val, nodata_value))
                             val = NA_REAL;
                     }
                 }

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -8,6 +8,7 @@
 #ifndef SRC_GDALRASTER_H_
 #define SRC_GDALRASTER_H_
 
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -25,6 +26,20 @@ typedef void *GDALDatasetH;
 typedef void *GDALRasterBandH;
 typedef enum {GA_ReadOnly = 0, GA_Update = 1} GDALAccess;
 #endif
+
+// The function ARE_REAL_EQUAL was copied from gcore/gdal_priv.h since we
+// do not need that header otherwise
+// Copyright (c) 1998, Frank Warmerdam
+// Copyright (c) 2007-2014, Even Rouault <even dot rouault at spatialys.com>
+// License: MIT
+// Behavior is undefined if fVal1 or fVal2 are NaN (should be tested before
+// calling this function)
+template <class T> inline bool ARE_REAL_EQUAL(T fVal1, T fVal2, int ulp = 2)
+{
+    return fVal1 == fVal2 || /* Should cover infinity */
+           std::abs(fVal1 - fVal2) < std::numeric_limits<float>::epsilon() *
+                                         std::abs(fVal1 + fVal2) * ulp;
+}
 
 #ifdef GDAL_H_INCLUDED
 // Map certain GDAL enums to string names for use in R


### PR DESCRIPTION
This PR changes the include in src/gdalraster.cpp from gdal_priv.h to gdal.h.

gdal_priv.h was included only for function `ARE_REAL_EQUAL`. Otherwise, that header is not needed because we are using the C API only. `ARE_REAL_EQUAL` was copied to src/gdalraster.h. This function is needed for recoding nodata values when raster data must be read as `double` (which includes `UInt32` raster data since R does not have an unsigned 32-bit integer data type).