### PR TITLE
[StepSecurity] ci: Harden GitHub Actions

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     # NO NEED TO CHECKOUT HERE
-    - uses: r-hub/actions/setup@v1
+    - uses: r-hub/actions/setup@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
       with:
         config: ${{ github.event.inputs.config }}
       id: rhub-setup
@@ -53,16 +53,16 @@ jobs:
       image: ${{ matrix.config.container }}
 
     steps:
-      - uses: r-hub/actions/checkout@v1
-      - uses: r-hub/actions/platform-info@v1
+      - uses: r-hub/actions/checkout@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
+      - uses: r-hub/actions/platform-info@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1
+      - uses: r-hub/actions/setup-deps@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/run-check@v1
+      - uses: r-hub/actions/run-check@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
@@ -78,20 +78,20 @@ jobs:
         config: ${{ fromJson(needs.setup.outputs.platforms) }}
 
     steps:
-      - uses: r-hub/actions/checkout@v1
-      - uses: r-hub/actions/setup-r@v1
+      - uses: r-hub/actions/checkout@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
+      - uses: r-hub/actions/setup-r@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/platform-info@v1
+      - uses: r-hub/actions/platform-info@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
-      - uses: r-hub/actions/setup-deps@v1
+      - uses: r-hub/actions/setup-deps@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
-      - uses: r-hub/actions/run-check@v1
+      - uses: r-hub/actions/run-check@6dfa5aa10532f35c73d10e7f0b10af8a1340de3e # v1.2.1
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This pull request is created by [StepSecurity](https://app.stepsecurity.io/securerepo) at the request of @ctoney. Please merge the Pull Request to incorporate the requested changes. Please tag @ctoney on your message if you have any questions related to the PR.
## Security Fixes

### Pinned Dependencies

GitHub Action tags and Docker tags are mutable. This poses a security risk. GitHub's Security Hardening guide recommends pinning actions to full length commit.

- [GitHub Security Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [The Open Source Security Foundation (OpenSSF) Security Guide](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)


## Feedback
For bug reports, feature requests, and general feedback; please email support@stepsecurity.io. To create such PRs, please visit https://app.stepsecurity.io/securerepo.


Signed-off-by: StepSecurity Bot <bot@stepsecurity.io>