### PR TITLE
Handle NA when attempting to set nodata value, scale and offset

### DIFF
--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -496,6 +496,9 @@ double GDALRaster::getNoDataValue(int band) const {
 bool GDALRaster::setNoDataValue(int band, double nodata_value) {
     checkAccess_(GA_Update);
 
+    if (!std::isfinite(nodata_value))
+        return false;
+
     GDALRasterBandH hBand = getBand_(band);
     if (GDALSetRasterNoDataValue(hBand, nodata_value) == CE_Failure) {
         if (!quiet)
@@ -561,6 +564,9 @@ double GDALRaster::getScale(int band) const {
 bool GDALRaster::setScale(int band, double scale) {
     checkAccess_(GA_ReadOnly);
 
+    if (!std::isfinite(scale))
+        return false;
+
     GDALRasterBandH hBand = getBand_(band);
     if (GDALSetRasterScale(hBand, scale) == CE_Failure) {
         if (!quiet)
@@ -595,6 +601,9 @@ double GDALRaster::getOffset(int band) const {
 
 bool GDALRaster::setOffset(int band, double offset) {
     checkAccess_(GA_ReadOnly);
+
+    if (!std::isfinite(offset))
+        return false;
 
     GDALRasterBandH hBand = getBand_(band);
     if (GDALSetRasterOffset(hBand, offset) == CE_Failure) {

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -288,17 +288,24 @@ test_that("Byte I/O: warn when data type not compatible", {
     ds$close()
 })
 
-test_that("set unit type, scale and offset works", {
+test_that("set nodata value, unit type, scale and offset works", {
     elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
     mod_file <- paste0(tempdir(), "/", "storml_elev_mod.tif")
     file.copy(elev_file,  mod_file)
     ds <- new(GDALRaster, mod_file, read_only=FALSE)
+    ds$setNoDataValue(1, -9999)
     ds$setUnitType(1, "m")
     ds$setScale(1, 1)
     ds$setOffset(1, 0)
+    expect_equal(ds$getNoDataValue(1), -9999)
     expect_equal(ds$getUnitType(1), "m")
     expect_equal(ds$getScale(1), 1)
     expect_equal(ds$getOffset(1), 0)
+
+    expect_false(ds$setNoDataValue(1, NA))
+    expect_false(ds$setScale(1, NA))
+    expect_false(ds$setOffset(1, NA))
+
     files <- ds$getFileList()
     on.exit(unlink(files))
     ds$close()


### PR DESCRIPTION
require that the input is a finite value, to avoid setting NA, NaN, Inf