### PR TITLE
Add GDALRaster::setMetadata()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9170
+Version: 1.11.1.9180
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9170 (dev)
+# gdalraster 1.11.1.9180 (dev)
+
+* add `GDALRaster::setMetadata()`: set dataset or band-level metadata from a character vector of NAME=VALUE pairs (instead of per metadata item with the existing `$setMetadataItem()`) (2024-08-07)
 
 * add transactions support in class `GDALVector` (`$startTransaction()`, `$commitTransaction()`, `$rollbackTransaction()`) (2024-08-03)
 

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -99,6 +99,7 @@
 #' ds$getDefaultHistogram(band, force)
 #'
 #' ds$getMetadata(band, domain)
+#' ds$setMetadata(band, metadata, domain)
 #' ds$getMetadataItem(band, mdi_name, domain)
 #' ds$setMetadataItem(band, mdi_name, mdi_value, domain)
 #' ds$getMetadataDomainList(band)
@@ -530,7 +531,7 @@
 #'`$histogram` (a numeric vector of length `num_buckets`).
 #'
 #' \code{$getMetadata(band, domain)}\cr
-#' Returns a character vector of all metadata `name=value` pairs that exist in
+#' Returns a character vector of all metadata `NAME=VALUE` pairs that exist in
 #' the specified \code{domain}, or empty string (`""`) if there are no
 #' metadata items in \code{domain} (metadata in the context of the GDAL
 #' Raster Data Model: \url{https://gdal.org/user/raster_data_model.html}).
@@ -538,6 +539,15 @@
 #' band number to retrieve band-level metadata.
 #' Set \code{domain = ""} (empty string) to retrieve metadata in the
 #' default domain.
+#'
+#' \code{$setMetadata(band, metadata, domain)}\cr
+#' Sets metadata in the specified \code{domain}. The \code{metadata} argument
+#' is given as a character vector of `NAME=VALUE` pairs.
+#' Pass \code{band = 0} to set dataset-level metadata, or pass an integer
+#' band number to set band-level metadata.
+#' Use \code{domain = ""} (empty string) to set an item in the default domain.
+#' Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+#' not be set.
 #'
 #' \code{$getMetadataItem(band, mdi_name, domain)}\cr
 #' Returns the value of a specific metadata item named \code{mdi_name} in the
@@ -551,9 +561,11 @@
 #' \code{$setMetadataItem(band, mdi_name, mdi_value, domain)}\cr
 #' Sets the value (\code{mdi_value}) of a specific metadata item named
 #' \code{mdi_name} in the specified \code{domain}.
-#' Set \code{band = 0} to set dataset-level metadata, or to an integer
+#' Pass \code{band = 0} to set dataset-level metadata, or pass an integer
 #' band number to set band-level metadata.
-#' Set \code{domain = ""} (empty string) to set an item in the default domain.
+#' Use \code{domain = ""} (empty string) to set an item in the default domain.
+#' Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+#' not be set.
 #'
 #' \code{$getMetadataDomainList(band)}\cr
 #' Returns a character vector of metadata domains or empty string (`""`).

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -129,6 +129,7 @@ ds$getHistogram(band, min, max, num_buckets, incl_out_of_range, approx_ok)
 ds$getDefaultHistogram(band, force)
 
 ds$getMetadata(band, domain)
+ds$setMetadata(band, metadata, domain)
 ds$getMetadataItem(band, mdi_name, domain)
 ds$setMetadataItem(band, mdi_name, mdi_value, domain)
 ds$getMetadataDomainList(band)
@@ -568,7 +569,7 @@ bound), \verb{$max} (upper bound), \verb{$num_buckets} (number of buckets), and
 \verb{$histogram} (a numeric vector of length \code{num_buckets}).
 
 \code{$getMetadata(band, domain)}\cr
