### PR TITLE
add `GDALVector::setIgnoredFields()`: set which fields can be omitted when retrieving features from the layer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9130
+Version: 1.11.1.9140
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# gdalraster 1.11.1.9130 (dev)
+# gdalraster 1.11.1.9140 (dev)
 
-* add GDALVector class methods: `getAttributeFilter()`, `setSpatialFilter()`, `getSpatialFilter()` (2024-07-30) 
+* add `GDALVector::setIgnoredFields()`: set which fields can be omitted when retrieving features from the layer (2024-08-01)
+
+* add GDALVector class methods: `getAttributeFilter()`, `setSpatialFilter()`, `getSpatialFilter()` (2024-07-30)
 
 * add `ogr_proc()`: GDAL OGR facilities for vector geoprocessing (2024-07-28)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -82,6 +82,8 @@
 #'
 #' lyr$setAttributeFilter(query)
 #' lyr$getAttributeFilter()
+#' lyr$setIgnoredFields(fields)
+#'
 #' lyr$setSpatialFilter(wkt)
 #' lyr$setSpatialFilterRect(bbox)
 #' lyr$getSpatialFilter()
@@ -242,9 +244,23 @@
 #' The `query` parameter may be set to empty string (`""`) to clear the current
 #' attribute filter.
 #'
-#' \code{getAttributeFilter()}\cr
+#' \code{$getAttributeFilter()}\cr
 #' Returns the attribute query string currently in use, or empty string (`""`)
 #' if an attribute filter is not set.
+#'
+#' \code{$setIgnoredFields(fields)}\cr
+#' Set which fields can be omitted when retrieving features from the layer.
+#' The `fields` argument is a character vector of field names.
+#' If the format driver supports this functionality (testable using
+#' `$testCapability()$IgnoreFields`), it will not fetch the specified fields
+#' in subsequent calls to `$GetFeature()` / `$getNextFeature()` / `$fetch()`,
+#' and thus save some processing time and/or bandwidth. Besides field names of
+#' the layer, the following special fields can be passed: `"OGR_GEOMETRY"` to
+#' ignore geometry and `"OGR_STYLE"` to ignore layer style. By default, no
+#' fields are ignored. Note that fields that are used in an attribute filter
+#' should generally not be set as ignored fields, as most drivers (such as
+#' those relying on the OGR SQL engine) will be unable to correctly evaluate
+#' the attribute filter. No return value, called for side effects.
 #'
 #' \code{$setSpatialFilter(wkt)}\cr
 #' Sets a new spatial filter from a geometry in WKT format. This method sets

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -253,7 +253,7 @@
 #' The `fields` argument is a character vector of field names.
 #' If the format driver supports this functionality (testable using
 #' `$testCapability()$IgnoreFields`), it will not fetch the specified fields
-#' in subsequent calls to `$GetFeature()` / `$getNextFeature()` / `$fetch()`,
+#' in subsequent calls to `$getFeature()` / `$getNextFeature()` / `$fetch()`,
 #' and thus save some processing time and/or bandwidth. Besides field names of
 #' the layer, the following special fields can be passed: `"OGR_GEOMETRY"` to
 #' ignore geometry and `"OGR_STYLE"` to ignore layer style. By default, no

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -70,8 +70,8 @@
 #' `RandomRead`, `SequentialWrite`, `RandomWrite`, `UpsertFeature`,
 #' `FastSpatialFilter`, `FastFeatureCount`, `FastGetExtent`,
 #' `FastSetNextByIndex`, `CreateField`, `CreateGeomField`, `DeleteField`,
-#' `ReorderFields`, `AlterFieldDefn`, `AlterGeomFieldDefn`, `DeleteFeature`,
-#' `StringsAsUTF8`, `Transactions`, `CurveGeometries`.
+#' `ReorderFields`, `AlterFieldDefn`, `AlterGeomFieldDefn`, `IgnoreFields`,
+#' `DeleteFeature`, `StringsAsUTF8`, `Transactions`, `CurveGeometries`.
 #' See the GDAL documentation for
 #' [`OGR_L_TestCapability()`](https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc).
 #'

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -268,7 +268,7 @@ Set which fields can be omitted when retrieving features from the layer.
 The \code{fields} argument is a character vector of field names.
 If the format driver supports this functionality (testable using
 \verb{$testCapability()$IgnoreFields}), it will not fetch the specified fields
