### PR TITLE
ogr_ds_create(): add param overwrite

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.10.9302
+Version: 1.10.9303
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.10.9302 (dev)
+# gdalraster 1.10.9303 (dev)
+
+* `ogr_ds_create()`: add param `overwrite` with default `FALSE` to avoid overwriting existing dataset (#400) (2024-06-01)
 
 * `calc()`: add input validation for `var.names`, must be in `expr` (2024-06-01)
 

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -180,6 +180,8 @@
 #' @param dialect Character string specifying the SQL dialect to use.
 #' The OGR SQL engine (`"OGRSQL"`) will be used by default if a value is not
 #' given. The `"SQLite"` dialect can also be used (see Note).
+#' @param overwrite Logical scalar. `TRUE` to overwrite `dsn` if it already
+#' exists when calling `ogr_ds_create()`. Default is `FALSE`.
 #'
 #' @note
 #' The OGR SQL document linked under **See Also** contains information on the
@@ -337,12 +339,15 @@ ogr_ds_test_cap <- function(dsn, with_update = TRUE) {
 #' @export
 ogr_ds_create <- function(format, dsn, layer = NULL, layer_defn = NULL,
                           geom_type = NULL, srs = NULL, fld_name = NULL,
-                          fld_type = NULL, dsco = NULL, lco = NULL) {
+                          fld_type = NULL, dsco = NULL, lco = NULL,
+                          overwrite = FALSE) {
 
     if (!(is.character(format) && length(format) == 1))
         stop("'format' must be a length-1 character vector", call. = FALSE)
     if (!(is.character(dsn) && length(dsn) == 1))
         stop("'dsn' must be a length-1 character vector", call. = FALSE)
+    if (vsi_stat(dsn) && !overwrite)
+        stop("'dsn' exists and 'overwrite' is FALSE", call. = FALSE)
     if (is.null(layer))
         layer <- ""
     if (!(is.character(layer) && length(layer) == 1))

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -37,7 +37,8 @@ ogr_ds_create(
   fld_name = NULL,
   fld_type = NULL,
   dsco = NULL,
-  lco = NULL
+  lco = NULL,
+  overwrite = FALSE
 )
 
 ogr_ds_layer_count(dsn)
@@ -139,6 +140,9 @@ for \code{dsn} (\code{"NAME=VALUE"} pairs).}
 
 \item{lco}{Optional character vector of format-specific creation options
 for \code{layer} (\code{"NAME=VALUE"} pairs).}
+
+\item{overwrite}{Logical scalar. \code{TRUE} to overwrite \code{dsn} if it already
+exists when calling \code{ogr_ds_create()}. Default is \code{FALSE}.}
 
 \item{fld_defn}{A field definition as list (see \code{\link[=ogr_def_field]{ogr_def_field()}}).
 Additional arguments in \code{ogr_field_create()} will be ignored if a \code{fld_defn}

--- a/tests/testthat/test-ogr_manage.R
+++ b/tests/testthat/test-ogr_manage.R
@@ -8,6 +8,13 @@ test_that("OGR management utilities work", {
     expect_true(ogr_ds_create("GPKG", dsn, "test_layer", geom_type = "POLYGON"))
     expect_true(ogr_ds_exists(dsn, with_update=TRUE))
     expect_true(ogr_layer_exists(dsn, "test_layer"))
+    # overwrite defaults to FALSE
+    expect_error(ogr_ds_create("GPKG", dsn, "test_layer",
+                               geom_type = "POLYGON"))
+    expect_true(ogr_ds_create("GPKG", dsn, "test_layer", geom_type = "POLYGON",
+                              overwrite = TRUE))
+    expect_true(ogr_ds_exists(dsn, with_update=TRUE))
+    expect_true(ogr_layer_exists(dsn, "test_layer"))
     expect_false(ogr_layer_exists(dsn, "test_layer_2"))
     expect_true(ogr_ds_test_cap(dsn)$CreateLayer)
     lco <- "DESCRIPTION=test layer2"


### PR DESCRIPTION
Add param `overwrite` with default `FALSE` in `ogr_ds_create()` to avoid overwriting existing dataset (#400).