### PR TITLE
Add GDALVector::setNextByIndex()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9140
+Version: 1.11.1.9150
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9140 (dev)
+# gdalraster 1.11.1.9150 (dev)
+
+* add `GDALVector::setNextByIndex()`: move the read cursor to the `i`th feature in the current result set (2024-08-02)
 
 * add `GDALVector::setIgnoredFields()`: set which fields can be omitted when retrieving features from the layer (2024-08-01)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -91,6 +91,7 @@
 #'
 #' lyr$getFeatureCount()
 #' lyr$getNextFeature()
+#' lyr$setNextByIndex(i)
 #' lyr$getFeature(fid)
 #' lyr$resetReading()
 #' lyr$fetch(n)
@@ -298,7 +299,7 @@
 #' (i.e., `bForce = TRUE` in the call to `OGR_L_GetFeatureCount()`). Note that
 #' some vector drivers will actually scan the entire layer once to count
 #' features. The `FastFeatureCount` element in the list returned by
-#' `$testCapability()` can be checked if this might be a concern.
+#' the `$testCapability()` method can be checked if this might be a concern.
 #' The number of features returned takes into account the spatial and/or
 #' attribute filters. Some driver implementations of this method may alter the
 #' read cursor of the layer.
@@ -311,6 +312,22 @@
 #' Returns a list with the unique feature identifier (FID), the attribute and
 #' geometry field names, and their values. `NULL` is returned if no more
 #' features are available.
+#'
+#' \code{$setNextByIndex(i)}\cr
+#' Moves the read cursor to the `i`th feature in the current result set
+#' (with 0-based indexing).
+#' This method allows positioning of a layer such that a call to
+#' `$getNextFeature()` or `fetch()` will read the requested feature(s), where
+#' `i` is an absolute index into the current result set. So, setting `i = 3`
+#' would mean the next feature read with `$getNextFeature()` would have been
+#' the 4th feature read if sequential reading took place from the beginning of
+#' the layer, including accounting for spatial and attribute filters.
+#' This method is not implemented efficiently by all vector format drivers. The
+#' default implementation simply resets reading to the beginning and then calls
+#' `GetNextFeature()` `i` times.
+#' To determine if fast seeking is available on the current layer, check
+#' the `FastSetNextByIndex` element in the list returned by the
+#' `$testCapability()` method. No return value, called for side effect.
 #'
 #' \code{$getFeature(fid)}\cr
 #' Returns a feature by its identifier. The value of `fid` must be a numeric

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -101,6 +101,7 @@ lyr$clearSpatialFilter()
 
 lyr$getFeatureCount()
 lyr$getNextFeature()
+lyr$setNextByIndex(i)
 lyr$getFeature(fid)
 lyr$resetReading()
 lyr$fetch(n)
@@ -313,7 +314,7 @@ may not be exact. This method forces a count in the underlying API call
 (i.e., \code{bForce = TRUE} in the call to \code{OGR_L_GetFeatureCount()}). Note that
 some vector drivers will actually scan the entire layer once to count
 features. The \code{FastFeatureCount} element in the list returned by
-\verb{$testCapability()} can be checked if this might be a concern.
+the \verb{$testCapability()} method can be checked if this might be a concern.
 The number of features returned takes into account the spatial and/or
 attribute filters. Some driver implementations of this method may alter the
 read cursor of the layer.
@@ -326,6 +327,22 @@ The \verb{$resetReading()} method can be used to start at the beginning again.
 Returns a list with the unique feature identifier (FID), the attribute and
 geometry field names, and their values. \code{NULL} is returned if no more
 features are available.
