### PR TITLE
add GDALRaster::clearColorTable()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9030
+Version: 1.11.1.9040
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9030 (dev)
+# gdalraster 1.11.1.9040 (dev)
+
+* add `GDALRaster$clearColorTable()`: clear the color table associated with a raster band (2024-07-10)
 
 * fix the mode name for `color-relief` in `DEFAULT_DEM_PROC` (`"color-relief"` instead of `"color_relief"`, fixes #428) (2024-07-09)
 

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -110,6 +110,7 @@
 #' ds$getColorTable(band)
 #' ds$getPaletteInterp(band)
 #' ds$setColorTable(band, col_tbl, palette_interp)
+#' ds$clearColorTable(band)
 #'
 #' ds$getDefaultRAT(band)
 #' ds$setDefaultRAT(band, df)
@@ -642,6 +643,11 @@
 #' (see \code{$getPaletteInterp()} above).
 #' Returns logical \code{TRUE} on success or \code{FALSE} if the color table
 #' could not be set.
+#'
+#' \code{$clearColorTable(band)}
+#' Clears the raster color table for \code{band}.
+#' Returns logical \code{TRUE} on success or \code{FALSE} if the color table
+#' could not be cleared, e.g., if this action is not supported by the driver.
 #'
 #' \code{$getDefaultRAT(band)}
 #' Returns the Raster Attribute Table for \code{band} as a data frame,

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -140,6 +140,7 @@ ds$fillRaster(value, ivalue)
 ds$getColorTable(band)
 ds$getPaletteInterp(band)
 ds$setColorTable(band, col_tbl, palette_interp)
+ds$clearColorTable(band)
 
 ds$getDefaultRAT(band)
 ds$setDefaultRAT(band, df)
@@ -678,6 +679,11 @@ opaque).
 (see \code{$getPaletteInterp()} above).
 Returns logical \code{TRUE} on success or \code{FALSE} if the color table
 could not be set.
+
+\code{$clearColorTable(band)}
+Clears the raster color table for \code{band}.
+Returns logical \code{TRUE} on success or \code{FALSE} if the color table
+could not be cleared, e.g., if this action is not supported by the driver.
 
 \code{$getDefaultRAT(band)}
 Returns the Raster Attribute Table for \code{band} as a data frame,

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -1201,6 +1201,20 @@ bool GDALRaster::setColorTable(int band, const Rcpp::RObject& col_tbl,
     }
 }
 
+bool GDALRaster::clearColorTable(int band) {
+
+    checkAccess_(GA_Update);
+
+    GDALRasterBandH hBand = getBand_(band);
+    CPLErr err = GDALSetRasterColorTable(hBand, nullptr);
+    if (err == CE_Failure) {
+        return false;
+    }
+    else {
+        return true;
+    }
+}
+
 SEXP GDALRaster::getDefaultRAT(int band) const {
     checkAccess_(GA_ReadOnly);
 
@@ -1659,6 +1673,8 @@ RCPP_MODULE(mod_GDALRaster) {
         "Get the palette interpretation")
     .method("setColorTable", &GDALRaster::setColorTable,
         "Set a color table for this band")
+    .method("clearColorTable", &GDALRaster::clearColorTable,
+        "Clear the color table for this band")
     .const_method("getDefaultRAT", &GDALRaster::getDefaultRAT,
         "Return default Raster Attribute Table as data frame")
     .method("setDefaultRAT", &GDALRaster::setDefaultRAT,

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -191,6 +191,7 @@ class GDALRaster {
     std::string getPaletteInterp(int band) const;
     bool setColorTable(int band, const Rcpp::RObject& col_tbl,
                        std::string palette_interp);
+    bool clearColorTable(int band);
 
     SEXP getDefaultRAT(int band) const;
     bool setDefaultRAT(int band, const Rcpp::DataFrame& df);


### PR DESCRIPTION
clear the color table associated with a raster band (where supported by the driver)