-Returns a character vector of all metadata \code{name=value} pairs that exist in
+Returns a character vector of all metadata \code{NAME=VALUE} pairs that exist in
 the specified \code{domain}, or empty string (\code{""}) if there are no
 metadata items in \code{domain} (metadata in the context of the GDAL
 Raster Data Model: \url{https://gdal.org/user/raster_data_model.html}).
@@ -576,6 +577,15 @@ Set \code{band = 0} to retrieve dataset-level metadata, or to an integer
 band number to retrieve band-level metadata.
 Set \code{domain = ""} (empty string) to retrieve metadata in the
 default domain.
+
+\code{$setMetadata(band, metadata, domain)}\cr
+Sets metadata in the specified \code{domain}. The \code{metadata} argument
+is given as a character vector of \code{NAME=VALUE} pairs.
+Pass \code{band = 0} to set dataset-level metadata, or pass an integer
+band number to set band-level metadata.
+Use \code{domain = ""} (empty string) to set an item in the default domain.
+Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+not be set.
 
 \code{$getMetadataItem(band, mdi_name, domain)}\cr
 Returns the value of a specific metadata item named \code{mdi_name} in the
@@ -589,9 +599,11 @@ default domain.
 \code{$setMetadataItem(band, mdi_name, mdi_value, domain)}\cr
 Sets the value (\code{mdi_value}) of a specific metadata item named
 \code{mdi_name} in the specified \code{domain}.
-Set \code{band = 0} to set dataset-level metadata, or to an integer
+Pass \code{band = 0} to set dataset-level metadata, or pass an integer
 band number to set band-level metadata.
-Set \code{domain = ""} (empty string) to set an item in the default domain.
+Use \code{domain = ""} (empty string) to set an item in the default domain.
+Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+not be set.
 
 \code{$getMetadataDomainList(band)}\cr
 Returns a character vector of metadata domains or empty string (\code{""}).

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -173,9 +173,11 @@ class GDALRaster {
     Rcpp::List getDefaultHistogram(int band, bool force) const;
 
     Rcpp::CharacterVector getMetadata(int band, std::string domain) const;
+    bool setMetadata(int band, const Rcpp::CharacterVector metadata,
+                     std::string domain);
     std::string getMetadataItem(int band, std::string mdi_name,
                                 std::string domain) const;
-    void setMetadataItem(int band, std::string mdi_name, std::string mdi_value,
+    bool setMetadataItem(int band, std::string mdi_name, std::string mdi_value,
                          std::string domain);
     Rcpp::CharacterVector getMetadataDomainList(int band) const;
 

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -86,7 +86,7 @@ test_that("band-level parameters are correct", {
     ds$close()
 })
 
-test_that("metadata are correct", {
+test_that("get/set metadata works", {
     evt_file <- system.file("extdata/storml_evt.tif", package="gdalraster")
     ds <- new(GDALRaster, evt_file, TRUE)
     expect_equal(ds$getMetadata(band=0, domain=""), "AREA_OR_POINT=Area")
@@ -106,7 +106,27 @@ test_that("metadata are correct", {
                  "")
     expect_equal(length(ds$getMetadataDomainList(band=0)), 3)
     expect_equal(length(ds$getMetadataDomainList(band=1)), 1)
+
+    f <- file.path(tempdir(), "testmd.tif")
+    create(format="GTiff", dst_filename=f, xsize=10, ysize=10,
+           nbands=1, dataType="Int32")
+    ds2 <- new(GDALRaster, f, read_only=FALSE)
+
+    # TODO: does not persist:
+    ds2$setMetadata(band=0, metadata="AREA_OR_POINT=Area", domain="")
+
+    expect_true(ds2$setMetadataItem(band=1, mdi_name="RepresentationType",
+                                    mdi_value="THEMATIC", domain=""))
+    ds2$close()
+    ds2$open(read_only = TRUE)
+    # TODO: does not persist:
+    # expect_equal(ds2$getMetadata(band=0, domain=""), "AREA_OR_POINT=Area")
+    expect_equal(ds2$getMetadata(band=1, domain=""),
+                 "RepresentationType=THEMATIC")
+
     ds$close()
+    ds2$close()
+    deleteDataset(f)
 })
 
 test_that("open/close/re-open works", {


### PR DESCRIPTION
Set dataset or band-level metadata from a character vector of NAME=VALUE pairs (instead of per metadata item with the existing `$setMetadataItem()`).