+
+\code{$setNextByIndex(i)}\cr
+Moves the read cursor to the \code{i}th feature in the current result set
+(with 0-based indexing).
+This method allows positioning of a layer such that a call to
+\verb{$getNextFeature()} or \code{fetch()} will read the requested feature(s), where
+\code{i} is an absolute index into the current result set. So, setting \code{i = 3}
+would mean the next feature read with \verb{$getNextFeature()} would have been
+the 4th feature read if sequential reading took place from the beginning of
+the layer, including accounting for spatial and attribute filters.
+This method is not implemented efficiently by all vector format drivers. The
+default implementation simply resets reading to the beginning and then calls
+\code{GetNextFeature()} \code{i} times.
+To determine if fast seeking is available on the current layer, check
+the \code{FastSetNextByIndex} element in the list returned by the
+\verb{$testCapability()} method. No return value, called for side effect.
 
 \code{$getFeature(fid)}\cr
 Returns a feature by its identifier. The value of \code{fid} must be a numeric

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -75,6 +75,7 @@ class GDALVector {
 
     double getFeatureCount();
     SEXP getNextFeature();
+    void setNextByIndex(double i);
     // fid must be a length-1 numeric vector, since numeric vector can carry
     // the class attribute for integer64:
     SEXP getFeature(Rcpp::NumericVector fid);

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -104,8 +104,6 @@ test_that("cursor positioning works correctly", {
     expect_equal(lyr$getFeature(10)$FID, bit64::as.integer64(10))
     lyr$setNextByIndex(61)
     expect_true(is.null(lyr$getNextFeature()))
-    lyr$setNextByIndex(1000)
-    expect_true(is.null(lyr$getNextFeature()))
 
     expect_error(lyr$setNextByIndex(NA))
     expect_error(lyr$setNextByIndex(-1))

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -82,3 +82,37 @@ test_that("setting ignored fields works", {
     lyr$close()
     unlink(dsn)
 })
+
+test_that("cursor positioning works correctly", {
+    f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")
+    dsn <- file.path(tempdir(), basename(f))
+    file.copy(f, dsn, overwrite = TRUE)
+
+    lyr <- new(GDALVector, dsn)
+
+    expect_equal(lyr$getFeatureCount(), 61)
+    expect_equal(lyr$getNextFeature()$FID, bit64::as.integer64(1))
+    expect_equal(lyr$getNextFeature()$FID, bit64::as.integer64(2))
+    lyr$resetReading()
+    expect_equal(lyr$getNextFeature()$FID, bit64::as.integer64(1))
+    lyr$setNextByIndex(3)
+    expect_equal(lyr$getNextFeature()$FID, bit64::as.integer64(4))
+    lyr$setNextByIndex(3.5)
+    expect_equal(lyr$getNextFeature()$FID, bit64::as.integer64(4))
+    lyr$setNextByIndex(0)
+    expect_equal(lyr$getNextFeature()$FID, bit64::as.integer64(1))
+    expect_equal(lyr$getFeature(10)$FID, bit64::as.integer64(10))
+    lyr$setNextByIndex(61)
+    expect_true(is.null(lyr$getNextFeature()))
+    lyr$setNextByIndex(1000)
+    expect_true(is.null(lyr$getNextFeature()))
+
+    expect_error(lyr$setNextByIndex(NA))
+    expect_error(lyr$setNextByIndex(-1))
+    expect_error(lyr$setNextByIndex(Inf))
+    expect_error(lyr$setNextByIndex(9007199254740993))
+
+    lyr$close()
+
+    unlink(dsn)
+})


### PR DESCRIPTION
`$setNextByIndex(i)`
#' Moves the read cursor to the `i`th feature in the current result set
#' (with 0-based indexing).
#' This method allows positioning of a layer such that a call to
#' `$getNextFeature()` or `fetch()` will read the requested feature(s), where
#' `i` is an absolute index into the current result set. So, setting `i = 3`
#' would mean the next feature read with `$getNextFeature()` would have been
#' the 4th feature read if sequential reading took place from the beginning of
#' the layer, including accounting for spatial and attribute filters.
#' This method is not implemented efficiently by all vector format drivers. The
#' default implementation simply resets reading to the beginning and then calls
#' `GetNextFeature()` `i` times.
#' To determine if fast seeking is available on the current layer, check
#' the `FastSetNextByIndex` element in the list returned by the
#' `$testCapability()` method. No return value, called for side effect.