### PR TITLE
Fix test in test-ogr_manage.R

### DIFF
--- a/tests/testthat/test-ogr_manage.R
+++ b/tests/testthat/test-ogr_manage.R
@@ -161,10 +161,15 @@ test_that("edit data using SQL works on shapefile", {
 
 test_that("GeoJSON layer and field names are correct", {
     dsn <- system.file("extdata/test.geojson", package="gdalraster")
-    expect_true(ogr_ds_exists(dsn, with_update = TRUE))
-    expect_equal(ogr_ds_format(dsn), "GeoJSON")
-    expect_equal(ogr_ds_layer_count(dsn), 1)
-    expect_equal(ogr_ds_layer_names(dsn), "test")
-    expect_equal(ogr_layer_field_names(dsn, "test"),
+    expect_true(ogr_ds_exists(dsn))
+    dsn2 <- file.path(tempdir(TRUE), "test.geojson")
+    vsi_copy_file(dsn, dsn2)
+    expect_true(ogr_ds_exists(dsn2, with_update = TRUE))
+    expect_equal(ogr_ds_format(dsn2), "GeoJSON")
+    expect_equal(ogr_ds_layer_count(dsn2), 1)
+    expect_equal(ogr_ds_layer_names(dsn2), "test")
+    expect_equal(ogr_layer_field_names(dsn2, "test"),
                  c("int", "string", "double", "int2", ""))
+
+    deleteDataset(dsn2)
 })

--- a/tests/testthat/test-ogr_manage.R
+++ b/tests/testthat/test-ogr_manage.R
@@ -163,7 +163,7 @@ test_that("GeoJSON layer and field names are correct", {
     dsn <- system.file("extdata/test.geojson", package="gdalraster")
     expect_true(ogr_ds_exists(dsn))
     dsn2 <- file.path(tempdir(TRUE), "test.geojson")
-    vsi_copy_file(dsn, dsn2)
+    file.copy(dsn, dsn2)
     expect_true(ogr_ds_exists(dsn2, with_update = TRUE))
     expect_equal(ogr_ds_format(dsn2), "GeoJSON")
     expect_equal(ogr_ds_layer_count(dsn2), 1)


### PR DESCRIPTION
resolves #409 
The test for GeoJSON layer did not need to check existence `with_update = TRUE`. The file being checked was in `inst/extdata`, which is read-only on the CRAN check servers for r-devel-linux-x86_64-debian. This fixes the test by removing `with_update = TRUE` from the initial check of the dataset in `inst/extdata`, then copying it to a temp file and checking `with_update = TRUE`.