### PR TITLE
Add `GDALVector::deleteFeature()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9160
+Version: 1.11.1.9161
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9160 (dev)
+# gdalraster 1.11.1.9161 (dev)
+
+* add `GDALVector::deleteFeature()`: delete feature from layer (2024-08-03)
 
 * add `featureTemplate` as a read-only field in class `GDALVector` (2024-08-03)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -99,6 +99,8 @@
 #' lyr$resetReading()
 #' lyr$fetch(n)
 #'
+#' lyr$deleteFeature(fid)
+#'
 #' lyr$close()
 #' }
 #' @section Details:
@@ -411,6 +413,15 @@
 #'
 #' Note that `$getFeatureCount()` is called internally when fetching the full
 #' feature set or all remaining features (but not for a page of features).
+#'
+#' \code{$deleteFeature(fid)}\cr
+#' Delete feature from layer. The feature with the indicated feature ID is
+#' deleted from the layer if supported by the format driver. The value of `fid`
+#' must be a numeric scalar, optionally carrying the `bit64::integer64` class
+#' attribute (should be a whole number, will be truncated). The `DeleteFeature`
+#' element in the list returned by `$testCapability()` can be checked to
+#' establish if this layer has delete feature capability. Returns logical
+#' `TRUE` if the operation succeeds, or `FALSE` on failure.
 #'
 #' \code{$close()}\cr
 #' Closes the vector dataset (no return value, called for side effects).

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -109,6 +109,8 @@ lyr$getFeature(fid)
 lyr$resetReading()
 lyr$fetch(n)
 
+lyr$deleteFeature(fid)
+
 lyr$close()
 }
 }
@@ -429,6 +431,15 @@ returned as \code{character} strings when \code{returnGeomAs} is set to one of \
 
 Note that \verb{$getFeatureCount()} is called internally when fetching the full
 feature set or all remaining features (but not for a page of features).
+
+\code{$deleteFeature(fid)}\cr
+Delete feature from layer. The feature with the indicated feature ID is
+deleted from the layer if supported by the format driver. The value of \code{fid}
+must be a numeric scalar, optionally carrying the \code{bit64::integer64} class
+attribute (should be a whole number, will be truncated). The \code{DeleteFeature}
+element in the list returned by \verb{$testCapability()} can be checked to
+establish if this layer has delete feature capability. Returns logical
+\code{TRUE} if the operation succeeds, or \code{FALSE} on failure.
 
 \code{$close()}\cr
 Closes the vector dataset (no return value, called for side effects).

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -88,6 +88,8 @@ class GDALVector {
 
     Rcpp::DataFrame fetch(double n);
 
+    bool deleteFeature(Rcpp::NumericVector fid);
+
     bool layerIntersection(
             GDALVector method_layer,
             GDALVector result_layer,

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -46,7 +46,7 @@ test_that("setting ignored fields works", {
     dsn <- file.path(tempdir(), basename(f))
     file.copy(f, dsn, overwrite = TRUE)
 
-    lyr <- new(GDALVector, dsn)
+    lyr <- new(GDALVector, dsn, "mtbs_perims")
     expect_true(lyr$testCapability()$IgnoreFields)
     feat <- lyr$getNextFeature()
     expect_length(feat, 10)
@@ -89,7 +89,7 @@ test_that("cursor positioning works correctly", {
     dsn <- file.path(tempdir(), basename(f))
     file.copy(f, dsn, overwrite = TRUE)
 
-    lyr <- new(GDALVector, dsn)
+    lyr <- new(GDALVector, dsn, "mtbs_perims")
 
     expect_equal(lyr$getFeatureCount(), 61)
     expect_equal(lyr$getNextFeature()$FID, bit64::as.integer64(1))
@@ -110,6 +110,25 @@ test_that("cursor positioning works correctly", {
     expect_error(lyr$setNextByIndex(-1))
     expect_error(lyr$setNextByIndex(Inf))
     expect_error(lyr$setNextByIndex(9007199254740993))
+
+    lyr$close()
+
+    unlink(dsn)
+})
+
+test_that("delete feature works", {
+    f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")
+    dsn <- file.path(tempdir(), basename(f))
+    file.copy(f, dsn, overwrite = TRUE)
+
+    lyr <- new(GDALVector, dsn, "mtbs_perims", read_only = FALSE)
+    num_feat <- lyr$getFeatureCount()
+    expect_true(lyr$deleteFeature(1))
+
+    lyr$open(read_only = TRUE)
+    expect_equal(lyr$getFeatureCount(), num_feat - 1)
+    expect_false(lyr$deleteFeature(2))
+    expect_equal(lyr$getFeatureCount(), num_feat - 1)
 
     lyr$close()
 


### PR DESCRIPTION
`$deleteFeature(fid)`
#' Delete feature from layer. The feature with the indicated feature ID is
#' deleted from the layer if supported by the format driver. The value of `fid`
#' must be a numeric scalar, optionally carrying the `bit64::integer64` class
#' attribute (should be a whole number, will be truncated). The `DeleteFeature`
#' element in the list returned by `$testCapability()` can be checked to
#' establish if this layer has delete feature capability. Returns logical
#' `TRUE` if the operation succeeds, or `FALSE` on failure.