-in subsequent calls to \verb{$GetFeature()} / \verb{$getNextFeature()} / \verb{$fetch()},
+in subsequent calls to \verb{$getFeature()} / \verb{$getNextFeature()} / \verb{$fetch()},
 and thus save some processing time and/or bandwidth. Besides field names of
 the layer, the following special fields can be passed: \code{"OGR_GEOMETRY"} to
 ignore geometry and \code{"OGR_STYLE"} to ignore layer style. By default, no

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -92,6 +92,8 @@ lyr$getLayerDefn()
 
 lyr$setAttributeFilter(query)
 lyr$getAttributeFilter()
+lyr$setIgnoredFields(fields)
+
 lyr$setSpatialFilter(wkt)
 lyr$setSpatialFilterRect(bbox)
 lyr$getSpatialFilter()
@@ -257,9 +259,23 @@ current reading position (as with \verb{$resetReading()} described below).
 The \code{query} parameter may be set to empty string (\code{""}) to clear the current
 attribute filter.
 
-\code{getAttributeFilter()}\cr
+\code{$getAttributeFilter()}\cr
 Returns the attribute query string currently in use, or empty string (\code{""})
 if an attribute filter is not set.
+
+\code{$setIgnoredFields(fields)}\cr
+Set which fields can be omitted when retrieving features from the layer.
+The \code{fields} argument is a character vector of field names.
+If the format driver supports this functionality (testable using
+\verb{$testCapability()$IgnoreFields}), it will not fetch the specified fields
+in subsequent calls to \verb{$GetFeature()} / \verb{$getNextFeature()} / \verb{$fetch()},
+and thus save some processing time and/or bandwidth. Besides field names of
+the layer, the following special fields can be passed: \code{"OGR_GEOMETRY"} to
+ignore geometry and \code{"OGR_STYLE"} to ignore layer style. By default, no
+fields are ignored. Note that fields that are used in an attribute filter
+should generally not be set as ignored fields, as most drivers (such as
+those relying on the OGR SQL engine) will be unable to correctly evaluate
+the attribute filter. No return value, called for side effects.
 
 \code{$setSpatialFilter(wkt)}\cr
 Sets a new spatial filter from a geometry in WKT format. This method sets

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -255,8 +255,8 @@ cannot be found. The returned list contains the following named elements:
 \code{RandomRead}, \code{SequentialWrite}, \code{RandomWrite}, \code{UpsertFeature},
 \code{FastSpatialFilter}, \code{FastFeatureCount}, \code{FastGetExtent},
 \code{FastSetNextByIndex}, \code{CreateField}, \code{CreateGeomField}, \code{DeleteField},
