### PR TITLE
createCopy(): test driver for GDAL_DCAP_CREATECOPY or GDAL_DCAP_CREATE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9260
+Version: 1.11.1.9270
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9260 (dev)
+# gdalraster 1.11.1.9270 (dev)
+
+* `createCopy()`: fix the check of CreateCopy() availability from the driver by testing for GDAL_DCAP_CREATECOPY or GDAL_DCAP_CREATE, previously only tested for GDAL_DCAP_CREATECOPY (2024-08-12)
 
 * add `srs_get_name()`: return the spatial reference system name (2024-08-12)
 

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -522,8 +522,11 @@ GDALRaster createCopy(std::string format, Rcpp::CharacterVector dst_filename,
         Rcpp::stop("failed to get driver from format name");
 
     char **papszMetadata = GDALGetMetadata(hDriver, nullptr);
-    if (!CPLFetchBool(papszMetadata, GDAL_DCAP_CREATECOPY, FALSE))
+    if (!CPLFetchBool(papszMetadata, GDAL_DCAP_CREATECOPY, FALSE) &&
+        !CPLFetchBool(papszMetadata, GDAL_DCAP_CREATE, FALSE)) {
+
         Rcpp::stop("driver does not support createCopy");
+    }
 
     std::string dst_filename_in;
     dst_filename_in = Rcpp::as<std::string>(check_gdal_filename(dst_filename));


### PR DESCRIPTION
Previously only tested for GDAL_DCAP_CREATECOPY.  For CreateCopy(), need to test also for GDAL_DCAP_CREATE:

>GDAL_DCAP_CREATECOPY
Capability set by a driver that implements the CreateCopy() API.

>If GDAL_DCAP_CREATECOPY is not defined, but GDAL_DCAP_CREATE is set, a generic CreateCopy() implementation is available and will use the Create() API of the driver. So to test if some CreateCopy() implementation is available, generic or specialize, test for both GDAL_DCAP_CREATE and GDAL_DCAP_CREATECOPY.