### PR TITLE
`vsi_read_dir()`: add parameter `recursive`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9010
+Version: 1.11.1.9020
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9010 (dev)
+# gdalraster 1.11.1.9020 (dev)
+
+* `vsi_read_dir()`: add parameter `recursive`, `TRUE` to read the list of entries in the directory and subdirectories (2024-07-01)
 
 * avoid data copy in `GDALRaster::getDefaultRAT()` for better performance in the case of large attribute tables (2024-06-24)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1474,13 +1474,17 @@ vsi_curl_clear_cache <- function(partial = FALSE, file_prefix = "", quiet = TRUE
 #'
 #' `vsi_read_dir()` abstracts access to directory contents. It returns a
 #' character vector containing the names of files and directories in this
-#' directory. This function is a wrapper for `VSIReadDirEx()` in the GDAL
-#' Common Portability Library.
+#' directory. With `recursive = TRUE`, reads the list of entries in the
+#' directory and subdirectories.
+#' This function is a wrapper for `VSIReadDirEx()` and `VSIReadDirRecursive()`
+#' in the GDAL Common Portability Library.
 #'
 #' @param path Character string. The relative or absolute path of a
 #' directory to read.
 #' @param max_files Integer scalar. The maximum number of files after which to
-#' stop, or 0 for no limit (see Note).
+#' stop, or 0 for no limit (see Note). Ignored if `recursive = TRUE`.
+#' @param recursive Logical scalar. `TRUE` to read the directory and its
+#' subdirectories. Defaults to `FALSE`.
 #' @returns A character vector containing the names of files and directories
 #' in the directory given by `path`. An empty string (`""`) is returned if
 #' `path` does not exist.
@@ -1490,7 +1494,8 @@ vsi_curl_clear_cache <- function(partial = FALSE, file_prefix = "", quiet = TRUE
 #' after that limit has been reached. Note that to indicate truncation, at
 #' least one element more than the `max_files` limit will be returned. If the
 #' length of the returned character vector is lesser or equal to `max_files`,
-#' then no truncation occurred.
+#' then no truncation occurred. The `max_files` parameter is ignored when
+#' `recursive = TRUE`.
 #'
 #' @seealso
 #' [vsi_mkdir()], [vsi_rmdir()], [vsi_stat()], [vsi_sync()]
@@ -1499,8 +1504,8 @@ vsi_curl_clear_cache <- function(partial = FALSE, file_prefix = "", quiet = TRUE
 #' # regular file system for illustration
 #' data_dir <- system.file("extdata", package="gdalraster")
 #' vsi_read_dir(data_dir)
-vsi_read_dir <- function(path, max_files = 0L) {
-    .Call(`_gdalraster_vsi_read_dir`, path, max_files)
+vsi_read_dir <- function(path, max_files = 0L, recursive = FALSE) {
+    .Call(`_gdalraster_vsi_read_dir`, path, max_files, recursive)
 }
 
 #' Synchronize a source file/directory with a target file/directory

--- a/man/vsi_read_dir.Rd
+++ b/man/vsi_read_dir.Rd
@@ -4,14 +4,17 @@
 \alias{vsi_read_dir}
 \title{Read names in a directory}
 \usage{
-vsi_read_dir(path, max_files = 0L)
+vsi_read_dir(path, max_files = 0L, recursive = FALSE)
 }
 \arguments{
 \item{path}{Character string. The relative or absolute path of a
 directory to read.}
 
 \item{max_files}{Integer scalar. The maximum number of files after which to
-stop, or 0 for no limit (see Note).}
+stop, or 0 for no limit (see Note). Ignored if \code{recursive = TRUE}.}
+
+\item{recursive}{Logical scalar. \code{TRUE} to read the directory and its
+subdirectories. Defaults to \code{FALSE}.}
 }
 \value{
 A character vector containing the names of files and directories
@@ -21,15 +24,18 @@ in the directory given by \code{path}. An empty string (\code{""}) is returned i
 \description{
 \code{vsi_read_dir()} abstracts access to directory contents. It returns a
 character vector containing the names of files and directories in this
-directory. This function is a wrapper for \code{VSIReadDirEx()} in the GDAL
-Common Portability Library.
+directory. With \code{recursive = TRUE}, reads the list of entries in the
+directory and subdirectories.
+This function is a wrapper for \code{VSIReadDirEx()} and \code{VSIReadDirRecursive()}
+in the GDAL Common Portability Library.
 }
 \note{
 If \code{max_files} is set to a positive number, directory listing will stop
 after that limit has been reached. Note that to indicate truncation, at
 least one element more than the \code{max_files} limit will be returned. If the
 length of the returned character vector is lesser or equal to \code{max_files},
-then no truncation occurred.
+then no truncation occurred. The \code{max_files} parameter is ignored when
+\code{recursive = TRUE}.
 }
 \examples{
 # regular file system for illustration

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -594,14 +594,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // vsi_read_dir
-Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path, int max_files);
-RcppExport SEXP _gdalraster_vsi_read_dir(SEXP pathSEXP, SEXP max_filesSEXP) {
+Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path, int max_files, bool recursive);
+RcppExport SEXP _gdalraster_vsi_read_dir(SEXP pathSEXP, SEXP max_filesSEXP, SEXP recursiveSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type path(pathSEXP);
     Rcpp::traits::input_parameter< int >::type max_files(max_filesSEXP);
-    rcpp_result_gen = Rcpp::wrap(vsi_read_dir(path, max_files));
+    Rcpp::traits::input_parameter< bool >::type recursive(recursiveSEXP);
+    rcpp_result_gen = Rcpp::wrap(vsi_read_dir(path, max_files, recursive));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1550,7 +1551,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_addFileInZip", (DL_FUNC) &_gdalraster_addFileInZip, 6},
     {"_gdalraster_vsi_copy_file", (DL_FUNC) &_gdalraster_vsi_copy_file, 3},
     {"_gdalraster_vsi_curl_clear_cache", (DL_FUNC) &_gdalraster_vsi_curl_clear_cache, 3},
-    {"_gdalraster_vsi_read_dir", (DL_FUNC) &_gdalraster_vsi_read_dir, 2},
+    {"_gdalraster_vsi_read_dir", (DL_FUNC) &_gdalraster_vsi_read_dir, 3},
     {"_gdalraster_vsi_sync", (DL_FUNC) &_gdalraster_vsi_sync, 4},
     {"_gdalraster_vsi_mkdir", (DL_FUNC) &_gdalraster_vsi_mkdir, 3},
     {"_gdalraster_vsi_rmdir", (DL_FUNC) &_gdalraster_vsi_rmdir, 2},

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -137,13 +137,17 @@ void vsi_curl_clear_cache(bool partial = false,
 //'
 //' `vsi_read_dir()` abstracts access to directory contents. It returns a
 //' character vector containing the names of files and directories in this
-//' directory. This function is a wrapper for `VSIReadDirEx()` in the GDAL
-//' Common Portability Library.
+//' directory. With `recursive = TRUE`, reads the list of entries in the
+//' directory and subdirectories.
+//' This function is a wrapper for `VSIReadDirEx()` and `VSIReadDirRecursive()`
+//' in the GDAL Common Portability Library.
 //'
 //' @param path Character string. The relative or absolute path of a
 //' directory to read.
 //' @param max_files Integer scalar. The maximum number of files after which to
-//' stop, or 0 for no limit (see Note).
+//' stop, or 0 for no limit (see Note). Ignored if `recursive = TRUE`.
+//' @param recursive Logical scalar. `TRUE` to read the directory and its
+//' subdirectories. Defaults to `FALSE`.
 //' @returns A character vector containing the names of files and directories
 //' in the directory given by `path`. An empty string (`""`) is returned if
 //' `path` does not exist.
@@ -153,7 +157,8 @@ void vsi_curl_clear_cache(bool partial = false,
 //' after that limit has been reached. Note that to indicate truncation, at
 //' least one element more than the `max_files` limit will be returned. If the
 //' length of the returned character vector is lesser or equal to `max_files`,
-//' then no truncation occurred.
+//' then no truncation occurred. The `max_files` parameter is ignored when
+//' `recursive = TRUE`.
 //'
 //' @seealso
 //' [vsi_mkdir()], [vsi_rmdir()], [vsi_stat()], [vsi_sync()]
@@ -164,13 +169,17 @@ void vsi_curl_clear_cache(bool partial = false,
 //' vsi_read_dir(data_dir)
 // [[Rcpp::export()]]
 Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
-                                   int max_files = 0) {
+                                   int max_files = 0,
+                                   bool recursive = false) {
 
     std::string path_in;
     path_in = Rcpp::as<std::string>(check_gdal_filename(path));
 
     char **papszFiles;
-    papszFiles = VSIReadDirEx(path_in.c_str(), max_files);
+    if (recursive)
+        papszFiles = VSIReadDirRecursive(path_in.c_str());
+    else
+        papszFiles = VSIReadDirEx(path_in.c_str(), max_files);
 
     int nItems = CSLCount(papszFiles);
     if (nItems > 0) {


### PR DESCRIPTION
Adds parameter `recursive`, `TRUE` to read the list of entries in the directory and subdirectories.

#425 

We use "recursive" for the parameter name here instead of "recurse" since we already have "recursive" in `vsi_mkdir()` and `vsi_rmdir()`.

Note that `max_files` is ignored when `recursive = TRUE`.