### PR TITLE
calc(): add input validation for variable names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9301
+Version: 1.10.9302
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9301 (dev)
+# gdalraster 1.10.9302 (dev)
+
+* `calc()`: add input validation for `var.names`, must be in `expr` (2024-06-01)
 
 * fix missing calls to `GDALReleaseDataset()` on error condition in some vector related functions (2024-06-01)
 

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -1044,6 +1044,11 @@ calc <- function(expr,
         var.names <- LETTERS[1:nrasters]
     }
 
+    for (nm in var.names) {
+        if (!length(grep(nm, expr, fixed = TRUE)))
+            stop("variable name '", nm, "' not in 'expr'", call. = FALSE)
+    }
+
     if (is.null(fmt)) {
         fmt <- .getGDALformat(dstfile)
         if (is.null(fmt)) {

--- a/tests/testthat/test-gdalraster_proc.R
+++ b/tests/testthat/test-gdalraster_proc.R
@@ -18,7 +18,7 @@ test_that("calc writes correct results", {
                     var.names = "ELEV_M",
                     dtName = "Int16",
                     setRasterNodataValue = TRUE)
-    on.exit(unlink(hi_file))
+    on.exit(deleteDataset(hi_file))
     ds <- new(GDALRaster, hi_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -30,12 +30,12 @@ test_that("calc writes correct results", {
     b5_file <- system.file("extdata/sr_b5_20200829.tif", package="gdalraster")
     expr <- "((B5-B4)/(B5+B4)) * 1000" # rescale for checksum
     ndvi_file <- calc(expr = expr,
-                    rasterfiles = c(b4_file, b5_file),
-                    var.names = c("B4", "B5"),
-                    dtName = "Float32",
-                    nodata_value = -32767,
-                    setRasterNodataValue = TRUE)
-    on.exit(unlink(ndvi_file))
+                      rasterfiles = c(b4_file, b5_file),
+                      var.names = c("B4", "B5"),
+                      dtName = "Float32",
+                      nodata_value = -32767,
+                      setRasterNodataValue = TRUE)
+    on.exit(deleteDataset(ndvi_file))
     ds <- new(GDALRaster, ndvi_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -45,16 +45,16 @@ test_that("calc writes correct results", {
     # recode
     lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
     tif_file <- paste0(tempdir(), "/", "storml_lndscp.tif")
-    on.exit(unlink(tif_file))
+    on.exit(deleteDataset(tif_file))
     createCopy("GTiff", tif_file, lcp_file)
     expr <- "ifelse( SLP >= 40 & FBFM %in% c(101,102), 99, FBFM)"
     calc(expr = expr,
-            rasterfiles = c(lcp_file, lcp_file),
-            bands = c(2, 4),
-            var.names = c("SLP", "FBFM"),
-            dstfile = tif_file,
-            out_band = 4,
-            write_mode = "update")
+         rasterfiles = c(lcp_file, lcp_file),
+         bands = c(2, 4),
+         var.names = c("SLP", "FBFM"),
+         dstfile = tif_file,
+         out_band = 4,
+         write_mode = "update")
     ds <- new(GDALRaster, tif_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -124,53 +124,53 @@ from_terrainrgb(R,G,B)"
     # test errors from input validation
     expr <- "((B5-B4)/(B5+B4))"
     expect_error(calc(expr = expr,
-                    rasterfiles = c(b4_file, paste0(b5_file, ".error")),
-                    var.names = c("B4", "B5"),
-                    dtName = "Float32",
-                    nodata_value = -32767,
-                    setRasterNodataValue = TRUE))
+                      rasterfiles = c(b4_file, paste0(b5_file, ".error")),
+                      var.names = c("B4", "B5"),
+                      dtName = "Float32",
+                      nodata_value = -32767,
+                      setRasterNodataValue = TRUE))
 
     expect_error(calc(expr = expr,
-                    rasterfiles = c(b4_file, b5_file),
-                    bands = 1,
-                    var.names = c("B4", "B5"),
-                    dtName = "Float32",
-                    nodata_value = -32767,
-                    setRasterNodataValue = TRUE))
+                      rasterfiles = c(b4_file, b5_file),
+                      bands = 1,
+                      var.names = c("B4", "B5"),
+                      dtName = "Float32",
+                      nodata_value = -32767,
+                      setRasterNodataValue = TRUE))
 
     expect_error(calc(expr = expr,
-                    rasterfiles = c(b4_file, b5_file),
-                    var.names = c("B4", "B5", "err"),
-                    dtName = "Float32",
-                    nodata_value = -32767,
-                    setRasterNodataValue = TRUE))
+                      rasterfiles = c(b4_file, b5_file),
+                      var.names = c("B4", "B5", "err"),
+                      dtName = "Float32",
+                      nodata_value = -32767,
+                      setRasterNodataValue = TRUE))
 
     expect_error(calc(expr = expr,
-                    rasterfiles = c(b4_file, b5_file),
-                    dtName = "Float32",
-                    nodata_value = -32767,
-                    setRasterNodataValue = TRUE))
+                      rasterfiles = c(b4_file, b5_file),
+                      dtName = "Float32",
+                      nodata_value = -32767,
+                      setRasterNodataValue = TRUE))
 
     expect_error(calc(expr = expr,
-                    rasterfiles = c(b4_file, b5_file),
-                    var.names = c("B4", "B5"),
-                    dstfile = "unknown_file_type.err",
-                    dtName = "Float32",
-                    nodata_value = -32767,
-                    setRasterNodataValue = TRUE))
+                      rasterfiles = c(b4_file, b5_file),
+                      var.names = c("B4", "B5"),
+                      dstfile = "unknown_file_type.err",
+                      dtName = "Float32",
+                      nodata_value = -32767,
+                      setRasterNodataValue = TRUE))
 
     expect_error(calc(expr = expr,
-                    rasterfiles = c(b4_file, b5_file),
-                    var.names = c("B4", "B5"),
-                    dtName = "Int64",
-                    setRasterNodataValue = TRUE))
+                      rasterfiles = c(b4_file, b5_file),
+                      var.names = c("B4", "B5"),
+                      dtName = "Int64",
+                      setRasterNodataValue = TRUE))
 
     expect_error(calc(expr = expr,
-                    rasterfiles = c(b4_file, elev_file),
-                    var.names = c("B4", "B5"),
-                    dtName = "Float32",
-                    nodata_value = -32767,
-                    setRasterNodataValue = TRUE))
+                      rasterfiles = c(b4_file, elev_file),
+                      var.names = c("B4", "B5"),
+                      dtName = "Float32",
+                      nodata_value = -32767,
+                      setRasterNodataValue = TRUE))
 })
 
 test_that("combine writes correct output", {
@@ -179,7 +179,7 @@ test_that("combine writes correct output", {
     bands <- c(4, 5)
     var.names <- c("fbfm", "tree_cov")
     cmb_file <- paste0(tempdir(), "/", "fbfm_cov_cmbid.tif")
-    on.exit(unlink(cmb_file))
+    on.exit(deleteDataset(cmb_file))
     df <- combine(rasterfiles, var.names, bands, cmb_file)
     expect_equal(nrow(df), 29)
     df <- NULL
@@ -197,14 +197,14 @@ test_that("combine writes correct output", {
 test_that("rasterFromRaster works", {
     lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
     slpp_file <- paste0(tempdir(), "/", "storml_slpp.tif")
-    on.exit(unlink(slpp_file))
+    on.exit(deleteDataset(slpp_file))
     options = c("COMPRESS=LZW")
     rasterFromRaster(srcfile = lcp_file,
-                        dstfile = slpp_file,
-                        nbands = 1,
-                        dtName = "Int16",
-                        options = options,
-                        init = -32767)
+                     dstfile = slpp_file,
+                     nbands = 1,
+                     dtName = "Int16",
+                     options = options,
+                     init = -32767)
     ds <- new(GDALRaster, slpp_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -212,14 +212,14 @@ test_that("rasterFromRaster works", {
     expect_equal(chk, 47771)
 
     slpp_file_img <- paste0(tempdir(), "/", "storml_slpp.img")
-    on.exit(unlink(slpp_file_img))
+    on.exit(deleteDataset(slpp_file_img))
     options = c("COMPRESSED=YES")
     rasterFromRaster(srcfile = lcp_file,
-                        dstfile = slpp_file_img,
-                        nbands = 1,
-                        dtName = "Int16",
-                        options = options,
-                        init = -32767)
+                     dstfile = slpp_file_img,
+                     nbands = 1,
+                     dtName = "Int16",
+                     options = options,
+                     init = -32767)
     ds <- new(GDALRaster, slpp_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -227,20 +227,19 @@ test_that("rasterFromRaster works", {
     expect_equal(chk, 47771)
 
     slpp_file_envi <- paste0(tempdir(), "/", "storml_slpp")
-    on.exit(unlink(slpp_file_envi))
-    on.exit(unlink(paste0(slpp_file_envi, ".hdr")))
+    on.exit(deleteDataset(slpp_file_envi))
     # error on unknown file format:
     expect_error(rasterFromRaster(srcfile = lcp_file,
-                        dstfile = slpp_file_envi,
-                        nbands = 1,
-                        dtName = "Int16",
-                        init = -32767))
+                                  dstfile = slpp_file_envi,
+                                  nbands = 1,
+                                  dtName = "Int16",
+                                  init = -32767))
     rasterFromRaster(srcfile = lcp_file,
-                        dstfile = slpp_file_envi,
-                        fmt = "ENVI",
-                        nbands = 1,
-                        dtName = "Int16",
-                        init = -32767)
+                     dstfile = slpp_file_envi,
+                     fmt = "ENVI",
+                     nbands = 1,
+                     dtName = "Int16",
+                     init = -32767)
     ds <- new(GDALRaster, slpp_file_envi, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -254,7 +253,7 @@ test_that("rasterToVRT works", {
     vrt_file <- rasterToVRT(evt_file,
                             resolution=c(90,90),
                             resampling="mode")
-    on.exit(unlink(vrt_file))
+    on.exit(deleteDataset(vrt_file))
     ds <- new(GDALRaster, vrt_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -270,7 +269,7 @@ test_that("rasterToVRT works", {
     vrt_file <- rasterToVRT(evt_file,
                             subwindow = bbox_from_wkt(bnd),
                             src_align=TRUE)
-    on.exit(unlink(vrt_file))
+    on.exit(deleteDataset(vrt_file))
     ds <- new(GDALRaster, vrt_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -281,7 +280,7 @@ test_that("rasterToVRT works", {
     vrt_file <- rasterToVRT(evt_file,
                             subwindow = bbox_from_wkt(bnd),
                             src_align=FALSE)
-    on.exit(unlink(vrt_file))
+    on.exit(deleteDataset(vrt_file))
     ds <- new(GDALRaster, vrt_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -290,8 +289,8 @@ test_that("rasterToVRT works", {
 
     # subwindow outside raster extent
     expect_error(rasterToVRT(evt_file,
-                subwindow = bbox_from_wkt(.g_buffer(bnd, 10000)),
-                src_align=TRUE))
+                             subwindow = bbox_from_wkt(.g_buffer(bnd, 10000)),
+                             src_align=TRUE))
 
     ## subset and pixel align two rasters
     lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
@@ -301,7 +300,7 @@ test_that("rasterToVRT works", {
                             resolution = ds_lcp$res(),
                             subwindow = ds_lcp$bbox(),
                             src_align = FALSE)
-    on.exit(unlink(vrt_file))
+    on.exit(deleteDataset(vrt_file))
     ds_lcp$close()
     ds <- new(GDALRaster, vrt_file, read_only=TRUE)
     dm <- ds$dim()
@@ -315,7 +314,7 @@ test_that("rasterToVRT works", {
               0.11111, 0.11111, 0.11111,
               0.11111, 0.11111, 0.11111)
     vrt_file <- rasterToVRT(elev_file, krnl=krnl)
-    on.exit(unlink(vrt_file))
+    on.exit(deleteDataset(vrt_file))
     ds <- new(GDALRaster, vrt_file, read_only=TRUE)
     dm <- ds$dim()
     chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
@@ -328,7 +327,7 @@ test_that("rasterToVRT works", {
 test_that("dem_proc runs without error", {
     elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
     hs_file <- paste0(tempdir(), "/", "storml_hillshade.tif")
-    on.exit(unlink(hs_file))
+    on.exit(deleteDataset(hs_file))
     expect_true(dem_proc("hillshade", elev_file, hs_file))
 })
 
@@ -341,21 +340,21 @@ test_that("polygonize runs without error", {
 
     # overwrite
     expect_true(polygonize(evt_file, dsn, layer, fld, connectedness=8,
-                overwrite=TRUE))
+                           overwrite=TRUE))
 
     # with mask_file
     expr <- "ifelse(EVT == -9999, 0, 1)"
     mask_file <- calc(expr, rasterfiles=evt_file, var.names="EVT")
     expect_true(polygonize(evt_file, dsn, layer, fld, mask_file=mask_file,
-                overwrite=TRUE))
+                           overwrite=TRUE))
 
     # nomask
     expect_true(polygonize(evt_file, dsn, layer, fld, nomask=TRUE,
-                overwrite=TRUE))
+                           overwrite=TRUE))
 
     # append: layer already exists so expect warning if lco given
     expect_warning(polygonize(evt_file, dsn, layer, fld, connectedness=8,
-                lco="SPATIAL_INDEX=YES"))
+                              lco="SPATIAL_INDEX=YES"))
 
     deleteDataset(dsn)
     deleteDataset(mask_file)
@@ -389,15 +388,15 @@ test_that("rasterize runs without error", {
     out_file <- paste0(tempdir(), "/", "ynp_fires_1984_2022.tif")
 
     res <- rasterize(src_dsn = dsn,
-                dstfile = out_file,
-                sql = sql,
-                burn_attr = "ig_year",
-                tr = c(90,90),
-                tap = TRUE,
-                dtName = "Int16",
-                dstnodata = -9999,
-                init = -9999,
-                co = c("TILED=YES","COMPRESS=LZW"))
+                     dstfile = out_file,
+                     sql = sql,
+                     burn_attr = "ig_year",
+                     tr = c(90,90),
+                     tap = TRUE,
+                     dtName = "Int16",
+                     dstnodata = -9999,
+                     init = -9999,
+                     co = c("TILED=YES","COMPRESS=LZW"))
     expect_true(res)
     ds <- new(GDALRaster, out_file, TRUE)
     bbox <- ds$bbox()
@@ -411,17 +410,17 @@ test_that("rasterize runs without error", {
     where <- "ig_year = 1988"
 
     res <- rasterize(src_dsn = dsn,
-                dstfile = out_file,
-                layer = layer,
-                where = where,
-                burn_value = 1,
-                te = bbox,
-                ts = dm[1:2],
-                dtName = "Byte",
-                init = 0,
-                fmt = "GTiff",
-                co = c("TILED=YES","COMPRESS=LZW"),
-                add_options = "-q")
+                     dstfile = out_file,
+                     layer = layer,
+                     where = where,
+                     burn_value = 1,
+                     te = bbox,
+                     ts = dm[1:2],
+                     dtName = "Byte",
+                     init = 0,
+                     fmt = "GTiff",
+                     co = c("TILED=YES","COMPRESS=LZW"),
+                     add_options = "-q")
     expect_true(res)
     deleteDataset(out_file)
 })


### PR DESCRIPTION
 `var.names` must be in `expr`

Without this check, the input and output datasets would be left in an open condition after the error from `eval(calc_expr)`.