### PR TITLE
Add `featureTemplate` as a read-only field in class `GDALVector`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9150
+Version: 1.11.1.9160
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9150 (dev)
+# gdalraster 1.11.1.9160 (dev)
+
+* add `featureTemplate` as a read-only field in class `GDALVector` (2024-08-03)
 
 * add `GDALVector::setNextByIndex()`: move the read cursor to the `i`th feature in the current result set (2024-08-02)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -132,12 +132,15 @@
 #' ## Read-only fields
 #'
 #' \code{$featureTemplate}\cr
-#' A list of the attribute and geometry field names, and `NA` values equivalent
+#' A list of the attribute and geometry field names, with `NA` values equivalent
 #' to OGR NULL values. The list elements are fully typed with the corresponding
 #' missing value types assigned (‘NA_integer_’, ‘NA_real_’, ‘NA_character_’,
 #' etc.). The `featureTemplate` is useful to initialize a new empty feature,
 #' to which field and geometry values can be assigned, for use with the
 #' `$createFeature()` method (create and write a new feature within the layer).
+#' Note that geometry fields are initialized as `character` type in the
+#' template, but may be set either to a `character` string specifying a
+#' geometry in WKT format, or to a `raw` vector containing a geometry as WKB.
 #'
 #' ## Read/write fields
 #'

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -58,6 +58,9 @@
 #' # setting a spatial filter and/or specifying the SQL dialect
 #' lyr <- new(GDALVector, dsn, layer, read_only, open_options, spatial_filter, dialect)
 #'
+#' ## Read-only fields
+#' lyr$featureTemplate
+#'
 #' ## Read/write fields
 #' lyr$defaultGeomFldName
 #' lyr$returnGeomAs
@@ -125,6 +128,16 @@
 #' Constructor to specify a spatial filter and/or SQL dialect. All arguments
 #' are required in this form of the constructor, but `open_options` may be
 #' `NULL`, and `spatial_filter` or `dialect` may be an empty string (`""`).
+#'
+#' ## Read-only fields
+#'
+#' \code{$featureTemplate}\cr
+#' A list of the attribute and geometry field names, and `NA` values equivalent
+#' to OGR NULL values. The list elements are fully typed with the corresponding
+#' missing value types assigned (‘NA_integer_’, ‘NA_real_’, ‘NA_character_’,
+#' etc.). The `featureTemplate` is useful to initialize a new empty feature,
+#' to which field and geometry values can be assigned, for use with the
+#' `$createFeature()` method (create and write a new feature within the layer).
 #'
 #' ## Read/write fields
 #'

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -134,7 +134,7 @@
 #' \code{$featureTemplate}\cr
 #' A list of the attribute and geometry field names, with `NA` values equivalent
 #' to OGR NULL values. The list elements are fully typed with the corresponding
-#' missing value types assigned (‘NA_integer_’, ‘NA_real_’, ‘NA_character_’,
+#' missing value types assigned (`NA_integer_`, `NA_real_`, `NA_character_`,
 #' etc.). The `featureTemplate` is useful to initialize a new empty feature,
 #' to which field and geometry values can be assigned, for use with the
 #' `$createFeature()` method (create and write a new feature within the layer).

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -68,6 +68,9 @@ lyr <- new(GDALVector, dsn, layer, read_only, open_options)
 # setting a spatial filter and/or specifying the SQL dialect
 lyr <- new(GDALVector, dsn, layer, read_only, open_options, spatial_filter, dialect)
 
+## Read-only fields
+lyr$featureTemplate
+
 ## Read/write fields
 lyr$defaultGeomFldName
 lyr$returnGeomAs
@@ -138,6 +141,17 @@ Constructor specifying dataset open options as a character vector of
 Constructor to specify a spatial filter and/or SQL dialect. All arguments
 are required in this form of the constructor, but \code{open_options} may be
 \code{NULL}, and \code{spatial_filter} or \code{dialect} may be an empty string (\code{""}).
