### PR TITLE
add GDALVector::getAttributeFilter()

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -81,6 +81,7 @@
 #' lyr$getLayerDefn()
 #'
 #' lyr$setAttributeFilter(query)
+#' lyr$getAttributeFilter()
 #' lyr$setSpatialFilterRect(bbox)
 #' lyr$clearSpatialFilter()
 #'
@@ -238,6 +239,10 @@
 #' current reading position (as with `$resetReading()` described below).
 #' The `query` parameter may be set to empty string (`""`) to clear the current
 #' attribute filter.
+#'
+#' \code{getAttributeFilter()}\cr
+#' Returns the attribute query string currently in use, or empty string (`""`)
+#' if an attribute filter is not set.
 #'
 #' \code{$setSpatialFilterRect(bbox)}\cr
 #' Sets a new rectangular spatial filter. This method sets a rectangle to be

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -91,6 +91,7 @@ lyr$bbox()
 lyr$getLayerDefn()
 
 lyr$setAttributeFilter(query)
+lyr$getAttributeFilter()
 lyr$setSpatialFilterRect(bbox)
 lyr$clearSpatialFilter()
 
@@ -253,6 +254,10 @@ Note that installing a query string will generally result in resetting the
 current reading position (as with \verb{$resetReading()} described below).
 The \code{query} parameter may be set to empty string (\code{""}) to clear the current
 attribute filter.
+
+\code{getAttributeFilter()}\cr
+Returns the attribute query string currently in use, or empty string (\code{""})
+if an attribute filter is not set.
 
 \code{$setSpatialFilterRect(bbox)}\cr
 Sets a new rectangular spatial filter. This method sets a rectangle to be

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -407,6 +407,12 @@ void GDALVector::setAttributeFilter(std::string query) {
         m_attr_filter = query;
 }
 
+std::string GDALVector::getAttributeFilter() const {
+    checkAccess_(GA_ReadOnly);
+
+    return(m_attr_filter);
+}
+
 void GDALVector::setSpatialFilterRect(Rcpp::NumericVector bbox) {
     checkAccess_(GA_ReadOnly);
 
@@ -1369,6 +1375,8 @@ RCPP_MODULE(mod_GDALVector) {
         "Fetch the schema information for this layer")
     .method("setAttributeFilter", &GDALVector::setAttributeFilter,
         "Set a new attribute query")
+    .const_method("getAttributeFilter", &GDALVector::getAttributeFilter,
+        "Get the attribute filter string (or empty string if not set")
     .method("setSpatialFilterRect", &GDALVector::setSpatialFilterRect,
         "Set a new rectangular spatial filter")
     .method("clearSpatialFilter", &GDALVector::clearSpatialFilter,

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -65,6 +65,7 @@ class GDALVector {
     Rcpp::List getLayerDefn() const;
 
     void setAttributeFilter(std::string query);
+    std::string getAttributeFilter() const;
     void setSpatialFilterRect(Rcpp::NumericVector bbox);
     void clearSpatialFilter();
 


### PR DESCRIPTION
#' Returns the attribute query string currently in use, or empty string (`""`)
#' if an attribute filter is not set.