### PR TITLE
Fix `GDALVector::setSpatialFilter()`: SRS was not set on the geometry before using it as the layer spatial filter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9460
+Version: 1.11.1.9461
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9460 (dev)
+# gdalraster 1.11.1.9461 (dev)
+
+* fix `GDALVector::setSpatialFilter()`: SRS was not set on the geometry before using it as the layer spatial filter, which could cause segfault (2024-09-15)
 
 * add `g_make_valid()`: attempt to make invalid geometries valid, operating on input of WKB raw vector, list of WKB, or character vector of WKT strings (2024-09-15)
 

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -502,9 +502,11 @@ void GDALVector::setSpatialFilter(const std::string &wkt) {
     checkAccess_(GA_ReadOnly);
 
     OGRGeometryH hFilterGeom = nullptr;
+    OGRSpatialReferenceH hSRS = OGR_L_GetSpatialRef(m_hLayer);
+
     if (wkt != "") {
         char *pszWKT = (char *) wkt.c_str();
-        if (OGR_G_CreateFromWkt(&pszWKT, nullptr, &hFilterGeom) !=
+        if (OGR_G_CreateFromWkt(&pszWKT, hSRS, &hFilterGeom) !=
                 OGRERR_NONE) {
             if (hFilterGeom != nullptr)
                 OGR_G_DestroyGeometry(hFilterGeom);


### PR DESCRIPTION
Fixes eventual segfault. This PR also adds new tests for class `GDALVector`.
