### PR TITLE
Omit Rcpp .finalizer function in class VSIFile for now

### DIFF
--- a/src/vsifile.cpp
+++ b/src/vsifile.cpp
@@ -276,10 +276,10 @@ int VSIFile::set_access(std::string access) {
     }
 }
 
-void vsifile_finalizer(VSIFile* ptr) {
-    if (ptr)
-        ptr->close();
-}
+// void vsifile_finalizer(VSIFile* ptr) {
+//     if (ptr)
+//         ptr->close();
+// }
 
 // ****************************************************************************
 
@@ -326,6 +326,6 @@ RCPP_MODULE(mod_VSIFile) {
     .method("set_access", &VSIFile::set_access,
         "Set the access if the file is closed")
 
-    .finalizer(&vsifile_finalizer)
+    // .finalizer(&vsifile_finalizer)
     ;
 }

--- a/src/vsifile.h
+++ b/src/vsifile.h
@@ -63,7 +63,7 @@ class VSIFile {
     int set_access(std::string access);
 };
 
-static void vsifile_finalizer(VSIFile* ptr);
+// static void vsifile_finalizer(VSIFile* ptr);
 
 RCPP_EXPOSED_CLASS(VSIFile)
 

--- a/tests/testthat/test-VSIFile-class.R
+++ b/tests/testthat/test-VSIFile-class.R
@@ -15,18 +15,18 @@ test_that("VSIFile works", {
     expect_true(is(vf, "Rcpp_VSIFile"))
     expect_equal(vf$close(), 0)
     # filename, r+ access
-    mem_file <- "/vsimem/test_open_rw.lcp"
-    vsi_copy_file(lcp_file, mem_file)
-    expect_no_error(vf <- new(VSIFile, mem_file, "r+"))
+    tmp_file <- tempfile(fileext = ".lcp")
+    file.copy(lcp_file, tmp_file, overwrite = TRUE)
+    expect_no_error(vf <- new(VSIFile, tmp_file, "r+"))
     vf$seek(0, SEEK_END)
     expect_equal(vf$tell(), vsi_stat(lcp_file, "size"))
     expect_equal(vf$close(), 0)
     # filename, w access
-    expect_no_error(vf <- new(VSIFile, mem_file, "w"))
+    expect_no_error(vf <- new(VSIFile, tmp_file, "w"))
     vf$seek(0, SEEK_END)
     expect_equal(vf$tell(), bit64::as.integer64(0))
     expect_equal(vf$close(), 0)
-    vsi_unlink(mem_file)
+    vsi_unlink(tmp_file)
     # testing options depends on GDAL version, and needs internet access
     # so only testing with an empty vector for now
     expect_no_error(vf <- new(VSIFile, lcp_file, "r", character(0)))

--- a/tests/testthat/test-VSIFile-class.R
+++ b/tests/testthat/test-VSIFile-class.R
@@ -14,6 +14,19 @@ test_that("VSIFile works", {
     expect_no_error(vf <- new(VSIFile, lcp_file, "r"))
     expect_true(is(vf, "Rcpp_VSIFile"))
     expect_equal(vf$close(), 0)
+    # filename, r+ access
+    mem_file <- "/vsimem/test_open_rw.lcp"
+    vsi_copy_file(lcp_file, mem_file)
+    expect_no_error(vf <- new(VSIFile, mem_file, "r+"))
+    vf$seek(0, SEEK_END)
+    expect_equal(vf$tell(), vsi_stat(lcp_file, "size"))
+    expect_equal(vf$close(), 0)
+    # filename, w access
+    expect_no_error(vf <- new(VSIFile, mem_file, "w"))
+    vf$seek(0, SEEK_END)
+    expect_equal(vf$tell(), bit64::as.integer64(0))
+    expect_equal(vf$close(), 0)
+    vsi_unlink(mem_file)
     # testing options depends on GDAL version, and needs internet access
     # so only testing with an empty vector for now
     expect_no_error(vf <- new(VSIFile, lcp_file, "r", character(0)))


### PR DESCRIPTION
The finalizer function seems unneeded in this case.