+}
+
+\subsection{Read-only fields}{
+
+\code{$featureTemplate}\cr
+A list of the attribute and geometry field names, and \code{NA} values equivalent
+to OGR NULL values. The list elements are fully typed with the corresponding
+missing value types assigned (‘NA_integer_’, ‘NA_real_’, ‘NA_character_’,
+etc.). The \code{featureTemplate} is useful to initialize a new empty feature,
+to which field and geometry values can be assigned, for use with the
+\verb{$createFeature()} method (create and write a new feature within the layer).
 }
 
 \subsection{Read/write fields}{

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -146,12 +146,15 @@ are required in this form of the constructor, but \code{open_options} may be
 \subsection{Read-only fields}{
 
 \code{$featureTemplate}\cr
-A list of the attribute and geometry field names, and \code{NA} values equivalent
+A list of the attribute and geometry field names, with \code{NA} values equivalent
 to OGR NULL values. The list elements are fully typed with the corresponding
 missing value types assigned (‘NA_integer_’, ‘NA_real_’, ‘NA_character_’,
 etc.). The \code{featureTemplate} is useful to initialize a new empty feature,
 to which field and geometry values can be assigned, for use with the
 \verb{$createFeature()} method (create and write a new feature within the layer).
+Note that geometry fields are initialized as \code{character} type in the
+template, but may be set either to a \code{character} string specifying a
+geometry in WKT format, or to a \code{raw} vector containing a geometry as WKB.
 }
 
 \subsection{Read/write fields}{

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -148,7 +148,7 @@ are required in this form of the constructor, but \code{open_options} may be
 \code{$featureTemplate}\cr
 A list of the attribute and geometry field names, with \code{NA} values equivalent
 to OGR NULL values. The list elements are fully typed with the corresponding
-missing value types assigned (‘NA_integer_’, ‘NA_real_’, ‘NA_character_’,
+missing value types assigned (\code{NA_integer_}, \code{NA_real_}, \code{NA_character_},
 etc.). The \code{featureTemplate} is useful to initialize a new empty feature,
 to which field and geometry values can be assigned, for use with the
 \verb{$createFeature()} method (create and write a new feature within the layer).

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -1313,12 +1313,13 @@ OGRLayerH GDALVector::getOGRLayerH_() const {
 }
 
 void GDALVector::setFeatureTemplate_() {
-    std::string orig = returnGeomAs;
+    std::string orig_geom_as = returnGeomAs;
     returnGeomAs = "WKT";
 
-    Rcpp::DataFrame null_feat = initDF_(1);
-    null_feat.attr("class") = R_NilValue;
-    null_feat.attr("row.names") = R_NilValue;
+    Rcpp::DataFrame feat_template = initDF_(1);
+    // as list
+    feat_template.attr("class") = R_NilValue;
+    feat_template.attr("row.names") = R_NilValue;
 
     // set null values for the list columns if any
     OGRFeatureDefnH hFDefn = nullptr;
@@ -1334,21 +1335,21 @@ void GDALVector::setFeatureTemplate_() {
 
         OGRFieldType fld_type = OGR_Fld_GetType(hFieldDefn);
 
-        // the first element in null_feat is FID so [i + 1]
+        // the first element in feat_template is FID so [i + 1]
         if (fld_type == OFTBinary)
-            null_feat[i + 1] = Rcpp::RawVector::create();
+            feat_template[i + 1] = Rcpp::RawVector::create();
         else if (fld_type == OFTIntegerList)
-            null_feat[i + 1] = NA_INTEGER;
+            feat_template[i + 1] = NA_INTEGER;
         else if (fld_type == OFTInteger64List)
-            null_feat[i + 1] = NA_INTEGER64;
+            feat_template[i + 1] = NA_INTEGER64;
         else if (fld_type == OFTRealList)
-            null_feat[i + 1] = NA_REAL;
+            feat_template[i + 1] = NA_REAL;
         else if (fld_type == OFTStringList)
-            null_feat[i + 1] = NA_STRING;
+            feat_template[i + 1] = NA_STRING;
     }
 
-    featureTemplate = null_feat;
-    returnGeomAs = orig;
+    featureTemplate = feat_template;
+    returnGeomAs = orig_geom_as;
 }
 
 SEXP GDALVector::initDF_(R_xlen_t nrow) const {

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -65,6 +65,7 @@ GDALVector::GDALVector(Rcpp::CharacterVector dsn, std::string layer,
 
     m_dsn = Rcpp::as<std::string>(check_gdal_filename(dsn));
     open(read_only);
+    setFeatureTemplate_();
 }
 
 void GDALVector::open(bool read_only) {
@@ -1311,6 +1312,45 @@ OGRLayerH GDALVector::getOGRLayerH_() const {
     return m_hLayer;
 }
 
+void GDALVector::setFeatureTemplate_() {
+    std::string orig = returnGeomAs;
+    returnGeomAs = "WKT";
+
+    Rcpp::DataFrame null_feat = initDF_(1);
+    null_feat.attr("class") = R_NilValue;
+    null_feat.attr("row.names") = R_NilValue;
+
+    // set null values for the list columns if any
+    OGRFeatureDefnH hFDefn = nullptr;
+    hFDefn = OGR_L_GetLayerDefn(m_hLayer);
+    if (hFDefn == nullptr)
+        Rcpp::stop("failed to get layer definition");
+
+    int nFields = OGR_FD_GetFieldCount(hFDefn);
+    for (int i = 0; i < nFields; ++i) {
+        OGRFieldDefnH hFieldDefn = OGR_FD_GetFieldDefn(hFDefn, i);
+        if (hFieldDefn == nullptr)
+            Rcpp::stop("could not obtain field definition");
+
+        OGRFieldType fld_type = OGR_Fld_GetType(hFieldDefn);
+
+        // the first element in null_feat is FID so [i + 1]
+        if (fld_type == OFTBinary)
+            null_feat[i + 1] = Rcpp::RawVector::create();
+        else if (fld_type == OFTIntegerList)
+            null_feat[i + 1] = NA_INTEGER;
+        else if (fld_type == OFTInteger64List)
+            null_feat[i + 1] = NA_INTEGER64;
+        else if (fld_type == OFTRealList)
+            null_feat[i + 1] = NA_REAL;
+        else if (fld_type == OFTStringList)
+            null_feat[i + 1] = NA_STRING;
+    }
+
+    featureTemplate = null_feat;
+    returnGeomAs = orig;
+}
+
 SEXP GDALVector::initDF_(R_xlen_t nrow) const {
     // initialize a data frame based on the layer definition
     // this mthod must be kept consistent with fetch()
@@ -1487,6 +1527,9 @@ RCPP_MODULE(mod_GDALVector) {
                  Rcpp::Nullable<Rcpp::CharacterVector>, std::string,
                  std::string>
         ("Usage: new(GDALVector, dsn, layer, read_only, open_options, spatial_filter, dialect)")
+
+    // exposed read-only fields
+    .field_readonly("featureTemplate", &GDALVector::featureTemplate)
 
     // exposed read/write fields
     .field("defaultGeomFldName", &GDALVector::defaultGeomFldName)

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -44,10 +44,15 @@ class GDALVector {
                Rcpp::Nullable<Rcpp::CharacterVector> open_options,
                std::string spatial_filter, std::string dialect);
 
+    // read-only fields
+    Rcpp::List featureTemplate;
+
+    // read/write fields
     std::string defaultGeomFldName = "geometry";
     std::string returnGeomAs = "NONE";
     std::string wkbByteOrder = "LSB";
 
+    // public methods
     void open(bool read_only);
     bool isOpen() const;
     std::string getDsn() const;
@@ -124,6 +129,7 @@ class GDALVector {
     // methods for internal use not exported to R
     void checkAccess_(GDALAccess access_needed) const;
     OGRLayerH getOGRLayerH_() const;
+    void setFeatureTemplate_();
     SEXP initDF_(R_xlen_t nrow) const;
 };
 

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -52,7 +52,7 @@ class GDALVector {
     std::string returnGeomAs = "NONE";
     std::string wkbByteOrder = "LSB";
 
-    // public methods
+    // exported methods
     void open(bool read_only);
     bool isOpen() const;
     std::string getDsn() const;

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -7,6 +7,7 @@ test_that("class constructors work", {
     lyr <- new(GDALVector, dsn)
     expect_equal(lyr$getName(), "mtbs_perims")
     expect_type(lyr$getFeature(1), "list")
+    expect_equal(length(lyr$getLayerDefn()) + 1, length(lyr$featureTemplate))
     lyr$close()
 
     lyr <- new(GDALVector, dsn, "mtbs_perims")


### PR DESCRIPTION
## Read-only fields

`$featureTemplate`
#' A list of the attribute and geometry field names, with `NA` values equivalent
#' to OGR NULL values. The list elements are fully typed with the corresponding
#' missing value types assigned (`NA_integer_`, `NA_real_`, `NA_character_`,
#' etc.). The `featureTemplate` is useful to initialize a new empty feature,
#' to which field and geometry values can be assigned, for use with the
#' `$createFeature()` method (create and write a new feature within the layer).
#' Note that geometry fields are initialized as `character` type in the
#' template, but may be set either to a `character` string specifying a
#' geometry in WKT format, or to a `raw` vector containing a geometry as WKB.