### PR TITLE
`GDALVector::initDF_()`: create the data frame vectors with `Rcpp::no_init()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9431
+Version: 1.11.1.9432
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9431 (dev)
+# gdalraster 1.11.1.9432 (dev)
+
+* (internal) `GDALVector::initDF_()`: create the data frame vectors with `Rcpp::no_init()` (2024-09-12)
 
 * (internal) add src/transform.h, header for src/transform.cpp (2024-09-11)
 


### PR DESCRIPTION
We already iterate each element of the data frame in `GDALVector::fetch()`, so set `NA` values there and skip initialization when the vectors are created. Potential performance improvement when reading large result sets.