### PR TITLE
g_make_valid(): destroy the input geometry object before return if OGR MakeValid() returns NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9461
+Version: 1.11.1.9462
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# gdalraster 1.11.1.9461 (dev)
+# gdalraster 1.11.1.9462 (dev)
 
 * fix `GDALVector::setSpatialFilter()`: SRS was not set on the geometry before using it as the layer spatial filter, which could cause segfault (2024-09-15)
 

--- a/src/geom_api.cpp
+++ b/src/geom_api.cpp
@@ -554,6 +554,7 @@ SEXP g_make_valid(const Rcpp::RawVector &geom,
 #endif
 
     if (hGeomValid == nullptr) {
+        OGR_G_DestroyGeometry(hGeom);
         if (!quiet) {
             Rcpp::warning("OGR MakeValid() gave NULL geometry, NA returned");
         }


### PR DESCRIPTION
avoid memory leak
