### PR TITLE
Add an alternate constructor in class GDALRaster to allow specifying shared = FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9281
+Version: 1.10.9290
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9281 (dev)
+# gdalraster 1.10.9290 (dev)
+
+* add an optional constructor in class `GDALRaster` to allow specifying whether the dataset is opened in shared mode, `TRUE` by default (2024-06-01)
 
 * add `_cpl_http_cleanup()` for internal use (2024-05-29)
 

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -21,6 +21,8 @@
 #' or `FALSE` to open with write access.
 #' @param open_options Optional character vector of `NAME=VALUE` pairs
 #' specifying dataset open options.
+#' @param shared Logical. `FALSE` to open the dataset without using shared
+#' mode. Default is `TRUE` (see Note).
 #' @returns An object of class `GDALRaster` which contains a pointer to the
 #' opened dataset, and methods that operate on the dataset as described in
 #' Details. `GDALRaster` is a C++ class exposed directly to R (via
@@ -125,6 +127,14 @@
 #' vector of `NAME=VALUE` pairs.
 #' `read_only` is required for this form of the constructor, `TRUE` for
 #'  read-only, or `FALSE` to open with write access.
+#' Returns an object of class `GDALRaster`.
+#'
+#' \code{new(GDALRaster, filename, read_only, open_options, shared)}
+#' Alternate constructor for setting the `shared` mode for dataset opening.
+#' `shared` defaults to `TRUE` but can be set to `FALSE` with this constructor
+#' (see Note).
+#' All arguments are required with this form of the constructor, but
+#' `open_options` may be given as empty vector (`open_opens = character(0)`).
 #' Returns an object of class `GDALRaster`.
 #'
 #' \code{$infoOptions}
@@ -673,6 +683,17 @@
 #' @note
 #' If a dataset object is opened with update access (`read_only = FALSE`), it
 #' is not recommended to open a new dataset on the same underlying `filename`.
+#'
+#' Datasets are opened in shared mode by default. This allows the sharing of
+#' `GDALDataset` handles for a dataset with other callers that open shared on
+#' the same `filename`, if the dataset is opened from the same thread.
+#' Functions in `gdalraster` that do processing will open input datasets in
+#' shared mode. This provides potential efficiency for cases when an object of
+#' class `GDALRaster` is already open in read-only mode on the same `filename`
+#' (avoids overhead associated with the initial dataset opening by using the
+#' existing handle, and potentially makes use of existing data in the GDAL
+#' block cache). Opening in shared mode can be disabled by specifying the
+#' optional `shared` paramater in the class constructor.
 #'
 #' The `$read()` method will perform automatic resampling if the
 #' specified output size (`out_xsize * out_ysize`) is different than

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -19,6 +19,9 @@ or \code{FALSE} to open with write access.}
 
 \item{open_options}{Optional character vector of \code{NAME=VALUE} pairs
 specifying dataset open options.}
+
+\item{shared}{Logical. \code{FALSE} to open the dataset without using shared
+mode. Default is \code{TRUE} (see Note).}
 }
 \value{
 An object of class \code{GDALRaster} which contains a pointer to the
@@ -36,6 +39,17 @@ details of the GDAL Raster API.
 \note{
 If a dataset object is opened with update access (\code{read_only = FALSE}), it
 is not recommended to open a new dataset on the same underlying \code{filename}.
+
+Datasets are opened in shared mode by default. This allows the sharing of
+\code{GDALDataset} handles for a dataset with other callers that open shared on
+the same \code{filename}, if the dataset is opened from the same thread.
+Functions in \code{gdalraster} that do processing will open input datasets in
+shared mode. This provides potential efficiency for cases when an object of
+class \code{GDALRaster} is already open in read-only mode on the same \code{filename}
+(avoids overhead associated with the initial dataset opening by using the
+existing handle, and potentially makes use of existing data in the GDAL
+block cache). Opening in shared mode can be disabled by specifying the
+optional \code{shared} paramater in the class constructor.
 
 The \verb{$read()} method will perform automatic resampling if the
 specified output size (\code{out_xsize * out_ysize}) is different than
@@ -146,6 +160,14 @@ Alternate constructor for passing dataset \code{open_options}, a character
 vector of \code{NAME=VALUE} pairs.
 \code{read_only} is required for this form of the constructor, \code{TRUE} for
 read-only, or \code{FALSE} to open with write access.
+Returns an object of class \code{GDALRaster}.
+
+\code{new(GDALRaster, filename, read_only, open_options, shared)}
+Alternate constructor for setting the \code{shared} mode for dataset opening.
+\code{shared} defaults to \code{TRUE} but can be set to \code{FALSE} with this constructor
+(see Note).
+All arguments are required with this form of the constructor, but
+\code{open_options} may be given as empty vector (\code{open_opens = character(0)}).
 Returns an object of class \code{GDALRaster}.
 
 \code{$infoOptions}

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -90,6 +90,7 @@ class GDALRaster {
  private:
     std::string fname_in;
     Rcpp::CharacterVector open_options_in;
+    bool shared_in;
     GDALDatasetH  hDataset;
     GDALAccess eAccess;
 
@@ -99,6 +100,8 @@ class GDALRaster {
     GDALRaster(Rcpp::CharacterVector filename, bool read_only);
     GDALRaster(Rcpp::CharacterVector filename, bool read_only,
                Rcpp::CharacterVector open_options);
+    GDALRaster(Rcpp::CharacterVector filename, bool read_only,
+               Rcpp::CharacterVector open_options, bool shared);
 
     // read/write fields exposed to R
     Rcpp::CharacterVector infoOptions = Rcpp::CharacterVector::create();


### PR DESCRIPTION
The default is to open datasets shared.