-\code{ReorderFields}, \code{AlterFieldDefn}, \code{AlterGeomFieldDefn}, \code{DeleteFeature},
-\code{StringsAsUTF8}, \code{Transactions}, \code{CurveGeometries}.
+\code{ReorderFields}, \code{AlterFieldDefn}, \code{AlterGeomFieldDefn}, \code{IgnoreFields},
+\code{DeleteFeature}, \code{StringsAsUTF8}, \code{Transactions}, \code{CurveGeometries}.
 See the GDAL documentation for
 \href{https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc}{\code{OGR_L_TestCapability()}}.
 

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -1335,7 +1335,7 @@ SEXP GDALVector::initDF_(R_xlen_t nrow) const {
 
     std::vector<int64_t> fid(nrow, NA_INTEGER64);
     df[col_num] = Rcpp::wrap(fid);
-    col_names[0] = "FID";
+    col_names[col_num] = "FID";
 
     for (int i = 0; i < nFields; ++i) {
         OGRFieldDefnH hFieldDefn = OGR_FD_GetFieldDefn(hFDefn, i);

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -66,6 +66,8 @@ class GDALVector {
 
     void setAttributeFilter(std::string query);
     std::string getAttributeFilter() const;
+    void setIgnoredFields(Rcpp::CharacterVector fields);
+
     void setSpatialFilter(std::string wkt);
     void setSpatialFilterRect(Rcpp::NumericVector bbox);
     std::string getSpatialFilter() const;

--- a/src/ogr_util.cpp
+++ b/src/ogr_util.cpp
@@ -12,6 +12,7 @@
 #include "ogr_srs_api.h"
 
 #include "gdalraster.h"
+#include "gdalvector.h"
 #include "ogr_util.h"
 
 
@@ -374,50 +375,13 @@ SEXP ogr_layer_test_cap(std::string dsn, std::string layer,
 
     if (hDS == nullptr || hLayer == nullptr)
         return R_NilValue;
+    else
+        GDALReleaseDataset(hDS);
 
-    Rcpp::List cap = Rcpp::List::create(
-        Rcpp::Named("RandomRead") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCRandomRead)),
-        Rcpp::Named("SequentialWrite") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCSequentialWrite)),
-        Rcpp::Named("RandomWrite") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCRandomWrite)),
-#if GDAL_VERSION_NUM >= 3060000
-        Rcpp::Named("UpsertFeature") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCUpsertFeature)),
-#endif
-        Rcpp::Named("FastSpatialFilter") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCFastSpatialFilter)),
-        Rcpp::Named("FastFeatureCount") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCFastFeatureCount)),
-        Rcpp::Named("FastGetExtent") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCFastGetExtent)),
-        Rcpp::Named("FastSetNextByIndex") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCFastSetNextByIndex)),
-        Rcpp::Named("CreateField") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCCreateField)),
-        Rcpp::Named("CreateGeomField") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCCreateGeomField)),
-        Rcpp::Named("DeleteField") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCDeleteField)),
-        Rcpp::Named("ReorderFields") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCReorderFields)),
-        Rcpp::Named("AlterFieldDefn") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCAlterFieldDefn)),
-#if GDAL_VERSION_NUM >= 3060000
-        Rcpp::Named("AlterGeomFieldDefn") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCAlterGeomFieldDefn)),
-#endif
-        Rcpp::Named("DeleteFeature") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCDeleteFeature)),
-        Rcpp::Named("StringsAsUTF8") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCStringsAsUTF8)),
-        Rcpp::Named("Transactions") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCTransactions)),
-        Rcpp::Named("CurveGeometries") = static_cast<bool>(
-            OGR_L_TestCapability(hLayer, OLCCurveGeometries)));
+    GDALVector lyr = GDALVector(dsn_in.c_str(), layer, !with_update);
+    Rcpp::List cap = lyr.testCapability();
+    lyr.close();
 
-    GDALReleaseDataset(hDS);
     return cap;
 }
 

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -39,3 +39,46 @@ test_that("class constructors work", {
 
     unlink(dsn)
 })
+
+test_that("setting ignored fields works", {
+    f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")
+    dsn <- file.path(tempdir(), basename(f))
+    file.copy(f, dsn, overwrite = TRUE)
+
+    lyr <- new(GDALVector, dsn)
+    expect_true(lyr$testCapability()$IgnoreFields)
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 10)
+    lyr$setIgnoredFields("event_id")
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 9)
+    expect_true(is.null(feat$event_id))
+    expect_false(is.null(feat$incid_name))
+    lyr$setIgnoredFields("")
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 10)
+    lyr$setIgnoredFields(c("event_id", "map_id", "ig_year"))
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 7)
+    lyr$setIgnoredFields("")
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 10)
+
+    # geometry
+    lyr$returnGeomAs <- "WKT"
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 11)
+    lyr$setIgnoredFields("OGR_GEOMETRY")
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 10)
+    expect_true(is.null(feat$geom))
+    lyr$setIgnoredFields(c("event_id", "OGR_GEOMETRY"))
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 9)
+    lyr$setIgnoredFields("")
+    feat <- lyr$getNextFeature()
+    expect_length(feat, 11)
+
+    lyr$close()
+    unlink(dsn)
+})


### PR DESCRIPTION
`$setIgnoredFields(fields)`
#' Set which fields can be omitted when retrieving features from the layer.
#' The `fields` argument is a character vector of field names.
#' If the format driver supports this functionality (testable using
#' `$testCapability()$IgnoreFields`), it will not fetch the specified fields
#' in subsequent calls to `$getFeature()` / `$getNextFeature()` / `$fetch()`,
#' and thus save some processing time and/or bandwidth. Besides field names of
#' the layer, the following special fields can be passed: `"OGR_GEOMETRY"` to
#' ignore geometry and `"OGR_STYLE"` to ignore layer style. By default, no
#' fields are ignored. Note that fields that are used in an attribute filter
#' should generally not be set as ignored fields, as most drivers (such as
#' those relying on the OGR SQL engine) will be unable to correctly evaluate
#' the attribute filter. No return value, called for side effects.