### PR TITLE
Document the w+ access flag for VSIFile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gdalraster 1.11.0.9000
 
+* document the `w+` access flag for class `VSIFile` and add `CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE` configuration option in vignette [GDAL Config Quick Reference](https://usdaforestservice.github.io/gdalraster/articles/gdal-config-quick-ref.html) (2024-06-06)
+
 * fix test in test-ogr_manage.R: the test for GeoJSON layer did not need to check existence using `with_update = TRUE` on a file in extdata (#410) (2024-06-06)
 
 # gdalraster 1.11.0

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -33,13 +33,14 @@ SEEK_END <- "SEEK_END"
 #' a file in a regular local filesystem, or a filename with a GDAL /vsiPREFIX/
 #' (see \url{https://gdal.org/user/virtual_file_systems.html}).
 #' @param access Character string containing the access requested (i.e., `"r"`,
-#' `"r+"`, `"w"`). Defaults to `"r"`. Binary access is always implied and the
-#' "b" does not need to be included in `access`.
+#' `"r+"`, `"w"`, `"w+`). Defaults to `"r"`. Binary access is always implied
+#' and the "b" does not need to be included in `access`.
 #' \tabular{lll}{
-#'  **Access** \tab **Explanation**           \tab **If file exists**\cr
-#'  `"r"`      \tab open file for reading     \tab read from start\cr
-#'  `"r+"`     \tab open file for read/write  \tab read from start\cr
-#'  `"w"`      \tab create file for writing   \tab destroy contents
+#'  **Access** \tab **Explanation**             \tab **If file exists**\cr
+#'  `"r"`      \tab open file for reading       \tab read from start\cr
+#'  `"r+"`     \tab open file for read/write    \tab read from start\cr
+#'  `"w"`      \tab create file for writing     \tab destroy contents\cr
+#'  `"w+"`     \tab create file for read/write  \tab destroy contents
 #' }
 #' @param options Optional character vector of `NAME=VALUE` pairs specifying
 #' filesystem-dependent options (GDAL >= 3.3, see Details).
@@ -81,8 +82,8 @@ SEEK_END <- "SEEK_END"
 #' if a file handle cannot be obtained.
 #'
 #' \code{new(VSIFile, filename, access)}
-#' Alternate constructor for passing `access` as a character string (`"r"`,
-#' `"r+"`, `"w"`).
+#' Alternate constructor for passing `access` as a character string
+#' (e.g., `"r"`, `"r+"`, `"w"`, `"w+"`).
 #' Returns an object of class `VSIFile` with an open file handle, or an error
 #' is raised if a file handle cannot be obtained.
 #'
@@ -186,8 +187,8 @@ SEEK_END <- "SEEK_END"
 #'
 #' \code{$set_access(access)}
 #' Sets the requested read/write access on this `VSIFile` object, given as a
-#' character string (i.e., `"r"`, `"r+"`, `"w"`). The access can be changed
-#' only while the `VSIFile` object is closed, and will apply when it is
+#' character string (i.e., `"r"`, `"r+"`, `"w"`, `"w+"`). The access can be
+#' changed only while the `VSIFile` object is closed, and will apply when it is
 #' re-opened with a call to `$open()`.
 #' Returns `0` on success or `-1` on error.
 #'
@@ -197,6 +198,18 @@ SEEK_END <- "SEEK_END"
 #' `numeric` with the `integer64` class attribute attached. The `integer64`
 #' type is signed, so the maximum file offset supported by this interface
 #' is `9223372036854775807` (the value of `bit64::lim.integer64()[2]`).
+#'
+#' Some virtual file systems allow only sequential write, so no seeks or read
+#' operations are then allowed (e.g., AWS S3 files with /vsis3/).
+#' Starting with GDAL 3.2, a configuration option can be set with:
+#' ```
+#' set_config_option("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES")
+#' ````
+#' in which case random-write access is possible (involves the creation of a
+#' temporary local file, whose location is controlled by the `CPL_TMPDIR`
+#' configuration option). In this case, setting `access` to `"w+"` is needed
+#' for random-write with seek and read operations, while `"w"` access would
+#' allow sequential write only.
 #'
 #' @seealso
 #' GDAL Virtual File Systems (compressed, network hosted, etc...):\cr

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -207,8 +207,9 @@ SEEK_END <- "SEEK_END"
 #' ````
 #' in which case random-write access is possible (involves the creation of a
 #' temporary local file, whose location is controlled by the `CPL_TMPDIR`
-#' configuration option). In this case, setting `access` to `"w+"` is needed
-#' for random-write with seek and read operations, while `"w"` access would
+#' configuration option). In this case, setting `access` to `"w+"` may be
+#' needed for writing with seek and read operations (if creating a new file,
+#' otherwise, `"r+"` to open an existing file), while `"w"` access would
 #' allow sequential write only.
 #'
 #' @seealso

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -58,8 +58,9 @@ Starting with GDAL 3.2, a configuration option can be set with:
 
 in which case random-write access is possible (involves the creation of a
 temporary local file, whose location is controlled by the \code{CPL_TMPDIR}
-configuration option). In this case, setting \code{access} to \code{"w+"} is needed
-for random-write with seek and read operations, while \code{"w"} access would
+configuration option). In this case, setting \code{access} to \code{"w+"} may be
+needed for writing with seek and read operations (if creating a new file,
+otherwise, \code{"r+"} to open an existing file), while \code{"w"} access would
 allow sequential write only.
 }
 \section{Usage}{

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -12,13 +12,14 @@ a file in a regular local filesystem, or a filename with a GDAL /vsiPREFIX/
 (see \url{https://gdal.org/user/virtual_file_systems.html}).}
 
 \item{access}{Character string containing the access requested (i.e., \code{"r"},
-\code{"r+"}, \code{"w"}). Defaults to \code{"r"}. Binary access is always implied and the
-"b" does not need to be included in \code{access}.
+\code{"r+"}, \code{"w"}, \verb{"w+}). Defaults to \code{"r"}. Binary access is always implied
+and the "b" does not need to be included in \code{access}.
 \tabular{lll}{
-\strong{Access} \tab \strong{Explanation}           \tab \strong{If file exists}\cr
-\code{"r"}      \tab open file for reading     \tab read from start\cr
-\code{"r+"}     \tab open file for read/write  \tab read from start\cr
-\code{"w"}      \tab create file for writing   \tab destroy contents
+\strong{Access} \tab \strong{Explanation}             \tab \strong{If file exists}\cr
+\code{"r"}      \tab open file for reading       \tab read from start\cr
+\code{"r+"}     \tab open file for read/write    \tab read from start\cr
+\code{"w"}      \tab create file for writing     \tab destroy contents\cr
+\code{"w+"}     \tab create file for read/write  \tab destroy contents
 }}
 
 \item{options}{Optional character vector of \code{NAME=VALUE} pairs specifying
@@ -47,6 +48,19 @@ carrying the \code{bit64::integer64} class attribute. They are returned as
 \code{numeric} with the \code{integer64} class attribute attached. The \code{integer64}
 type is signed, so the maximum file offset supported by this interface
 is \code{9223372036854775807} (the value of \code{bit64::lim.integer64()[2]}).
+
+Some virtual file systems allow only sequential write, so no seeks or read
+operations are then allowed (e.g., AWS S3 files with /vsis3/).
+Starting with GDAL 3.2, a configuration option can be set with:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{set_config_option("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES")
+}\if{html}{\out{</div>}}
+
+in which case random-write access is possible (involves the creation of a
+temporary local file, whose location is controlled by the \code{CPL_TMPDIR}
+configuration option). In this case, setting \code{access} to \code{"w+"} is needed
+for random-write with seek and read operations, while \code{"w"} access would
+allow sequential write only.
 }
 \section{Usage}{
 
@@ -84,8 +98,8 @@ Constructor. Returns an object of class \code{VSIFile}, or an error is raised
 if a file handle cannot be obtained.
 
 \code{new(VSIFile, filename, access)}
-Alternate constructor for passing \code{access} as a character string (\code{"r"},
-\code{"r+"}, \code{"w"}).
+Alternate constructor for passing \code{access} as a character string
+(e.g., \code{"r"}, \code{"r+"}, \code{"w"}, \code{"w+"}).
 Returns an object of class \code{VSIFile} with an open file handle, or an error
 is raised if a file handle cannot be obtained.
 
@@ -192,8 +206,8 @@ Returns a character string containing the \code{access} as currently set on this
 
 \code{$set_access(access)}
 Sets the requested read/write access on this \code{VSIFile} object, given as a
-character string (i.e., \code{"r"}, \code{"r+"}, \code{"w"}). The access can be changed
-only while the \code{VSIFile} object is closed, and will apply when it is
+character string (i.e., \code{"r"}, \code{"r+"}, \code{"w"}, \code{"w+"}). The access can be
+changed only while the \code{VSIFile} object is closed, and will apply when it is
 re-opened with a call to \verb{$open()}.
 Returns \code{0} on success or \code{-1} on error.
 }

--- a/src/vsifile.cpp
+++ b/src/vsifile.cpp
@@ -31,7 +31,7 @@ VSIFile::VSIFile(Rcpp::CharacterVector filename, std::string access,
     if (access.length() > 0 && access.length() < 4)
         access_in = access;
     else
-        Rcpp::stop("'access' should be 'r', 'r+' or 'w'");
+        Rcpp::stop("'access' should be 'r', 'r+', 'w' or 'w+'");
     options_in = options;
     open();
 }
@@ -265,7 +265,7 @@ int VSIFile::set_access(std::string access) {
         return 0;
     }
     else {
-        Rcpp::Rcerr << "'access' should be 'r', 'r+' or 'w'\n";
+        Rcpp::Rcerr << "'access' should be 'r', 'r+', 'w' or 'w+'\n";
         return -1;
     }
 }

--- a/vignettes/gdal-config-quick-ref.Rmd
+++ b/vignettes/gdal-config-quick-ref.Rmd
@@ -122,6 +122,15 @@ set_config_option("OGR_SQLITE_JOURNAL", "MEMORY")
 
 GDAL doc: https://gdal.org/user/configoptions.html#networking-options
 
+**`CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE`**
+
+Whether to use a local temporary file to support random writes in certain virtual file systems. The temporary file will be located in `CPL_TMPDIR` (see above).
+
+```r
+# YES|NO to use a temp file
+set_config_option("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES")
+```
+
 ## PROJ
 
 GDAL doc: https://gdal.org/user/configoptions.html#proj-options


### PR DESCRIPTION
This PR documents the `w+` access flag for class `VSIFile` and adds`CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE` configuration option in vignette "GDAL Config Quick Reference".