### PR TITLE
Add `return_obj` argument in `ogr_ds_create()` and `ogr_layer_create()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9410
+Version: 1.11.1.9420
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9410 (dev)
+# gdalraster 1.11.1.9420 (dev)
+
+* add `return_obj` argument in `ogr_ds_create()` and `ogr_layer_create()`, `TRUE` to return a writable `GDALVector` object on the created layer (2024-09-11)
 
 * `GDALVector`: add method `$setSelectedFields()`, alternative to `$setIgnoredFields()` (2024-09-10)
 

--- a/R/gdal_create.R
+++ b/R/gdal_create.R
@@ -24,7 +24,7 @@
 #' returned, otherwise returns a logical value. Defaults to `FALSE`.
 #' @returns By default, returns a logical value indicating success (invisible
 #' \code{TRUE}, output written to `dst_filename`). An error is raised if the
-#' operation fails. An object of class [`GDALRaster`][GDALRaster] opened on the
+#' operation fails. An object of class [`GDALRaster`][GDALRaster] open on the
 #' output dataset will be returned if `return_obj = TRUE`.
 #' @note
 #' `dst_filename` may be an empty string (`""`) with `format = "MEM"` and
@@ -61,6 +61,12 @@
 create <- function(format, dst_filename, xsize, ysize, nbands, dataType,
                    options = NULL, return_obj = FALSE) {
 
+    if (is.null(return_obj))
+        stop("'return_obj' must be a logical value", call. = FALSE)
+
+    if (!is.logical(return_obj) || length(return_obj) > 1)
+        stop("'return_obj' must be a logical scalar", call. = FALSE)
+
     ds <- .create(format, dst_filename, xsize, ysize, nbands, dataType, options)
 
     if (return_obj) {
@@ -96,10 +102,10 @@ create <- function(format, dst_filename, xsize, ysize, nbands, dataType,
 #' displayed. Defaults to `FALSE`.
 #' @param return_obj Logical scalar. If `TRUE`, an object of class
 #' [`GDALRaster`][GDALRaster] opened on the newly created dataset will be
-#' returned, otherwise returns a logical value. Defaults to `FALSE`.
+#' returned. Defaults to `FALSE`.
 #' @returns By default, returns a logical value indicating success (invisible
 #' \code{TRUE}, output written to `dst_filename`). An error is raised if the
-#' operation fails. An object of class [`GDALRaster`][GDALRaster] opened on the
+#' operation fails. An object of class [`GDALRaster`][GDALRaster] open on the
 #' output dataset will be returned if `return_obj = TRUE`.
 #' @note
 #' `dst_filename` may be an empty string (`""`) with `format = "MEM"` and
@@ -140,6 +146,12 @@ createCopy <- function(format, dst_filename, src_filename, strict = FALSE,
         stop("'src_filename' must be a character string or 'GDALRaster' object",
              call. = FALSE)
     }
+
+    if (is.null(return_obj))
+        stop("'return_obj' must be a logical value", call. = FALSE)
+
+    if (!is.logical(return_obj) || length(return_obj) > 1)
+        stop("'return_obj' must be a logical scalar", call. = FALSE)
 
     ds <- .createCopy(format, dst_filename, src_ds, strict, options, quiet)
 

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -1555,8 +1555,8 @@ polygonize <- function(raster_file,
         mask_file <- ""
     }
 
-    if (!.ogr_ds_exists(out_dsn, with_update=TRUE)) {
-        if (.ogr_ds_exists(out_dsn) && !overwrite) {
+    if (!ogr_ds_exists(out_dsn, with_update = TRUE)) {
+        if (ogr_ds_exists(out_dsn) && !overwrite) {
             msg <- "'out_dsn' exists but cannot be updated.\n"
             msg <- paste0(msg, "You may need to remove it first, ")
             msg <- paste0(msg, "or use 'overwrite = TRUE'.")
@@ -1564,13 +1564,13 @@ polygonize <- function(raster_file,
         }
     }
 
-    if (.ogr_ds_exists(out_dsn, with_update=TRUE) && overwrite) {
+    if (ogr_ds_exists(out_dsn, with_update = TRUE) && overwrite) {
         deleted <- FALSE
-        if (.ogr_layer_exists(out_dsn, out_layer)) {
-            deleted <- .ogr_layer_delete(out_dsn, out_layer)
+        if (ogr_layer_exists(out_dsn, out_layer)) {
+            deleted <- ogr_layer_delete(out_dsn, out_layer)
         }
         if (!deleted) {
-            if (.ogr_ds_layer_count(out_dsn) == 1) {
+            if (ogr_ds_layer_count(out_dsn) == 1) {
                 if (vsi_stat(out_dsn, "type") == "file")
                     deleted <- deleteDataset(out_dsn)
             }
@@ -1580,33 +1580,35 @@ polygonize <- function(raster_file,
         }
     }
 
-    if (.ogr_layer_exists(out_dsn, out_layer)) {
+    if (ogr_layer_exists(out_dsn, out_layer)) {
         if (!is.null(lco)) {
             warning("'lco' ignored since the layer already exists",
                     call. = FALSE)
         }
     }
 
-    if (!.ogr_ds_exists(out_dsn, with_update=TRUE)) {
+    if (!ogr_ds_exists(out_dsn, with_update = TRUE)) {
         if (is.null(out_fmt))
             out_fmt <- .getOGRformat(out_dsn)
         if (is.null(out_fmt)) {
             message("format driver cannot be determined for: ", out_dsn)
             stop("specify 'out_fmt' to create a new dataset", call. = FALSE)
         }
-        if (!.create_ogr(out_fmt, out_dsn, 0, 0, 0, "Unknown",
-                         out_layer, "POLYGON", srs, fld_name, "OFTInteger",
-                         dsco, lco)) {
+        if (!ogr_ds_create(out_fmt, out_dsn, out_layer, geom_type = "POLYGON",
+                           srs = srs, fld_name = fld_name,
+                           fld_type = "OFTInteger", dsco= dsco, lco = lco)) {
+
             stop("failed to create 'out_dsn'", call. = FALSE)
         }
     }
 
-    if (!.ogr_layer_exists(out_dsn, out_layer)) {
-        res <- .ogr_layer_create(out_dsn, out_layer, NULL, "POLYGON", srs, lco)
+    if (!ogr_layer_exists(out_dsn, out_layer)) {
+        res <- ogr_layer_create(out_dsn, out_layer, NULL, "POLYGON", srs, lco)
         if (!res)
             stop("failed to create 'out_layer'", call. = FALSE)
         if (fld_name != "") {
-            res <- .ogr_field_create(out_dsn, out_layer, fld_name, "OFTInteger")
+            res <- ogr_field_create(out_dsn, out_layer, fld_name = fld_name,
+                                    fld_type = "OFTInteger")
             if (!res)
                 stop("failed to create the output field", call. = FALSE)
         }

--- a/R/ogr_define.R
+++ b/R/ogr_define.R
@@ -262,7 +262,7 @@ ogr_def_geom_field <- function(geom_type, srs = NULL, is_nullable = NULL,
 
 #' @name ogr_define
 #' @export
-ogr_def_layer <- function(geom_type, geom_fld_name = "geom", srs = NULL) {
+ogr_def_layer <- function(geom_type, geom_fld_name = "geometry", srs = NULL) {
 
     defn <- list()
 

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -51,8 +51,11 @@
 #' The attribute fields and geometry field(s) to create can be specified as a
 #' feature class definition (`layer_defn` as list, see [ogr_define]), or
 #' alternatively, by giving the `geom_type` and `srs`, optionally along with
-#' one `fld_name` and `fld_type` to be created in the layer. Returns a logical
-#' scalar, `TRUE` indicating success.
+#' one `fld_name` and `fld_type` to be created in the layer.
+#' By default, returns logical `TRUE` indicating success (output written to
+#' `dst_filename`), or an object of class [`GDALVector`][GDALVector] for the
+#' output layer will be returned if `return_obj = TRUE`. An error is raised if
+#' the operation fails.
 #'
 #' `ogr_ds_layer_count()` returns the number of layers in a vector dataset.
 #'
@@ -81,7 +84,9 @@
 #' field names and their definitions (see [ogr_define]).
 #' (Note: use `ogr_ds_create()` to create single-layer formats such as "ESRI
 #' Shapefile", "FlatGeobuf", "GeoJSON", etc.)
-#' Returns a logical scalar, `TRUE` indicating success.
+#' By default, returns logical `TRUE` indicating success, or an object of class
+#' [`GDALVector`][GDALVector] will be returned if `return_obj = TRUE`.
+#' An error is raised if the operation fails.
 #'
 #' `ogr_layer_field_names()` returns a character vector of field names on a
 #' layer, or `NULL` if no fields are found.
@@ -189,6 +194,10 @@
 #' given. The `"SQLite"` dialect can also be used (see Note).
 #' @param overwrite Logical scalar. `TRUE` to overwrite `dsn` if it already
 #' exists when calling `ogr_ds_create()`. Default is `FALSE`.
+#' @param return_obj Logical scalar. If `TRUE`, an object of class
+#' [`GDALVector`][GDALVector] open on the newly created layer will be
+#' returned. Defaults to `FALSE`. Must be used with either the `layer` or
+#' `layer_defn` arguments.
 #'
 #' @note
 #' The OGR SQL document linked under **See Also** contains information on the
@@ -345,38 +354,89 @@ ogr_ds_test_cap <- function(dsn, with_update = TRUE) {
 ogr_ds_create <- function(format, dsn, layer = NULL, layer_defn = NULL,
                           geom_type = NULL, srs = NULL, fld_name = NULL,
                           fld_type = NULL, dsco = NULL, lco = NULL,
-                          overwrite = FALSE) {
+                          overwrite = FALSE, return_obj = FALSE) {
 
+    # format
     if (!(is.character(format) && length(format) == 1))
         stop("'format' must be a length-1 character vector", call. = FALSE)
+    # dsn
     if (!(is.character(dsn) && length(dsn) == 1))
         stop("'dsn' must be a length-1 character vector", call. = FALSE)
     if (vsi_stat(dsn) && !overwrite)
-        stop("'dsn' exists and 'overwrite' is FALSE", call. = FALSE)
+        stop("'dsn' exists but 'overwrite' is `FALSE`", call. = FALSE)
+    # layer
     if (is.null(layer))
         layer <- ""
     if (!(is.character(layer) && length(layer) == 1))
         stop("'layer' must be a length-1 character vector", call. = FALSE)
+    # layer_defn
+    if (!is.null(layer_defn)) {
+        if (!is.list(layer_defn) || is.data.frame(layer_defn)) {
+            stop("'layer_defn' must be a list object", call. = FALSE)
+        }
+    }
+    # geom_type
     if (is.null(geom_type))
         geom_type <- ""
     if (!(is.character(geom_type) && length(geom_type) == 1))
         stop("'geom_type' must be a length-1 character vector", call. = FALSE)
+    # srs
     if (is.null(srs))
         srs <- ""
+    if (!(is.character(srs) && length(srs) == 1))
+        stop("'srs' must be a length-1 character vector", call. = FALSE)
+    # fld_name
     if (is.null(fld_name))
         fld_name <- ""
+    if (!(is.character(fld_name) && length(fld_name) == 1))
+        stop("'fld_name' must be a length-1 character vector", call. = FALSE)
+    # fld_type
     if (is.null(fld_type))
         fld_type <- ""
+    if (!(is.character(fld_type) && length(fld_type) == 1))
+        stop("'fld_type' must be a length-1 character vector", call. = FALSE)
+    # dsco
+    if (!is.null(dsco)) {
+        if (!is.character(dsco))
+            stop("'dsco' must be a character vector", call. = FALSE)
+    }
+    # lco
+    if (!is.null(lco)) {
+        if (!is.character(lco))
+            stop("'lco' must be a character vector", call. = FALSE)
+    }
+    # overwrite
+    if (is.null(overwrite))
+        stop("'overwrite' must be a logical value", call. = FALSE)
+    if (!is.logical(overwrite) || length(overwrite) > 1)
+        stop("'overwrite' must be a logical scalar", call. = FALSE)
+    # return_obj
+    if (is.null(return_obj))
+        stop("'return_obj' must be a logical value", call. = FALSE)
+    if (!is.logical(return_obj) || length(return_obj) > 1)
+        stop("'return_obj' must be a logical scalar", call. = FALSE)
+    if (return_obj && layer == "" && is.null(layer_defn)) {
+        stop("'layer' or 'layer_defn' must be given with 'return_obj = TRUE'",
+             call. = FALSE)
+    }
 
     if (is.null(layer_defn)) {
-        return(.create_ogr(format, dsn, 0, 0, 0, "Unknown",
+        lyr <- .create_ogr(format, dsn, 0, 0, 0, "Unknown",
                            layer, geom_type, srs, fld_name, fld_type,
-                           dsco, lco, NULL))
+                           dsco, lco, NULL)
+
     } else {
-        return(.create_ogr(format, dsn, 0, 0, 0, "Unknown",
+        lyr <- .create_ogr(format, dsn, 0, 0, 0, "Unknown",
                            layer = layer, geom_type = "", srs = "",
                            fld_name = "", fld_type = "",
-                           dsco = dsco, lco = lco, layer_defn = layer_defn))
+                           dsco = dsco, lco = lco, layer_defn = layer_defn)
+    }
+
+    if (return_obj) {
+        return(lyr)
+    } else {
+        lyr$close()
+        return(TRUE)
     }
 }
 
@@ -423,8 +483,9 @@ ogr_layer_test_cap <- function(dsn, layer, with_update = TRUE) {
 #' @name ogr_manage
 #' @export
 ogr_layer_create <- function(dsn, layer, layer_defn = NULL, geom_type = NULL,
-                             srs = NULL, lco = NULL) {
+                             srs = NULL, lco = NULL, return_obj = FALSE) {
 
+    # dsn / layer
     if (!(is.character(dsn) && length(dsn) == 1))
         stop("'dsn' must be a length-1 character vector", call. = FALSE)
     if (!(is.character(layer) && length(layer) == 1))
@@ -433,11 +494,14 @@ ogr_layer_create <- function(dsn, layer, layer_defn = NULL, geom_type = NULL,
         stop("'dsn' does not exist, or no update access", call. = FALSE)
     if (ogr_layer_exists(dsn, layer))
         stop("'layer' already exists", call. = FALSE)
+    # layer_defn
+    if (!is.null(layer_defn)) {
+        if (!is.list(layer_defn) || is.data.frame(layer_defn)) {
+            stop("'layer_defn' must be a list object", call. = FALSE)
+        }
+    }
 
     if (!is.null(layer_defn)) {
-        if (!is.list(layer_defn))
-            stop("'layer_defn' must be a list", call. = FALSE)
-
         # using layer_defn so get geom_type and srs from the geom field defn
         has_geom_fld_defn <- FALSE
         for (nm in names(layer_defn)) {
@@ -463,20 +527,40 @@ ogr_layer_create <- function(dsn, layer, layer_defn = NULL, geom_type = NULL,
         }
     }
 
+    # geom_type
     if (is.null(geom_type)) {
-        message("geometry type not specified, using 'UNKNOWN'", call. = FALSE)
+        warning("geometry type not specified, using 'UNKNOWN'", call. = FALSE)
         geom_type <- "UNKNOWN"
     }
-
+    # srs
     if (is.null(srs))
         srs <- ""
+    if (!(is.character(srs) && length(srs) == 1))
+        stop("'srs' must be a length-1 character vector", call. = FALSE)
+    # lco
+    if (!is.null(lco)) {
+        if (!is.character(lco))
+            stop("'lco' must be a character vector", call. = FALSE)
+    }
+    # return_obj
+    if (is.null(return_obj))
+        stop("'return_obj' must be a logical value", call. = FALSE)
+    if (!is.logical(return_obj) || length(return_obj) > 1)
+        stop("'return_obj' must be a logical scalar", call. = FALSE)
 
-    return(.ogr_layer_create(dsn = dsn,
+    lyr <- .ogr_layer_create(dsn = dsn,
                              layer = layer,
                              layer_defn = layer_defn,
                              geom_type = geom_type,
                              srs = srs,
-                             options = lco))
+                             options = lco)
+
+    if (return_obj) {
+        return(lyr)
+    } else {
+        lyr$close()
+        return(TRUE)
+    }
 }
 
 #' @name ogr_manage

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -44,7 +44,7 @@ returned, otherwise returns a logical value. Defaults to \code{FALSE}.}
 \value{
 By default, returns a logical value indicating success (invisible
 \code{TRUE}, output written to \code{dst_filename}). An error is raised if the
-operation fails. An object of class \code{\link{GDALRaster}} opened on the
+operation fails. An object of class \code{\link{GDALRaster}} open on the
 output dataset will be returned if \code{return_obj = TRUE}.
 }
 \description{

--- a/man/createCopy.Rd
+++ b/man/createCopy.Rd
@@ -39,12 +39,12 @@ displayed. Defaults to \code{FALSE}.}
 
 \item{return_obj}{Logical scalar. If \code{TRUE}, an object of class
 \code{\link{GDALRaster}} opened on the newly created dataset will be
-returned, otherwise returns a logical value. Defaults to \code{FALSE}.}
+returned. Defaults to \code{FALSE}.}
 }
 \value{
 By default, returns a logical value indicating success (invisible
 \code{TRUE}, output written to \code{dst_filename}). An error is raised if the
-operation fails. An object of class \code{\link{GDALRaster}} opened on the
+operation fails. An object of class \code{\link{GDALRaster}} open on the
 output dataset will be returned if \code{return_obj = TRUE}.
 }
 \description{

--- a/man/ogr_define.Rd
+++ b/man/ogr_define.Rd
@@ -25,7 +25,7 @@ ogr_def_geom_field(
   is_ignored = NULL
 )
 
-ogr_def_layer(geom_type, geom_fld_name = "geom", srs = NULL)
+ogr_def_layer(geom_type, geom_fld_name = "geometry", srs = NULL)
 }
 \arguments{
 \item{fld_type}{Character string containing the name of a field data type

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -348,101 +348,90 @@ dialect used. See the GDAL documentation for the "OGR SQL" and "SQLite"
 dialects for details.
 }
 \examples{
+## Create GeoPackage and manage schema
 dsn <- file.path(tempdir(), "test1.gpkg")
 ogr_ds_create("GPKG", dsn)
 ogr_ds_exists(dsn, with_update = TRUE)
-ogr_ds_layer_count(dsn)
+# dataset capabilities
 ogr_ds_test_cap(dsn)
-ogr_layer_exists(dsn, "layer1")
-if (ogr_ds_test_cap(dsn)$CreateLayer) {
-  opt <- c("GEOMETRY_NULLABLE=NO", "DESCRIPTION=test layer")
-  ogr_layer_create(dsn, "layer1", geom_type = "Polygon", srs = "EPSG:5070",
-                   lco = opt)
-}
-ogr_ds_layer_count(dsn)
-ogr_layer_exists(dsn, "layer1")
-ogr_ds_layer_names(dsn)
 
-ogr_layer_field_names(dsn, "layer1")
-ogr_field_index(dsn, "layer1", "field1")
-if (ogr_layer_test_cap(dsn, "layer1")$CreateField) {
-  ogr_field_create(dsn, "layer1", "field1",
-                   fld_type = "OFTInteger64",
-                   is_nullable = FALSE)
-  ogr_field_create(dsn, "layer1", "field2",
-                   fld_type = "OFTString")
-}
-ogr_field_index(dsn, "layer1", "field1")
-ogr_layer_field_names(dsn, "layer1")
+ogr_layer_create(dsn, layer = "layer1", geom_type = "Polygon",
+                 srs = "EPSG:5070")
+
+ogr_field_create(dsn, layer = "layer1",
+                 fld_name = "field1",
+                 fld_type = "OFTInteger64",
+                 is_nullable = FALSE)
+ogr_field_create(dsn, layer = "layer1",
+                 fld_name = "field2",
+                 fld_type = "OFTString")
+
+ogr_ds_layer_count(dsn)
+ogr_ds_layer_names(dsn)
+ogr_layer_field_names(dsn, layer = "layer1")
 
 # delete a field
 if (ogr_layer_test_cap(dsn, "layer1")$DeleteField) {
-  ogr_field_delete(dsn, "layer1", "field2")
+  ogr_field_delete(dsn, layer = "layer1", fld_name = "field2")
 }
+
 ogr_layer_field_names(dsn, "layer1")
 
-# define a feature class (layer definition)
+# define a feature class and create layer
 defn <- ogr_def_layer("Point", srs = epsg_to_wkt(4326))
 # add the attribute fields
-defn$fld1_name <- ogr_def_field("OFTInteger64",
-                                is_nullable = FALSE,
-                                is_unique = TRUE)
-defn$fld2_name <- ogr_def_field("OFTString",
+defn$id_field <- ogr_def_field(fld_type = "OFTInteger64",
+                               is_nullable = FALSE,
+                               is_unique = TRUE)
+defn$str_field <- ogr_def_field(fld_type = "OFTString",
                                 fld_width = 25,
                                 is_nullable = FALSE,
                                 default_value = "'a default string'")
-defn$third_field <- ogr_def_field("OFTReal",
-                                  default_value = "0.0")
+defn$numeric_field <- ogr_def_field(fld_type = "OFTReal",
+                                    default_value = "0.0")
 
-ogr_layer_create(dsn, "layer2", layer_defn = defn)
+ogr_layer_create(dsn, layer = "layer2", layer_defn = defn)
 ogr_ds_layer_names(dsn)
-ogr_layer_field_names(dsn, "layer2")
+ogr_layer_field_names(dsn, layer = "layer2")
 
 # add a field using SQL instead
-sql <- "ALTER TABLE layer2 ADD field4 float"
-ogr_execute_sql(dsn, sql)
-ogr_layer_field_names(dsn, "layer2")
+ogr_execute_sql(dsn, sql = "ALTER TABLE layer2 ADD field4 float")
 
 # rename a field
 if (ogr_layer_test_cap(dsn, "layer1")$AlterFieldDefn) {
-  ogr_field_rename(dsn, "layer2", "field4", "renamed_field")
+  ogr_field_rename(dsn, layer = "layer2",
+                   fld_name = "field4",
+                   new_name = "renamed_field")
 }
-ogr_layer_field_names(dsn, "layer2")
+ogr_layer_field_names(dsn, layer = "layer2")
 
 # GDAL >= 3.7
 if (as.integer(gdal_version()[2]) >= 3070000)
   ogrinfo(dsn, "layer2")
 
 \dontshow{deleteDataset(dsn)}
-# edit data using SQL
+## Edit data using SQL
 src <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")
 perims_shp <- file.path(tempdir(), "mtbs_perims.shp")
-ogr2ogr(src, perims_shp, src_layers = "mtbs_perims")
-ogr_ds_format(perims_shp)
-ogr_ds_layer_names(perims_shp)
-ogr_layer_field_names(perims_shp, "mtbs_perims")
+ogr2ogr(src_dsn = src, dst_dsn = perims_shp, src_layers = "mtbs_perims")
+ogr_ds_format(dsn = perims_shp)
+ogr_ds_layer_names(dsn = perims_shp)
+ogr_layer_field_names(dsn = perims_shp, layer = "mtbs_perims")
 
-if (ogr_layer_test_cap(perims_shp, "mtbs_perims")$CreateField) {
-  sql <- "ALTER TABLE mtbs_perims ADD burn_bnd_ha float"
-  ogr_execute_sql(perims_shp, sql)
-  # with GDAL >= 3.7, equivalent to:
-  # ogrinfo(perims_shp, cl_arg = c("-sql", sql), read_only = FALSE)
-}
+alt_tbl <- "ALTER TABLE mtbs_perims ADD burn_bnd_ha float"
+ogr_execute_sql(dsn = perims_shp, sql = alt_tbl)
 
-sql <- "UPDATE mtbs_perims SET burn_bnd_ha = (burn_bnd_ac / 2.471)"
-ogr_execute_sql(perims_shp, sql, dialect = "SQLite")
-ogr_layer_field_names(perims_shp, "mtbs_perims")
+upd <- "UPDATE mtbs_perims SET burn_bnd_ha = (burn_bnd_ac / 2.471)"
+ogr_execute_sql(dsn = perims_shp, sql = upd, dialect = "SQLite")
+ogr_layer_field_names(dsn = perims_shp, layer = "mtbs_perims")
 
 # if GDAL >= 3.7:
-#   ogrinfo(perims_shp, "mtbs_perims")
+#   ogrinfo(dsn = perims_shp, layer = "mtbs_perims")
 # or, for output incl. the feature data (omit the default "-so" arg):
-#   ogrinfo(perims_shp, "mtbs_perims", cl_arg = "-nomd")
+#   ogrinfo(dsn = perims_shp, layer = "mtbs_perims", cl_arg = "-nomd")
 \dontshow{deleteDataset(perims_shp)}
 }
 \seealso{
-\code{\link[=gdal_formats]{gdal_formats()}}, \code{\link[=has_spatialite]{has_spatialite()}}, \code{\link[=ogr_def_field]{ogr_def_field()}}, \code{\link[=ogr_def_layer]{ogr_def_layer()}},
-\code{\link[=ogrinfo]{ogrinfo()}}, \code{\link[=ogr2ogr]{ogr2ogr()}}
-
 OGR SQL dialect and SQLite SQL dialect:\cr
 \url{https://gdal.org/user/ogr_sql_sqlite_dialect.html}
 }

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -39,7 +39,8 @@ ogr_ds_create(
   fld_type = NULL,
   dsco = NULL,
   lco = NULL,
-  overwrite = FALSE
+  overwrite = FALSE,
+  return_obj = FALSE
 )
 
 ogr_ds_layer_count(dsn)
@@ -56,7 +57,8 @@ ogr_layer_create(
   layer_defn = NULL,
   geom_type = NULL,
   srs = NULL,
-  lco = NULL
+  lco = NULL,
+  return_obj = FALSE
 )
 
 ogr_layer_field_names(dsn, layer)
@@ -146,6 +148,11 @@ for \code{layer} (\code{"NAME=VALUE"} pairs).}
 
 \item{overwrite}{Logical scalar. \code{TRUE} to overwrite \code{dsn} if it already
 exists when calling \code{ogr_ds_create()}. Default is \code{FALSE}.}
+
+\item{return_obj}{Logical scalar. If \code{TRUE}, an object of class
+\code{\link{GDALVector}} open on the newly created layer will be
+returned. Defaults to \code{FALSE}. Must be used with either the \code{layer} or
+\code{layer_defn} arguments.}
 
 \item{new_name}{Character string containing a new name to assign.}
 
@@ -239,8 +246,11 @@ a layer, and optionally creating one or more fields on the layer.
 The attribute fields and geometry field(s) to create can be specified as a
 feature class definition (\code{layer_defn} as list, see \link{ogr_define}), or
 alternatively, by giving the \code{geom_type} and \code{srs}, optionally along with
-one \code{fld_name} and \code{fld_type} to be created in the layer. Returns a logical
-scalar, \code{TRUE} indicating success.
+one \code{fld_name} and \code{fld_type} to be created in the layer.
+By default, returns logical \code{TRUE} indicating success (output written to
+\code{dst_filename}), or an object of class \code{\link{GDALVector}} for the
+output layer will be returned if \code{return_obj = TRUE}. An error is raised if
+the operation fails.
 
 \code{ogr_ds_layer_count()} returns the number of layers in a vector dataset.
 
@@ -269,7 +279,9 @@ This function also accepts a feature class definition given as a list of
 field names and their definitions (see \link{ogr_define}).
 (Note: use \code{ogr_ds_create()} to create single-layer formats such as "ESRI
 Shapefile", "FlatGeobuf", "GeoJSON", etc.)
-Returns a logical scalar, \code{TRUE} indicating success.
+By default, returns logical \code{TRUE} indicating success, or an object of class
+\code{\link{GDALVector}} will be returned if \code{return_obj = TRUE}.
+An error is raised if the operation fails.
 
 \code{ogr_layer_field_names()} returns a character vector of field names on a
 layer, or \code{NULL} if no fields are found.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1151,7 +1151,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // create_ogr
-bool create_ogr(std::string format, std::string dst_filename, int xsize, int ysize, int nbands, std::string dataType, std::string layer, std::string geom_type, std::string srs, std::string fld_name, std::string fld_type, Rcpp::Nullable<Rcpp::CharacterVector> dsco, Rcpp::Nullable<Rcpp::CharacterVector> lco, Rcpp::Nullable<Rcpp::List> layer_defn);
+GDALVector create_ogr(std::string format, std::string dst_filename, int xsize, int ysize, int nbands, std::string dataType, std::string layer, std::string geom_type, std::string srs, std::string fld_name, std::string fld_type, Rcpp::Nullable<Rcpp::CharacterVector> dsco, Rcpp::Nullable<Rcpp::CharacterVector> lco, Rcpp::Nullable<Rcpp::List> layer_defn);
 RcppExport SEXP _gdalraster_create_ogr(SEXP formatSEXP, SEXP dst_filenameSEXP, SEXP xsizeSEXP, SEXP ysizeSEXP, SEXP nbandsSEXP, SEXP dataTypeSEXP, SEXP layerSEXP, SEXP geom_typeSEXP, SEXP srsSEXP, SEXP fld_nameSEXP, SEXP fld_typeSEXP, SEXP dscoSEXP, SEXP lcoSEXP, SEXP layer_defnSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -1222,7 +1222,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // ogr_layer_create
-bool ogr_layer_create(std::string dsn, std::string layer, Rcpp::Nullable<Rcpp::List> layer_defn, std::string geom_type, std::string srs, Rcpp::Nullable<Rcpp::CharacterVector> options);
+GDALVector ogr_layer_create(std::string dsn, std::string layer, Rcpp::Nullable<Rcpp::List> layer_defn, std::string geom_type, std::string srs, Rcpp::Nullable<Rcpp::CharacterVector> options);
 RcppExport SEXP _gdalraster_ogr_layer_create(SEXP dsnSEXP, SEXP layerSEXP, SEXP layer_defnSEXP, SEXP geom_typeSEXP, SEXP srsSEXP, SEXP optionsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/gdalraster_types.h
+++ b/src/gdalraster_types.h
@@ -2,5 +2,6 @@
 #define SRC_GDALRASTER_TYPES_H_
 
 #include "gdalraster.h"
+#include "gdalvector.h"
 
 #endif  // SRC_GDALRASTER_TYPES_H_

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -15,14 +15,17 @@
 
 // Predeclare some GDAL types until the public header is included
 #ifndef GDAL_H_INCLUDED
+#ifndef SRC_GDALRASTER_H_
 typedef void *GDALDatasetH;
+typedef enum {GA_ReadOnly = 0, GA_Update = 1} GDALAccess;
+#endif
 typedef void *OGRLayerH;
 typedef void *OGRFeatureH;
-typedef enum {GA_ReadOnly = 0, GA_Update = 1} GDALAccess;
 #endif
 
 class GDALVector {
  public:
+    GDALVector();
     explicit GDALVector(Rcpp::CharacterVector dsn);
     GDALVector(Rcpp::CharacterVector dsn, std::string layer);
     GDALVector(Rcpp::CharacterVector dsn, std::string layer, bool read_only);
@@ -137,6 +140,7 @@ class GDALVector {
 
     // methods for internal use not exposed to R
     void checkAccess_(GDALAccess access_needed) const;
+    void setDsn_(std::string dsn);
     GDALDatasetH getGDALDatasetH_() const;
     void setGDALDatasetH_(const GDALDatasetH hDs, bool with_update);
     OGRLayerH getOGRLayerH_() const;

--- a/src/ogr_util.h
+++ b/src/ogr_util.h
@@ -10,6 +10,8 @@
 #include <string>
 #include "rcpp_util.h"
 
+#include "gdalvector.h"
+
 #ifdef GDAL_H_INCLUDED
 // map OGRwkbGeometryType enum to string names for use in R
 const std::map<std::string, OGRwkbGeometryType> MAP_OGR_GEOM_TYPE{
@@ -146,13 +148,14 @@ std::string ogr_ds_format(std::string dsn);
 
 SEXP ogr_ds_test_cap(std::string dsn, bool with_update);
 
-bool create_ogr(std::string format, std::string dst_filename,
-                int xsize, int ysize, int nbands, std::string dataType,
-                std::string layer, std::string geom_type, std::string srs,
-                std::string fld_name, std::string fld_type,
-                Rcpp::Nullable<Rcpp::CharacterVector> dsco,
-                Rcpp::Nullable<Rcpp::CharacterVector> lco,
-                Rcpp::Nullable<Rcpp::List> layer_defn);
+GDALVector create_ogr(std::string format, std::string dst_filename,
+                      int xsize, int ysize, int nbands, std::string dataType,
+                      std::string layer, std::string geom_type,
+                      std::string srs, std::string fld_name,
+                      std::string fld_type,
+                      Rcpp::Nullable<Rcpp::CharacterVector> dsco,
+                      Rcpp::Nullable<Rcpp::CharacterVector> lco,
+                      Rcpp::Nullable<Rcpp::List> layer_defn);
 
 int ogr_ds_layer_count(std::string dsn);
 
@@ -169,10 +172,10 @@ OGRLayerH CreateLayer_(GDALDatasetH hDS, std::string layer,
                        std::string geom_type, std::string srs,
                        Rcpp::Nullable<Rcpp::CharacterVector> options);
 
-bool ogr_layer_create(std::string dsn, std::string layer,
-                       Rcpp::Nullable<Rcpp::List> layer_defn,
-                       std::string geom_type, std::string srs,
-                       Rcpp::Nullable<Rcpp::CharacterVector> options);
+GDALVector ogr_layer_create(std::string dsn, std::string layer,
+                            Rcpp::Nullable<Rcpp::List> layer_defn,
+                            std::string geom_type, std::string srs,
+                            Rcpp::Nullable<Rcpp::CharacterVector> options);
 
 bool ogr_layer_rename(std::string dsn, std::string layer,
                       std::string new_name);

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -647,9 +647,11 @@ test_that("feature write methods work", {
     defn$real_field <- ogr_def_field("OFTReal")
     defn$str_field <- ogr_def_field("OFTString")
 
-    expect_no_error(lyr <- ogr_ds_create("GeoJSON", dsn5, layer_defn = defn,
+    expect_no_error(lyr <- ogr_ds_create("GeoJSON", dsn5, "test_layer",
+                                         layer_defn = defn,
                                          lco = "WRITE_BBOX=YES",
-                                         overwrite = TRUE, return_obj = TRUE))
+                                         overwrite = TRUE,
+                                         return_obj = TRUE))
 
     feat1 <- list()
     feat1$real_field <- 0.123

--- a/tests/testthat/test-ogr_manage.R
+++ b/tests/testthat/test-ogr_manage.R
@@ -2,7 +2,7 @@ test_that("OGR management utilities work", {
     # these tests assume GDAL was built with libsqlite3 which is optional
     # this should be a safe assumption since PROJ requires libsqlite3
 
-    # GPKG
+    ## GPKG
     dsn <- tempfile(fileext = ".gpkg")
     expect_false(ogr_ds_exists(dsn))
     expect_true(ogr_ds_create("GPKG", dsn, "test_layer", geom_type = "POLYGON"))
@@ -93,7 +93,7 @@ test_that("OGR management utilities work", {
 
     deleteDataset(dsn)
 
-    # SQLite
+    ## SQLite
     dsn <- tempfile(fileext = "sqlite")
     defn <- ogr_def_layer("Point", srs = epsg_to_wkt(4326))
     defn$field1 <- ogr_def_field("OFTInteger64",
@@ -133,6 +133,25 @@ test_that("OGR management utilities work", {
                  c("field1", "field2", "field3", "GEOMETRY", "geom2"))
 
     deleteDataset(dsn)
+})
+
+test_that("create Memory format works", {
+    defn <- ogr_def_layer("Point", srs = epsg_to_wkt(4269))
+    defn$int_field <- ogr_def_field("OFTInteger")
+    defn$str_field <- ogr_def_field("OFTString")
+    defn$real_field <- ogr_def_field("OFTReal")
+    defn$dt_field <- ogr_def_field("OFTDateTime")
+
+    expect_no_error(lyr <- ogr_ds_create("Memory", "", "mem_layer",
+                                         layer_defn = defn,
+                                         lco = "WRITE_BBOX=YES",
+                                         overwrite = TRUE,
+                                         return_obj = TRUE))
+
+    expect_equal(lyr$getDriverShortName(), "Memory")
+    expect_equal(lyr$getFieldNames() |> length(), 5)
+
+    lyr$close()
 })
 
 test_that("edit data using SQL works on shapefile", {


### PR DESCRIPTION
`TRUE` to return a writable `GDALVector` object on the created layer.

Done previously for raster in #464.
