### PR TITLE
`GDALVector`: remove the exposed field `$featureTemplate` as not needed / not useful (and fixing Valgrind errors)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9440
+Version: 1.11.1.9450
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9440 (dev)
+# gdalraster 1.11.1.9450 (dev)
+
+* remove the class field `GDALVector::featureTemplate` as not needed / not useful, and its removal fixes Valgrind errors (#520) (2024-09-14)
 
 * add `g_wk2wk()`: geometry WKB/WKT conversion (2024-09-13)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -60,10 +60,7 @@
 #' # setting a spatial filter and/or specifying the SQL dialect
 #' lyr <- new(GDALVector, dsn, layer, read_only, open_options, spatial_filter, dialect)
 #'
-#' ## Read-only fields
-#' lyr$featureTemplate
-#'
-#' ## Read/write fields
+#' ## Read/write fields (per-object settings)
 #' lyr$defaultGeomFldName
 #' lyr$promoteToMulti
 #' lyr$returnGeomAs
@@ -144,19 +141,6 @@
 #' Constructor to specify a spatial filter and/or SQL dialect. All arguments
 #' are required in this form of the constructor, but `open_options` may be
 #' `NULL`, and `spatial_filter` or `dialect` may be an empty string (`""`).
-#'
-#' ## Read-only fields
-#'
-#' \code{$featureTemplate}\cr
-#' A list of the attribute and geometry field names, with `NA` values equivalent
-#' to OGR NULL values. The list elements are fully typed with the corresponding
-#' missing value types assigned (`NA_integer_`, `NA_real_`, `NA_character_`,
-#' etc.). The `featureTemplate` is useful to initialize a new empty feature,
-#' to which field and geometry values can be assigned, for use with the
-#' `$createFeature()` method (create and write a new feature within the layer).
-#' Note that geometry fields are initialized as `character` type in the
-#' template, but may be set either to a `character` string specifying a
-#' geometry in WKT format, or to a `raw` vector containing a geometry as WKB.
 #'
 #' ## Read/write fields
 #'
@@ -474,9 +458,7 @@
 #'
 #' \code{$createFeature(feature)}\cr
 #' Creates and writes a new feature within the layer. The `feature` argument is
-#' a named list of fields and their values. A `GDALVector` object provides
-#' a read-only `$featureTemplate` that is set to such a list with values
-#' initialized to `NA` (OGR NULL).
+#' a named list of fields and their values.
 #' The passed feature is written to the layer as a new feature, rather than
 #' overwriting an existing one. If the feature has a `$FID` element other than
 #' `NA`, then the vector format driver may use that as the feature id of the
@@ -726,11 +708,6 @@
 #' # lyr$getLayerDefn() |> str()
 #'
 #' ## define a feature to write
-#' ## the read-only field lyr$featureTemplate can be examined for structure
-#' ## fields in the template are initialized to NA (= OGR NULL)
-#' lyr$featureTemplate |> str()
-#'
-#' ## copy the template or make a new list
 #' feat1 <- list()
 #' ## $FID is omitted since it is assigned when written (could also be NA)
 #' ## $dt_modified is omitted since the datasource sets a default timestamp

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -70,10 +70,7 @@ lyr <- new(GDALVector, dsn, layer, read_only, open_options)
 # setting a spatial filter and/or specifying the SQL dialect
 lyr <- new(GDALVector, dsn, layer, read_only, open_options, spatial_filter, dialect)
 
-## Read-only fields
-lyr$featureTemplate
-
-## Read/write fields
+## Read/write fields (per-object settings)
 lyr$defaultGeomFldName
 lyr$promoteToMulti
 lyr$returnGeomAs
@@ -157,20 +154,6 @@ Constructor specifying dataset open options as a character vector of
 Constructor to specify a spatial filter and/or SQL dialect. All arguments
 are required in this form of the constructor, but \code{open_options} may be
 \code{NULL}, and \code{spatial_filter} or \code{dialect} may be an empty string (\code{""}).
-}
-
-\subsection{Read-only fields}{
-
-\code{$featureTemplate}\cr
-A list of the attribute and geometry field names, with \code{NA} values equivalent
-to OGR NULL values. The list elements are fully typed with the corresponding
-missing value types assigned (\code{NA_integer_}, \code{NA_real_}, \code{NA_character_},
-etc.). The \code{featureTemplate} is useful to initialize a new empty feature,
-to which field and geometry values can be assigned, for use with the
-\verb{$createFeature()} method (create and write a new feature within the layer).
-Note that geometry fields are initialized as \code{character} type in the
-template, but may be set either to a \code{character} string specifying a
-geometry in WKT format, or to a \code{raw} vector containing a geometry as WKB.
 }
 
 \subsection{Read/write fields}{
@@ -494,9 +477,7 @@ feature, but create it if it doesn't exist see the \verb{$upsertFeature()} metho
 
 \code{$createFeature(feature)}\cr
 Creates and writes a new feature within the layer. The \code{feature} argument is
-a named list of fields and their values. A \code{GDALVector} object provides
-a read-only \verb{$featureTemplate} that is set to such a list with values
-initialized to \code{NA} (OGR NULL).
+a named list of fields and their values.
 The passed feature is written to the layer as a new feature, rather than
 overwriting an existing one. If the feature has a \verb{$FID} element other than
 \code{NA}, then the vector format driver may use that as the feature id of the
@@ -739,11 +720,6 @@ lyr <- new(GDALVector, dsn2, "test_layer", read_only = FALSE)
 # lyr$getLayerDefn() |> str()
 
 ## define a feature to write
-## the read-only field lyr$featureTemplate can be examined for structure
-## fields in the template are initialized to NA (= OGR NULL)
-lyr$featureTemplate |> str()
-
-## copy the template or make a new list
 feat1 <- list()
 ## $FID is omitted since it is assigned when written (could also be NA)
 ## $dt_modified is omitted since the datasource sets a default timestamp

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -40,9 +40,6 @@ class GDALVector {
     bool m_is_sql {false};
     std::string m_dialect {""};
 
-    // exposed read-only fields
-    Rcpp::List featureTemplate {};
-
     // exposed read/write fields
     std::string defaultGeomFldName {"geometry"};
     bool promoteToMulti {false};
@@ -145,9 +142,8 @@ class GDALVector {
     void setGDALDatasetH_(const GDALDatasetH hDs, bool with_update);
     OGRLayerH getOGRLayerH_() const;
     void setOGRLayerH_(const OGRLayerH hLyr, const std::string &lyr_name);
-    void setFeatureTemplate_();
     void setFieldNames_();
-    SEXP initDF_(R_xlen_t nrow) const;
+    SEXP createDF_(R_xlen_t nrow) const;
     OGRFeatureH OGRFeatureFromList_(const Rcpp::RObject &feature) const;
 
  private:

--- a/src/ogr_util.cpp
+++ b/src/ogr_util.cpp
@@ -280,7 +280,6 @@ GDALVector create_ogr(std::string format, std::string dst_filename,
         lyr.setDsn_(dsn_in);
         lyr.setGDALDatasetH_(hDstDS, true);
         lyr.setOGRLayerH_(hLayer, layer);
-        lyr.setFeatureTemplate_();
         lyr.setFieldNames_();
         return lyr;
     }
@@ -605,7 +604,6 @@ GDALVector ogr_layer_create(std::string dsn, std::string layer,
         lyr.setDsn_(dsn_in);
         lyr.setGDALDatasetH_(hDS, true);
         lyr.setOGRLayerH_(hLayer, layer);
-        lyr.setFeatureTemplate_();
         lyr.setFieldNames_();
         return lyr;
     }

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -7,7 +7,6 @@ test_that("class constructors work", {
     lyr <- new(GDALVector, dsn)
     expect_equal(lyr$getName(), "mtbs_perims")
     expect_type(lyr$getFeature(1), "list")
-    expect_equal(length(lyr$getLayerDefn()) + 1, length(lyr$featureTemplate))
     lyr$close()
 
     lyr <- new(GDALVector, dsn, "mtbs_perims")

--- a/vignettes/articles/gdalvector-draft.Rmd
+++ b/vignettes/articles/gdalvector-draft.Rmd
@@ -11,7 +11,7 @@ knitr::opts_chunk$set(
 
 Chris Toney (chris.toney at usda.gov)
 
-Last modified: 2024-09-11
+Last modified: 2024-09-14
 
 Comment/discussion: <https://github.com/USDAForestService/gdalraster/issues/241>
 
@@ -124,9 +124,6 @@ class GDALVector {
     bool m_is_sql {false};
     std::string m_dialect {""};
 
-    // exposed read-only fields
-    Rcpp::List featureTemplate {};
-
     // exposed read/write fields
     std::string defaultGeomFldName {"geometry"};
     bool promoteToMulti {false};
@@ -229,7 +226,6 @@ class GDALVector {
     void setGDALDatasetH_(const GDALDatasetH hDs, bool with_update);
     OGRLayerH getOGRLayerH_() const;
     void setOGRLayerH_(const OGRLayerH hLyr, const std::string &lyr_name);
-    void setFeatureTemplate_();
     void setFieldNames_();
     SEXP initDF_(R_xlen_t nrow) const;
     OGRFeatureH OGRFeatureFromList_(const Rcpp::RObject &feature) const;
@@ -949,6 +945,7 @@ This is a working list of potential issues and design questions that need furthe
 * removed `is_ignored` from feature class defintion, not needed for feature class / field creation (2024-09-11)
 * feature write methods were implemented in [#504](https://github.com/USDAForestService/gdalraster/pull/504): `$createFeature()`, `$setFeature()`, `$upsertFeature()`; documentation and examples in the (online reference)[https://usdaforestservice.github.io/gdalraster/reference/GDALVector-class.html] (2024-09-11)
 * updated the `GDALVector` class declaration in the draft document (2024-09-11)
+* remove the read-only field `GDALVector::featureTemplate` as not needed / not useful (2024-09-14)
 
 ## Contributors
 


### PR DESCRIPTION
`GDALVector::featureTemplate` was exposed to R as a read-only field, containing a list object meant to be a template for a feature in the layer with field values initialized to `NA`.  It turned out not to be very helpful for its intended purpose. It is redundant with simply reading a feature from the layer and examining its structure (with `str()`), or examining the structure of the feature class definition returned by the method `getLayerDefn()`. Also, the class method `fetch()` can be called with `n = 0` to return a 0-row data frame that is fully typed.

The internal class method `setFeatureTemplate_()`, called in the constructor, assumed that the data frame returned by `initDF_()` was initialized to `NA` values. PR #516 changed the data frame creation to use `Rcpp::no_init()` for creation of the column vectors, for performance. This resulted in `setFeatureTemplate_()` causing "Conditional jump or move depends on uninitialised value(s)" reported by Valgrind.

Rather than fix `setFeatureTemplate_()` to handle the initialization, it is being removed instead, on the rationale that the `featureTemplate` field mainly adds clutter with minimal utility.

This PR also renames the method `initDF_()` to `createDF_()` to better reflect its purpose, and the fact that it no longer actually initializes (which is done in `fetch()`, now the only method that directly uses `createDF_()`).