### PR TITLE
Add GDALVector class methods setSpatialFilter() / getSpatialFilter()

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -82,7 +82,9 @@
 #'
 #' lyr$setAttributeFilter(query)
 #' lyr$getAttributeFilter()
+#' lyr$setSpatialFilter(wkt)
 #' lyr$setSpatialFilterRect(bbox)
+#' lyr$getSpatialFilter()
 #' lyr$clearSpatialFilter()
 #'
 #' lyr$getFeatureCount()
@@ -244,6 +246,19 @@
 #' Returns the attribute query string currently in use, or empty string (`""`)
 #' if an attribute filter is not set.
 #'
+#' \code{$setSpatialFilter(wkt)}\cr
+#' Sets a new spatial filter from a geometry in WKT format. This method sets
+#' the geometry to be used as a spatial filter when fetching features via the
+#' `$getNextFeature()` or `$fetch()` methods. Only features that geometrically
+#' intersect the filter geometry will be returned. Currently this test may be
+#' inaccurately implemented (depending on the vector format driver), but it is
+#' guaranteed that all features whose envelope overlaps the envelope of the
+#' spatial filter will be returned. This can result in more shapes being
+#' returned that should strictly be the case.
+#' `wkt` is a character string containing a WKT geometry in the same coordinate
+#' system as the layer. An empty string (`""`) may be passed indicating that
+#' the current spatial filter should be cleared, but no new one instituted.
+#'
 #' \code{$setSpatialFilterRect(bbox)}\cr
 #' Sets a new rectangular spatial filter. This method sets a rectangle to be
 #' used as a spatial filter when fetching features via the `$getNextFeature()`
@@ -252,6 +267,10 @@
 #' `bbox` is a numeric vector of length four containing xmin, ymin, xmax, ymax
 #' in the same coordinate system as the layer as a whole (as returned by
 #' `$getSpatialRef()`).
+#'
+#' \code{$getSpatialFilter()}\cr
+#' Returns the current spatial filter geometry as a WKT string, or empty string
+#' (`""`) if a spatial filter is not set.
 #'
 #' \code{$clearSpatialFilter()}\cr
 #' Clears a spatial filter that was set with `$setSpatialFilterRect()`.

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -92,7 +92,9 @@ lyr$getLayerDefn()
 
 lyr$setAttributeFilter(query)
 lyr$getAttributeFilter()
+lyr$setSpatialFilter(wkt)
 lyr$setSpatialFilterRect(bbox)
+lyr$getSpatialFilter()
 lyr$clearSpatialFilter()
 
 lyr$getFeatureCount()
@@ -259,6 +261,19 @@ attribute filter.
 Returns the attribute query string currently in use, or empty string (\code{""})
 if an attribute filter is not set.
 
+\code{$setSpatialFilter(wkt)}\cr
+Sets a new spatial filter from a geometry in WKT format. This method sets
+the geometry to be used as a spatial filter when fetching features via the
+\verb{$getNextFeature()} or \verb{$fetch()} methods. Only features that geometrically
+intersect the filter geometry will be returned. Currently this test may be
+inaccurately implemented (depending on the vector format driver), but it is
+guaranteed that all features whose envelope overlaps the envelope of the
+spatial filter will be returned. This can result in more shapes being
+returned that should strictly be the case.
+\code{wkt} is a character string containing a WKT geometry in the same coordinate
+system as the layer. An empty string (\code{""}) may be passed indicating that
+the current spatial filter should be cleared, but no new one instituted.
+
 \code{$setSpatialFilterRect(bbox)}\cr
 Sets a new rectangular spatial filter. This method sets a rectangle to be
 used as a spatial filter when fetching features via the \verb{$getNextFeature()}
@@ -267,6 +282,10 @@ rectangle will be returned.
 \code{bbox} is a numeric vector of length four containing xmin, ymin, xmax, ymax
 in the same coordinate system as the layer as a whole (as returned by
 \verb{$getSpatialRef()}).
