### PR TITLE
`GDALVector`: add method `$setSelectedFields()`, alternative to `$setIgnoredFields()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9403
+Version: 1.11.1.9410
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9403 (dev)
+# gdalraster 1.11.1.9410 (dev)
+
+* `GDALVector`: add method `$setSelectedFields()`, alternative to `$setIgnoredFields()` (2024-09-10)
 
 * (internal) `GDALVector`: use `$setIgnoredFields()` when `$returnGeomAs` is set to `NONE` (2024-09-09)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -78,6 +78,7 @@
 #' lyr$getDriverLongName()
 #'
 #' lyr$getName()
+#' lyr$getFieldNames()
 #' lyr$testCapability()
 #' lyr$getFIDColumn()
 #' lyr$getGeomType()
@@ -89,6 +90,7 @@
 #' lyr$setAttributeFilter(query)
 #' lyr$getAttributeFilter()
 #' lyr$setIgnoredFields(fields)
+#' lyr$setSelectedFields(fields)
 #'
 #' lyr$setSpatialFilter(wkt)
 #' lyr$setSpatialFilterRect(bbox)
@@ -218,6 +220,9 @@
 #' \code{$getName()}\cr
 #' Returns the layer name.
 #'
+#' #' \code{$getFieldNames()}\cr
+#' Returns a character vector of the layer's field names.
+#'
 #' \code{$testCapability()}\cr
 #' Tests whether the layer supports named capabilities based on the current
 #' read/write access. Returns a list of capabilities with values `TRUE` or
@@ -289,7 +294,8 @@
 #'
 #' \code{$setIgnoredFields(fields)}\cr
 #' Set which fields can be omitted when retrieving features from the layer.
-#' The `fields` argument is a character vector of field names.
+#' The `fields` argument is a character vector of field names. Passing an
+#' empty string (`""`) for `fields` will reset to no ignored fields.
 #' If the format driver supports this functionality (testable using
 #' `$testCapability()$IgnoreFields`), it will not fetch the specified fields
 #' in subsequent calls to `$getFeature()` / `$getNextFeature()` / `$fetch()`,
@@ -300,6 +306,17 @@
 #' should generally not be set as ignored fields, as most drivers (such as
 #' those relying on the OGR SQL engine) will be unable to correctly evaluate
 #' the attribute filter. No return value, called for side effects.
+#'
+#' \code{$setSelectedFields(fields)}\cr
+#' Set which fields will be included when retrieving features from the layer.
+#' The `fields` argument is a character vector of field names. Passing an
+#' empty string (`""`) for `fields` will reset to no ignored fields.
+#' See the `$setIgnoredFields()` method above for more information. The data
+#' source must provide IgnoreFields capability in order to set selected
+#' fields. Note that geometry fields, if desired, must be specified when setting
+#' selected fields, either by including named geometry field(s) or the special
+#' field `"OGR_GEOMETRY"` in the `fields` argument.
+#' No return value, called for side effects.
 #'
 #' \code{$setSpatialFilter(wkt)}\cr
 #' Sets a new spatial filter from a geometry in WKT format. This method sets

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -88,6 +88,7 @@ lyr$getDriverShortName()
 lyr$getDriverLongName()
 
 lyr$getName()
+lyr$getFieldNames()
 lyr$testCapability()
 lyr$getFIDColumn()
 lyr$getGeomType()
@@ -99,6 +100,7 @@ lyr$getLayerDefn()
 lyr$setAttributeFilter(query)
 lyr$getAttributeFilter()
 lyr$setIgnoredFields(fields)
+lyr$setSelectedFields(fields)
 
 lyr$setSpatialFilter(wkt)
 lyr$setSpatialFilterRect(bbox)
@@ -234,6 +236,9 @@ Returns the long name of the vector format driver.
 \code{$getName()}\cr
 Returns the layer name.
 
+#' \code{$getFieldNames()}\cr
+Returns a character vector of the layer's field names.
+
 \code{$testCapability()}\cr
 Tests whether the layer supports named capabilities based on the current
 read/write access. Returns a list of capabilities with values \code{TRUE} or
@@ -305,7 +310,8 @@ if an attribute filter is not set.
 
 \code{$setIgnoredFields(fields)}\cr
 Set which fields can be omitted when retrieving features from the layer.
-The \code{fields} argument is a character vector of field names.
+The \code{fields} argument is a character vector of field names. Passing an
+empty string (\code{""}) for \code{fields} will reset to no ignored fields.
 If the format driver supports this functionality (testable using
 \verb{$testCapability()$IgnoreFields}), it will not fetch the specified fields
 in subsequent calls to \verb{$getFeature()} / \verb{$getNextFeature()} / \verb{$fetch()},
@@ -316,6 +322,17 @@ fields are ignored. Note that fields that are used in an attribute filter
 should generally not be set as ignored fields, as most drivers (such as
 those relying on the OGR SQL engine) will be unable to correctly evaluate
 the attribute filter. No return value, called for side effects.
+
+\code{$setSelectedFields(fields)}\cr
+Set which fields will be included when retrieving features from the layer.
+The \code{fields} argument is a character vector of field names. Passing an
+empty string (\code{""}) for \code{fields} will reset to no ignored fields.
+See the \verb{$setIgnoredFields()} method above for more information. The data
+source must provide IgnoreFields capability in order to set selected
+fields. Note that geometry fields, if desired, must be specified when setting
+selected fields, either by including named geometry field(s) or the special
+field \code{"OGR_GEOMETRY"} in the \code{fields} argument.
+No return value, called for side effects.
 
 \code{$setSpatialFilter(wkt)}\cr
 Sets a new spatial filter from a geometry in WKT format. This method sets

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -459,7 +459,7 @@ void GDALVector::setSelectedFields(const Rcpp::RObject &fields) {
     checkAccess_(GA_ReadOnly);
 
     if (!OGR_L_TestCapability(m_hLayer, OLCIgnoreFields)) {
-        Rcpp::Rcout << "capability to ignore fields is needed to set selected"
+        Rcpp::Rcerr << "capability to ignore fields is needed to set selected"
                 << std::endl;
         Rcpp::Rcerr << "this layer does not have IgnoreFields capability"
                 << std::endl;
@@ -480,7 +480,7 @@ void GDALVector::setSelectedFields(const Rcpp::RObject &fields) {
     // if special field "OGR_GEOMETRY" is used here, we need to replace with
     // the geometry column name
     for (auto& x : fields_in) {
-        if (x == "OGR_GEOMETRY" || x == "ogr_geometry")
+        if (EQUAL(x, "OGR_GEOMETRY"))
             x = getGeometryColumn();
     }
 

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -191,6 +191,12 @@ std::string GDALVector::getName() const {
     return OGR_L_GetName(m_hLayer);
 }
 
+Rcpp::CharacterVector GDALVector::getFieldNames() const {
+    checkAccess_(GA_ReadOnly);
+
+    return m_field_names;
+}
+
 Rcpp::List GDALVector::testCapability() const {
     checkAccess_(GA_ReadOnly);
 
@@ -419,7 +425,7 @@ void GDALVector::setIgnoredFields(const Rcpp::RObject &fields) {
     checkAccess_(GA_ReadOnly);
 
     if (!OGR_L_TestCapability(m_hLayer, OLCIgnoreFields)) {
-        Rcpp::Rcerr << "this layer does not have ignored fields capability"
+        Rcpp::Rcerr << "this layer does not have IgnoreFields capability"
                 << std::endl;
         return;
     }
@@ -427,24 +433,73 @@ void GDALVector::setIgnoredFields(const Rcpp::RObject &fields) {
     if (fields.isNULL() || !Rcpp::is<Rcpp::CharacterVector>(fields))
         Rcpp::stop("'fields' must be a character vector");
 
-    Rcpp::CharacterVector fields_(fields);
-    std::vector<const char *> fields_in(fields_.begin(), fields_.end());
-    fields_in.push_back(nullptr);
+    Rcpp::CharacterVector fields_in(fields);
+    std::vector<const char *> oFields(fields_in.begin(), fields_in.end());
+    oFields.push_back(nullptr);
 
-    if (fields_in[0] == nullptr || EQUAL(fields_in[0], "")) {
+    if (oFields[0] == nullptr || EQUAL(oFields[0], "")) {
+        // reset to none
         OGR_L_SetIgnoredFields(m_hLayer, nullptr);
         m_ignored_fields = Rcpp::CharacterVector::create();
+        return;
     }
     else {
-        if (OGR_L_SetIgnoredFields(m_hLayer, fields_in.data()) != OGRERR_NONE) {
+        if (OGR_L_SetIgnoredFields(m_hLayer, oFields.data()) != OGRERR_NONE) {
             Rcpp::Rcerr << "not all field names could be resolved"
                 << std::endl;
-            return;
         }
         else {
-            m_ignored_fields = Rcpp::clone(fields_);
-            return;
+            m_ignored_fields = Rcpp::clone(fields_in);
         }
+        return;
+    }
+}
+
+void GDALVector::setSelectedFields(const Rcpp::RObject &fields) {
+    checkAccess_(GA_ReadOnly);
+
+    if (!OGR_L_TestCapability(m_hLayer, OLCIgnoreFields)) {
+        Rcpp::Rcout << "capability to ignore fields is needed to set selected"
+                << std::endl;
+        Rcpp::Rcerr << "this layer does not have IgnoreFields capability"
+                << std::endl;
+        return;
+    }
+
+    if (fields.isNULL() || !Rcpp::is<Rcpp::CharacterVector>(fields))
+        Rcpp::stop("'fields' must be a character vector");
+
+    Rcpp::CharacterVector fields_in(fields);
+    if (EQUAL(fields_in[0], "")) {
+        // reset to none
+        OGR_L_SetIgnoredFields(m_hLayer, nullptr);
+        m_ignored_fields = Rcpp::CharacterVector::create();
+        return;
+    }
+
+    // if special field "OGR_GEOMETRY" is used here, we need to replace with
+    // the geometry column name
+    for (auto& x : fields_in) {
+        if (x == "OGR_GEOMETRY" || x == "ogr_geometry")
+            x = getGeometryColumn();
+    }
+
+    Rcpp::CharacterVector ignore_fields = Rcpp::setdiff(m_field_names,
+                                                        fields_in);
+
+    std::vector<const char *> oFields(ignore_fields.begin(),
+                                      ignore_fields.end());
+    oFields.push_back(nullptr);
+
+    // reset first
+    OGR_L_SetIgnoredFields(m_hLayer, nullptr);
+    OGRErr err = OGR_L_SetIgnoredFields(m_hLayer, oFields.data());
+    if (err != OGRERR_NONE) {
+        Rcpp::Rcerr << "not all field names could be resolved"
+                << std::endl;
+    }
+    else {
+        m_ignored_fields = Rcpp::clone(ignore_fields);
     }
 }
 
@@ -2579,6 +2634,8 @@ RCPP_MODULE(mod_GDALVector) {
         "Return the long name of the format driver")
     .const_method("getName", &GDALVector::getName,
         "Return the layer name")
+    .const_method("getFieldNames", &GDALVector::getFieldNames,
+        "Return a character vector of the layer's field names")
     .const_method("testCapability", &GDALVector::testCapability,
         "Test if this layer supports the named capability")
     .const_method("getFIDColumn", &GDALVector::getFIDColumn,
@@ -2599,6 +2656,8 @@ RCPP_MODULE(mod_GDALVector) {
         "Get the attribute filter string (or empty string if not set")
     .method("setIgnoredFields", &GDALVector::setIgnoredFields,
         "Set which fields can be omitted when retrieving features")
+    .method("setSelectedFields", &GDALVector::setSelectedFields,
+        "Set which fields to include when retrieving features")
     .method("setSpatialFilter", &GDALVector::setSpatialFilter,
         "Set a new spatial filter from a geometry in WKT format")
     .method("setSpatialFilterRect", &GDALVector::setSpatialFilterRect,

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -55,6 +55,7 @@ class GDALVector {
     std::string getDriverLongName() const;
 
     std::string getName() const;
+    Rcpp::CharacterVector getFieldNames() const;
     Rcpp::List testCapability() const;
     std::string getFIDColumn() const;
     std::string getGeomType() const;
@@ -66,6 +67,7 @@ class GDALVector {
     void setAttributeFilter(const std::string &query);
     std::string getAttributeFilter() const;
     void setIgnoredFields(const Rcpp::RObject &fields);
+    void setSelectedFields(const Rcpp::RObject &fields);
 
     void setSpatialFilter(const std::string &wkt);
     void setSpatialFilterRect(const Rcpp::RObject &bbox);


### PR DESCRIPTION
GDAL API provides only `OGRLayer::SetIgnoredFields()` for reasons given in RFC 29.

`GDALVector::setSelectedFields()` sets the fields to include. Other than the specified fields will be ignored. This mimics the behavior of the `-select` argument in the `ogr2ogr` command line utility.

`$setSelectedFields(fields)`
#' Set which fields will be included when retrieving features from the layer.
#' The `fields` argument is a character vector of field names. Passing an
#' empty string (`""`) for `fields` will reset to no ignored fields.
#' See the `$setIgnoredFields()` method above for more information. The data
#' source must provide IgnoreFields capability in order to set selected
#' fields. Note that geometry fields, if desired, must be specified when setting
#' selected fields, either by including named geometry field(s) or the special
#' field `"OGR_GEOMETRY"` in the `fields` argument.
#' No return value, called for side effects.

This PR also adds `GDALVector::getFieldNames()`, a convenience method as alternative to the list structure returned by `getLayerDefn()`.

`$getFieldNames()`
#' Returns a character vector of the layer's field names.
