### PR TITLE
Add `ogr_layer_rename()`: rename an existing layer in a vector dataset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9330
+Version: 1.11.1.9340
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9330 (dev)
+# gdalraster 1.11.1.9340 (dev)
+
+* add `ogr_layer_rename()`: rename an existing layer in a vector dataset (GDAL >= 3.5) (2024-09-04)
 
 * (internal) add header `src/gdal_vsi.h` and minor code cleanups in `src/gdal_vsi.cpp` (2024-09-02)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2142,6 +2142,13 @@ has_geos <- function() {
     .Call(`_gdalraster_ogr_layer_create`, dsn, layer, layer_defn, geom_type, srs, options)
 }
 
+#' Rename a layer in a vector dataset
+#'
+#' @noRd
+.ogr_layer_rename <- function(dsn, layer, new_name) {
+    .Call(`_gdalraster_ogr_layer_rename`, dsn, layer, new_name)
+}
+
 #' Delete a layer in a vector dataset
 #'
 #' @noRd

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -71,7 +71,7 @@
 #' `FastSpatialFilter`, `FastFeatureCount`, `FastGetExtent`,
 #' `FastSetNextByIndex`, `CreateField`, `CreateGeomField`, `DeleteField`,
 #' `ReorderFields`, `AlterFieldDefn`, `AlterGeomFieldDefn`, `IgnoreFields`,
-#' `DeleteFeature`, `StringsAsUTF8`, `CurveGeometries`.
+#' `DeleteFeature`, `Rename`, `StringsAsUTF8`, `CurveGeometries`.
 #' See the GDAL documentation for
 #' [`OGR_L_TestCapability()`](https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc).
 #'
@@ -85,6 +85,12 @@
 #'
 #' `ogr_layer_field_names()` returns a character vector of field names on a
 #' layer, or `NULL` if no fields are found.
+#'
+#' `ogr_layer_rename()` renames a layer in a vector dataset. This operation is
+#' implemented only by layers that expose the `Rename` capability (see
+#' `ogr_layer_test_cap()` above). This operation will fail if a layer with the
+#' new name already exists. Returns a logical scalar, `TRUE` indicating success.
+#' Requires GDAL >= 3.5.
 #'
 #' `ogr_layer_delete()` deletes an existing layer in a vector dataset.
 #' Returns a logical scalar, `TRUE` indicating success.
@@ -484,6 +490,19 @@ ogr_layer_field_names <- function(dsn, layer) {
         stop("'layer' must be a length-1 character vector", call. = FALSE)
 
     return(.ogr_layer_field_names(dsn, layer))
+}
+
+#' @name ogr_manage
+#' @export
+ogr_layer_rename <- function(dsn, layer, new_name) {
+    if (!(is.character(dsn) && length(dsn) == 1))
+        stop("'dsn' must be a length-1 character vector", call. = FALSE)
+    if (!(is.character(layer) && length(layer) == 1))
+        stop("'layer' must be a length-1 character vector", call. = FALSE)
+    if (!(is.character(new_name) && length(new_name) == 1))
+        stop("'new_name' must be a length-1 character vector", call. = FALSE)
+
+    return(.ogr_layer_rename(dsn, layer, new_name))
 }
 
 #' @name ogr_manage

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -12,6 +12,7 @@
 \alias{ogr_layer_test_cap}
 \alias{ogr_layer_create}
 \alias{ogr_layer_field_names}
+\alias{ogr_layer_rename}
 \alias{ogr_layer_delete}
 \alias{ogr_field_index}
 \alias{ogr_field_create}
@@ -59,6 +60,8 @@ ogr_layer_create(
 )
 
 ogr_layer_field_names(dsn, layer)
+
+ogr_layer_rename(dsn, layer, new_name)
 
 ogr_layer_delete(dsn, layer)
 
@@ -144,6 +147,8 @@ for \code{layer} (\code{"NAME=VALUE"} pairs).}
 \item{overwrite}{Logical scalar. \code{TRUE} to overwrite \code{dsn} if it already
 exists when calling \code{ogr_ds_create()}. Default is \code{FALSE}.}
 