+
+\code{$getSpatialFilter()}\cr
+Returns the current spatial filter geometry as a WKT string, or empty string
+(\code{""}) if a spatial filter is not set.
 
 \code{$clearSpatialFilter()}\cr
 Clears a spatial filter that was set with \verb{$setSpatialFilterRect()}.

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -94,7 +94,7 @@ void GDALVector::open(bool read_only) {
 
     OGRGeometryH hGeom_filter = nullptr;
     if (m_spatial_filter != "") {
-        char* pszWKT = (char*) m_spatial_filter.c_str();
+        char *pszWKT = (char *) m_spatial_filter.c_str();
         if (OGR_G_CreateFromWkt(&pszWKT, nullptr, &hGeom_filter) !=
                 OGRERR_NONE) {
             if (hGeom_filter != nullptr)
@@ -114,7 +114,7 @@ void GDALVector::open(bool read_only) {
     if (m_hDataset == nullptr)
         Rcpp::stop("open dataset failed");
 
-    const char* pszDialect = m_dialect.c_str();
+    const char *pszDialect = m_dialect.c_str();
 
     if (m_layer_name == "") {
         m_is_sql = false;
@@ -397,7 +397,7 @@ Rcpp::List GDALVector::getLayerDefn() const {
 void GDALVector::setAttributeFilter(std::string query) {
     checkAccess_(GA_ReadOnly);
 
-    const char* query_in = nullptr;
+    const char *query_in = nullptr;
     if (query != "")
         query_in = query.c_str();
 
@@ -413,6 +413,26 @@ std::string GDALVector::getAttributeFilter() const {
     return(m_attr_filter);
 }
 
+void GDALVector::setSpatialFilter(std::string wkt) {
+    checkAccess_(GA_ReadOnly);
+
+    OGRGeometryH hFilterGeom = nullptr;
+    if (wkt != "") {
+        char *pszWKT = (char *) wkt.c_str();
+        if (OGR_G_CreateFromWkt(&pszWKT, nullptr, &hFilterGeom) !=
+                OGRERR_NONE) {
+            if (hFilterGeom != nullptr)
+                OGR_G_DestroyGeometry(hFilterGeom);
+            Rcpp::stop("failed to create geometry from 'wkt'");
+        }
+    }
+
+    OGR_L_SetSpatialFilter(m_hLayer, hFilterGeom);
+
+    if (hFilterGeom != nullptr)
+        OGR_G_DestroyGeometry(hFilterGeom);
+}
+
 void GDALVector::setSpatialFilterRect(Rcpp::NumericVector bbox) {
     checkAccess_(GA_ReadOnly);
 
@@ -420,6 +440,23 @@ void GDALVector::setSpatialFilterRect(Rcpp::NumericVector bbox) {
         Rcpp::stop("'bbox' has one or more 'NA' values");
 
     OGR_L_SetSpatialFilterRect(m_hLayer, bbox[0], bbox[1], bbox[2], bbox[3]);
+}
+
+std::string GDALVector::getSpatialFilter() const {
+    checkAccess_(GA_ReadOnly);
+
+    OGRGeometryH hFilterGeom = nullptr;
+    hFilterGeom = OGR_L_GetSpatialFilter(m_hLayer);
+    if (hFilterGeom != nullptr) {
+        char *pszWKT = nullptr;
+        OGR_G_ExportToWkt(hFilterGeom, &pszWKT);
+        std::string wkt(pszWKT);
+        CPLFree(pszWKT);
+        return wkt;
+    }
+    else {
+        return "";
+    }
 }
 
 void GDALVector::clearSpatialFilter() {
@@ -795,7 +832,7 @@ Rcpp::DataFrame GDALVector::fetch(double n) {
                     Rcpp::CharacterVector col = df[nFields + 1 + i];
                     OGRGeometryH hGeom = OGR_F_GetGeomFieldRef(hFeat, i);
                     if (hGeom != nullptr) {
-                        char* pszWKT;
+                        char *pszWKT;
                         if (EQUAL(returnGeomAs.c_str(), "WKT"))
                             OGR_G_ExportToWkt(hGeom, &pszWKT);
                         else if (EQUAL(returnGeomAs.c_str(), "WKT_ISO"))
@@ -1377,8 +1414,12 @@ RCPP_MODULE(mod_GDALVector) {
         "Set a new attribute query")
     .const_method("getAttributeFilter", &GDALVector::getAttributeFilter,
         "Get the attribute filter string (or empty string if not set")
+    .method("setSpatialFilter", &GDALVector::setSpatialFilter,
+        "Set a new spatial filter from a geometry in WKT format")
     .method("setSpatialFilterRect", &GDALVector::setSpatialFilterRect,
         "Set a new rectangular spatial filter")
+    .const_method("getSpatialFilter", &GDALVector::getSpatialFilter,
+        "Return the current spatial filter of this layer as WKT")
     .method("clearSpatialFilter", &GDALVector::clearSpatialFilter,
         "Clear the current spatial filter")
     .method("getFeatureCount", &GDALVector::getFeatureCount,

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -66,7 +66,9 @@ class GDALVector {
 
     void setAttributeFilter(std::string query);
     std::string getAttributeFilter() const;
+    void setSpatialFilter(std::string wkt);
     void setSpatialFilterRect(Rcpp::NumericVector bbox);
+    std::string getSpatialFilter() const;
     void clearSpatialFilter();
 
     double getFeatureCount();


### PR DESCRIPTION
`$setSpatialFilter(wkt)`
#' Sets a new spatial filter from a geometry in WKT format. This method sets
#' the geometry to be used as a spatial filter when fetching features via the
#' `$getNextFeature()` or `$fetch()` methods. Only features that geometrically
#' intersect the filter geometry will be returned. Currently this test may be
#' inaccurately implemented (depending on the vector format driver), but it is
#' guaranteed that all features whose envelope overlaps the envelope of the
#' spatial filter will be returned. This can result in more shapes being
#' returned that should strictly be the case.
#' `wkt` is a character string containing a WKT geometry in the same coordinate
#' system as the layer. An empty string (`""`) may be passed indicating that
#' the current spatial filter should be cleared, but no new one instituted.

`$getSpatialFilter()`
#' Returns the current spatial filter geometry as a WKT string, or empty string
#' (`""`) if a spatial filter is not set.