### PR TITLE
ogr_def_geom_field(): fix input validation for the srs argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9342
+Version: 1.11.1.9350
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9342 (dev)
+# gdalraster 1.11.1.9350 (dev)
+
+* fix input validation in `ogr_def_geom_field()`: if `srs` is `NULL` set to empty string, avoids exception in `ogr_layer_create()` if no SRS is given when using a layer definition created with `ogr_def_layer()` (2024-09-07)
 
 * add `ogr_layer_rename()`: rename an existing layer in a vector dataset (GDAL >= 3.5) (2024-09-04)
 

--- a/R/ogr_define.R
+++ b/R/ogr_define.R
@@ -232,12 +232,14 @@ ogr_def_geom_field <- function(geom_type, srs = NULL, is_nullable = NULL,
     else
         defn$type <- geom_type
 
-    if (!is.null(srs)) {
-        if (!(is.character(srs) && length(srs) == 1))
-            stop("'srs' must be a length-1 character vector", call. = FALSE)
-        else
-            defn$srs <- srs
-    }
+    if (is.null(srs))
+        srs <- ""
+
+    if (!(is.character(srs) && length(srs) == 1))
+        stop("'srs' must be a length-1 character vector", call. = FALSE)
+    else
+        defn$srs <- srs
+
 
     if (!is.null(is_nullable)) {
         if (!(is.logical(is_nullable) && length(is_nullable) == 1))
@@ -263,6 +265,9 @@ ogr_def_geom_field <- function(geom_type, srs = NULL, is_nullable = NULL,
 ogr_def_layer <- function(geom_type, geom_fld_name = "geom", srs = NULL) {
 
     defn <- list()
+
+    if (is.null(srs))
+        srs <- ""
 
     if (!(is.character(geom_fld_name) && length(geom_fld_name) == 1))
         stop("'geom_fld_name' must be a length-1 character vector",


### PR DESCRIPTION
if `srs` is `NULL` set to empty string, avoids exception in `ogr_layer_create()` if no SRS is given when using a layer definition created with `ogr_def_layer()` 