### PR TITLE
`GDALVector`: add `SUMMARY` option for the per-object setting `$returnGeomAs`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9401
+Version: 1.11.1.9402
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# gdalraster 1.11.1.9401 (dev)
+# gdalraster 1.11.1.9402 (dev)
 
-* `GDALVector`: add read/write field `promoteToMulti` (2024-09-09)
+* `GDALVector`: add a `SUMMARY` option for the per-object setting `$returnGeomAs` (2024-09-09)
+
+* `GDALVector`: add `$promoteToMulti` as a per-object setting (2024-09-09)
 
 * `GDALVector`: add class methods for writing features in a layer: `$createFeature()`, `$setFeature()`, `$upsertFeature()` (2024-09-08)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -173,11 +173,12 @@
 #'
 #' \code{$returnGeomAs}\cr
 #' Character string specifying the return format of feature geometries.
-#' Must be one of `WKT`, `WKT_ISO`, `WKB` (the default), `WKB_ISO`, `TYPE_NAME`
-#' or `NONE`. Using `WKB`/`WKT` exports as 99-402 extended dimension (Z) types
-#' for Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon
-#' and GeometryCollection. For other geometry types, it is equivalent to using
-#' `WKB_ISO`/`WKT_ISO` (see \url{https://libgeos.org/specifications/wkb/}).
+#' Must be one of `WKT`, `WKT_ISO`, `WKB` (the default), `WKB_ISO`,
+#' `SUMMARY` (GDAL >= 3.7), `TYPE_NAME` or `NONE`. Using `WKB`/`WKT` exports as
+#' 99-402 extended dimension (Z) types for Point, LineString, Polygon,
+#' MultiPoint, MultiLineString, MultiPolygon and GeometryCollection. For other
+#' geometry types, it is equivalent to using `WKB_ISO`/`WKT_ISO` (see
+#' \url{https://libgeos.org/specifications/wkb/}).
 #'
 #' \code{$wkbByteOrder}\cr
 #' Character string specifying the byte order for WKB geometries.

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -188,11 +188,12 @@ Polygons and MultiPolygons.
 
 \code{$returnGeomAs}\cr
 Character string specifying the return format of feature geometries.
-Must be one of \code{WKT}, \code{WKT_ISO}, \code{WKB} (the default), \code{WKB_ISO}, \code{TYPE_NAME}
-or \code{NONE}. Using \code{WKB}/\code{WKT} exports as 99-402 extended dimension (Z) types
-for Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon
-and GeometryCollection. For other geometry types, it is equivalent to using
-\code{WKB_ISO}/\code{WKT_ISO} (see \url{https://libgeos.org/specifications/wkb/}).
+Must be one of \code{WKT}, \code{WKT_ISO}, \code{WKB} (the default), \code{WKB_ISO},
+\code{SUMMARY} (GDAL >= 3.7), \code{TYPE_NAME} or \code{NONE}. Using \code{WKB}/\code{WKT} exports as
+99-402 extended dimension (Z) types for Point, LineString, Polygon,
+MultiPoint, MultiLineString, MultiPolygon and GeometryCollection. For other
+geometry types, it is equivalent to using \code{WKB_ISO}/\code{WKT_ISO} (see
+\url{https://libgeos.org/specifications/wkb/}).
 
 \code{$wkbByteOrder}\cr
 Character string specifying the byte order for WKB geometries.

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -133,6 +133,35 @@ test_that("read methods work correctly", {
     expect_false("POLYGON" %in% d[, geom_fld])
     expected_geoms <- rep("MULTIPOLYGON", lyr$getFeatureCount())
     expect_equal(d[, geom_fld], expected_geoms)
+    # returnGeomAs
+    lyr$returnGeomAs <- "WKB"
+    f <- lyr$getFeature(1)
+    expect_true(is.raw(f[[geom_fld]]))
+    f <- NULL
+    lyr$returnGeomAs <- "WKB_ISO"
+    f <- lyr$getFeature(1)
+    expect_true(is.raw(f[[geom_fld]]))
+    f <- NULL
+    lyr$returnGeomAs <- "WKT"
+    f <- lyr$getFeature(1)
+    expect_true(is.character(f[[geom_fld]]))
+    f <- NULL
+    lyr$returnGeomAs <- "WKT_ISO"
+    f <- lyr$getFeature(1)
+    expect_true(is.character(f[[geom_fld]]))
+    f <- NULL
+    lyr$returnGeomAs <- "TYPE_NAME"
+    f <- lyr$getFeature(1)
+    expect_true(is.character(f[[geom_fld]]))
+    f <- NULL
+    lyr$returnGeomAs <- "SUMMARY"
+    f <- lyr$getFeature(1)
+    expect_true(is.character(f[[geom_fld]]))
+    f <- NULL
+    lyr$returnGeomAs <- "NONE"
+    f <- lyr$getFeature(1)
+    expect_true(is.null(f[[geom_fld]]))
+    f <- NULL
 
     lyr$close()
     rm(lyr)


### PR DESCRIPTION
`$returnGeomAs`
#' Character string specifying the return format of feature geometries.
#' Must be one of `WKT`, `WKT_ISO`, `WKB` (the default), `WKB_ISO`,
#' `SUMMARY` (GDAL >= 3.7), `TYPE_NAME` or `NONE`. Using `WKB`/`WKT` exports as
#' 99-402 extended dimension (Z) types for Point, LineString, Polygon,
#' MultiPoint, MultiLineString, MultiPolygon and GeometryCollection. For other
#' geometry types, it is equivalent to using `WKB_ISO`/`WKT_ISO` (see
#' \url{https://libgeos.org/specifications/wkb/}).

for example with summary:
```r
lyr$returnGeomAs <- "SUMMARY"
lyr$getNextFeature()

#> $FID
#> integer64
#> [1] 1
#> 
#> $Event_ID
#> [1] "MO3742409133620170304"
#> 
#> $Map_ID
#> integer64
#> [1] 10011338
#> 
#> $Ig_Date
#> [1] "2017-03-04"
#> 
#> $geometry
#> [1] "MULTIPOLYGON : 2 geometries: POLYGON : 459 points POLYGON : 224 points"
```