+\item{new_name}{Character string containing a new name to assign.}
+
 \item{fld_defn}{A field definition as list (see \code{\link[=ogr_def_field]{ogr_def_field()}}).
 Additional arguments in \code{ogr_field_create()} will be ignored if a \code{fld_defn}
 is given.}
@@ -173,8 +178,6 @@ string.}
 (see \code{\link[=ogr_def_geom_field]{ogr_def_geom_field()}}).
 Additional arguments in \code{ogr_geom_field_create()} will be ignored if a
 \code{geom_fld_defn} is given.}
-
-\item{new_name}{Character string containing a new name to assign.}
 
 \item{sql}{Character string containing an SQL statement (see Note).}
 
@@ -256,7 +259,7 @@ cannot be found. The returned list contains the following named elements:
 \code{FastSpatialFilter}, \code{FastFeatureCount}, \code{FastGetExtent},
 \code{FastSetNextByIndex}, \code{CreateField}, \code{CreateGeomField}, \code{DeleteField},
 \code{ReorderFields}, \code{AlterFieldDefn}, \code{AlterGeomFieldDefn}, \code{IgnoreFields},
-\code{DeleteFeature}, \code{StringsAsUTF8}, \code{CurveGeometries}.
+\code{DeleteFeature}, \code{Rename}, \code{StringsAsUTF8}, \code{CurveGeometries}.
 See the GDAL documentation for
 \href{https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc}{\code{OGR_L_TestCapability()}}.
 
@@ -270,6 +273,12 @@ Returns a logical scalar, \code{TRUE} indicating success.
 
 \code{ogr_layer_field_names()} returns a character vector of field names on a
 layer, or \code{NULL} if no fields are found.
+
+\code{ogr_layer_rename()} renames a layer in a vector dataset. This operation is
+implemented only by layers that expose the \code{Rename} capability (see
+\code{ogr_layer_test_cap()} above). This operation will fail if a layer with the
+new name already exists. Returns a logical scalar, \code{TRUE} indicating success.
+Requires GDAL >= 3.5.
 
 \code{ogr_layer_delete()} deletes an existing layer in a vector dataset.
 Returns a logical scalar, \code{TRUE} indicating success.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1237,6 +1237,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// ogr_layer_rename
+bool ogr_layer_rename(std::string dsn, std::string layer, std::string new_name);
+RcppExport SEXP _gdalraster_ogr_layer_rename(SEXP dsnSEXP, SEXP layerSEXP, SEXP new_nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< std::string >::type new_name(new_nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(ogr_layer_rename(dsn, layer, new_name));
+    return rcpp_result_gen;
+END_RCPP
+}
 // ogr_layer_delete
 bool ogr_layer_delete(std::string dsn, std::string layer);
 RcppExport SEXP _gdalraster_ogr_layer_delete(SEXP dsnSEXP, SEXP layerSEXP) {
@@ -1645,6 +1658,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_ogr_layer_exists", (DL_FUNC) &_gdalraster_ogr_layer_exists, 2},
     {"_gdalraster_ogr_layer_test_cap", (DL_FUNC) &_gdalraster_ogr_layer_test_cap, 3},
     {"_gdalraster_ogr_layer_create", (DL_FUNC) &_gdalraster_ogr_layer_create, 6},
+    {"_gdalraster_ogr_layer_rename", (DL_FUNC) &_gdalraster_ogr_layer_rename, 3},
     {"_gdalraster_ogr_layer_delete", (DL_FUNC) &_gdalraster_ogr_layer_delete, 2},
     {"_gdalraster_ogr_layer_field_names", (DL_FUNC) &_gdalraster_ogr_layer_field_names, 2},
     {"_gdalraster_ogr_field_index", (DL_FUNC) &_gdalraster_ogr_field_index, 3},

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -207,7 +207,7 @@ Rcpp::List GDALVector::testCapability() const {
             OGR_L_TestCapability(m_hLayer, OLCSequentialWrite)),
         Rcpp::Named("RandomWrite") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCRandomWrite)),
-#if GDAL_VERSION_NUM >= 3060000
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 6, 0)
         Rcpp::Named("UpsertFeature") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCUpsertFeature)),
 #endif
