### PR TITLE
plot_raster(): default to no stretch when the input is an RGB Byte raster

### DIFF
--- a/man/plot_raster.Rd
+++ b/man/plot_raster.Rd
@@ -8,7 +8,7 @@ plot_raster(
   data,
   xsize = NULL,
   ysize = NULL,
-  nbands = 1,
+  nbands = NULL,
   max_pixels = 2.5e+07,
   col_tbl = NULL,
   maxColorValue = 1,
@@ -50,7 +50,9 @@ read (used for argument \code{out_ysize} in \code{GDALRaster$read()}). By defaul
 the entire raster will be read at full resolution.}
 
 \item{nbands}{The number of bands in \code{data}. Must be either 1 (grayscale) or
-3 (RGB). For RGB, \code{data} are interleaved by band.}
+3 (RGB). For RGB, \code{data} are interleaved by band. If \code{nbands} is \code{NULL} (the
+default), then \code{nbands = 3} is assumed if the input data contain 3 bands,
+otherwise band 1 is used.}
 
 \item{max_pixels}{The maximum number of pixels that the function will
 attempt to display (per band). An error is raised if \code{(xsize * ysize)}
@@ -134,6 +136,17 @@ The default is transparent (\code{"#00000000"}, the return value of
 }
 \description{
 \code{plot_raster()} displays raster data using base \code{graphics}.
+}
+\details{
+By default, contrast enhancement by stretch to min/max is applied when
+the input data are single-band grayscale with any raster data type, or
+three-band RGB with raster data type larger than Byte. The minimum/maximum
+of the input data are used by default (i.e., no outlier removal). No stretch
+is applied by default when the input is an RGB byte raster. These defaults
+can be overridden by specifying either the \code{minmax_def} argument
+(user-defined min/max per band), or the \code{minmax_pct_cut} argument (ignore
+outlier pixels based on a percentile range per band). These settings (and
+the \code{normalize} argument) are ignored if a color table is used.
 }
 \note{
 \code{plot_raster()} uses the function \code{graphics::rasterImage()} for plotting

--- a/man/read_ds.Rd
+++ b/man/read_ds.Rd
@@ -80,6 +80,7 @@ The output object has attribute \code{gis}, a list containing:
   $bbox = c(xmin, ymin, xmax, ymax)
   $dim = c(xsize, ysize, nbands)
   $srs = <projection as WKT2 string>
+  $datatype = <character vector of data type name by band>
 }
 The WKT version used for the projection string can be overridden by setting
 the \code{OSR_WKT_FORMAT} configuration option. See \code{\link[=srs_to_wkt]{srs_to_wkt()}} for a list of


### PR DESCRIPTION
This PR changes the default behavior for applying contrast enhancement. Previously, contrast enhancement by stretch to min/max per band was applied by default regardless of the input. The new behavior is documented as
>By default, contrast enhancement by stretch to min/max is applied when the input data are single-band grayscale with any raster data type, or three-band RGB with raster data type larger than Byte. The minimum/maximum of the input data are used by default (i.e., no outlier removal). No stretch is applied by default when the input is an RGB byte raster. These defaults can be overridden by specifying either the `minmax_def` argument (user-defined min/max per band), or the `minmax_pct_cut` argument (ignore outlier pixels based on a percentile range per band). These settings (and the `normalize` argument) are ignored if a color table is used.

This PR also changes the default value of the `nbands` argument to `NULL`:
>If `nbands` is `NULL` (the default), then `nbands = 3` is assumed if the input data contain 3 bands, otherwise band 1 is used.

It also adds `datatype` to the `gis` attribute list that is attached to the output of `read_ds()` (a character vector of data type names per band).