@@ -229,7 +229,7 @@ Rcpp::List GDALVector::testCapability() const {
             OGR_L_TestCapability(m_hLayer, OLCReorderFields)),
         Rcpp::Named("AlterFieldDefn") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCAlterFieldDefn)),
-#if GDAL_VERSION_NUM >= 3060000
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 6, 0)
         Rcpp::Named("AlterGeomFieldDefn") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCAlterGeomFieldDefn)),
 #endif
@@ -237,6 +237,10 @@ Rcpp::List GDALVector::testCapability() const {
             OGR_L_TestCapability(m_hLayer, OLCIgnoreFields)),
         Rcpp::Named("DeleteFeature") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCDeleteFeature)),
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
+        Rcpp::Named("Rename") = static_cast<bool>(
+            OGR_L_TestCapability(m_hLayer, OLCRename)),
+#endif
         Rcpp::Named("StringsAsUTF8") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCStringsAsUTF8)),
         Rcpp::Named("CurveGeometries") = static_cast<bool>(

--- a/src/ogr_util.h
+++ b/src/ogr_util.h
@@ -174,6 +174,9 @@ bool ogr_layer_create(std::string dsn, std::string layer,
                        std::string geom_type, std::string srs,
                        Rcpp::Nullable<Rcpp::CharacterVector> options);
 
+bool ogr_layer_rename(std::string dsn, std::string layer,
+                      std::string new_name);
+
 bool ogr_layer_delete(std::string dsn, std::string layer);
 
 SEXP ogr_layer_field_names(std::string dsn, std::string layer);
@@ -202,6 +205,9 @@ bool ogr_geom_field_create(std::string dsn, std::string layer,
                            std::string fld_name, std::string geom_type,
                            std::string srs, bool is_nullable,
                            bool is_ignored);
+
+bool ogr_field_rename(std::string dsn, std::string layer,
+                      std::string fld_name, std::string new_name);
 
 bool ogr_field_delete(std::string dsn, std::string layer,
                       std::string fld_name);

--- a/tests/testthat/test-ogr_manage.R
+++ b/tests/testthat/test-ogr_manage.R
@@ -82,6 +82,13 @@ test_that("OGR management utilities work", {
                  c("field1", "field2", "field3", "field4", "field5", "field6",
                    "geom"))
 
+    # rename layer
+    expect_true(ogr_layer_test_cap(dsn, "test_layer3")$Rename)
+    expect_true(ogr_layer_rename(dsn, "test_layer3", "test_new_name"))
+    expect_equal(ogr_layer_field_names(dsn, "test_new_name"),
+                 c("field1", "field2", "field3", "field4", "field5", "field6",
+                   "geom"))
+
     deleteDataset(dsn)
 
     # SQLite

--- a/tests/testthat/test-ogr_manage.R
+++ b/tests/testthat/test-ogr_manage.R
@@ -83,11 +83,13 @@ test_that("OGR management utilities work", {
                    "geom"))
 
     # rename layer
-    expect_true(ogr_layer_test_cap(dsn, "test_layer3")$Rename)
-    expect_true(ogr_layer_rename(dsn, "test_layer3", "test_new_name"))
-    expect_equal(ogr_layer_field_names(dsn, "test_new_name"),
-                 c("field1", "field2", "field3", "field4", "field5", "field6",
-                   "geom"))
+    if (as.integer(gdal_version()[2]) >= 3050000) {
+        expect_true(ogr_layer_test_cap(dsn, "test_layer3")$Rename)
+        expect_true(ogr_layer_rename(dsn, "test_layer3", "test_new_name"))
+        expect_equal(ogr_layer_field_names(dsn, "test_new_name"),
+                     c("field1", "field2", "field3", "field4", "field5",
+                       "field6", "geom"))
+    }
 
     deleteDataset(dsn)
 


### PR DESCRIPTION
#' `ogr_layer_rename()` renames a layer in a vector dataset. This operation is
#' implemented only by layers that expose the `Rename` capability (see
#' `ogr_layer_test_cap()` above). This operation will fail if a layer with the
#' new name already exists. Returns a logical scalar, `TRUE` indicating success.
#' Requires GDAL >= 3.5.