### PR TITLE
`vsi_read_dir()`: omit `"."` and `".."` and sort the returned listing, add arg `all_files`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9480
+Version: 1.11.1.9481
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gdalraster 1.11.1.9481 (dev)
 
-* `vsi_read_dir()`: omit `"."` and `".."` from the listing (behavior change) (2024-09-17)
+* `vsi_read_dir()`: omit `"."` and `".."` from the listing (behavior change); add argument `all_files`, `TRUE` to include hidden files; sort the listing alphabetically (2024-09-17)
 
 * `GDALVector`: support writing OFTTime fields from string input `"HH:MM:SS"` (2024-09-16)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9480 (dev)
+# gdalraster 1.11.1.9481 (dev)
+
+* `vsi_read_dir()`: omit `"."` and `".."` from the listing (behavior change) (2024-09-17)
 
 * `GDALVector`: support writing OFTTime fields from string input `"HH:MM:SS"` (2024-09-16)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1270,6 +1270,10 @@ vsi_curl_clear_cache <- function(partial = FALSE, file_prefix = "", quiet = TRUE
 #' stop, or 0 for no limit (see Note). Ignored if `recursive = TRUE`.
 #' @param recursive Logical scalar. `TRUE` to read the directory and its
 #' subdirectories. Defaults to `FALSE`.
+#' @param all_files Logical scalar. If ‘FALSE’ (the default), only the names
+#' of visible files are returned (following Unix-style visibility, that is
+#' files whose name does not start with a dot). If ‘TRUE’, all file names
+#' will be returned.
 #' @returns A character vector containing the names of files and directories
 #' in the directory given by `path`. An empty string (`""`) is returned if
 #' `path` does not exist.
@@ -1289,8 +1293,8 @@ vsi_curl_clear_cache <- function(partial = FALSE, file_prefix = "", quiet = TRUE
 #' # regular file system for illustration
 #' data_dir <- system.file("extdata", package="gdalraster")
 #' vsi_read_dir(data_dir)
-vsi_read_dir <- function(path, max_files = 0L, recursive = FALSE) {
-    .Call(`_gdalraster_vsi_read_dir`, path, max_files, recursive)
+vsi_read_dir <- function(path, max_files = 0L, recursive = FALSE, all_files = FALSE) {
+    .Call(`_gdalraster_vsi_read_dir`, path, max_files, recursive, all_files)
 }
 
 #' Synchronize a source file/directory with a target file/directory

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1275,8 +1275,10 @@ vsi_curl_clear_cache <- function(partial = FALSE, file_prefix = "", quiet = TRUE
 #' files whose name does not start with a dot). If ‘TRUE’, all file names
 #' will be returned.
 #' @returns A character vector containing the names of files and directories
-#' in the directory given by `path`. An empty string (`""`) is returned if
-#' `path` does not exist.
+#' in the directory given by `path`. The listing is in alphabetical order, and
+#' does not include the special entries '.' and '..' even if they are present
+#' in the directory. An empty string (`""`) is returned if `path` does not
+#' exist.
 #'
 #' @note
 #' If `max_files` is set to a positive number, directory listing will stop

--- a/man/vsi_read_dir.Rd
+++ b/man/vsi_read_dir.Rd
@@ -23,8 +23,10 @@ will be returned.}
 }
 \value{
 A character vector containing the names of files and directories
-in the directory given by \code{path}. An empty string (\code{""}) is returned if
-\code{path} does not exist.
+in the directory given by \code{path}. The listing is in alphabetical order, and
+does not include the special entries '.' and '..' even if they are present
+in the directory. An empty string (\code{""}) is returned if \code{path} does not
+exist.
 }
 \description{
 \code{vsi_read_dir()} abstracts access to directory contents. It returns a

--- a/man/vsi_read_dir.Rd
+++ b/man/vsi_read_dir.Rd
@@ -4,7 +4,7 @@
 \alias{vsi_read_dir}
 \title{Read names in a directory}
 \usage{
-vsi_read_dir(path, max_files = 0L, recursive = FALSE)
+vsi_read_dir(path, max_files = 0L, recursive = FALSE, all_files = FALSE)
 }
 \arguments{
 \item{path}{Character string. The relative or absolute path of a
@@ -15,6 +15,11 @@ stop, or 0 for no limit (see Note). Ignored if \code{recursive = TRUE}.}
 
 \item{recursive}{Logical scalar. \code{TRUE} to read the directory and its
 subdirectories. Defaults to \code{FALSE}.}
+
+\item{all_files}{Logical scalar. If ‘FALSE’ (the default), only the names
+of visible files are returned (following Unix-style visibility, that is
+files whose name does not start with a dot). If ‘TRUE’, all file names
+will be returned.}
 }
 \value{
 A character vector containing the names of files and directories

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -611,15 +611,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // vsi_read_dir
-Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path, int max_files, bool recursive);
-RcppExport SEXP _gdalraster_vsi_read_dir(SEXP pathSEXP, SEXP max_filesSEXP, SEXP recursiveSEXP) {
+Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path, int max_files, bool recursive, bool all_files);
+RcppExport SEXP _gdalraster_vsi_read_dir(SEXP pathSEXP, SEXP max_filesSEXP, SEXP recursiveSEXP, SEXP all_filesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type path(pathSEXP);
     Rcpp::traits::input_parameter< int >::type max_files(max_filesSEXP);
     Rcpp::traits::input_parameter< bool >::type recursive(recursiveSEXP);
-    rcpp_result_gen = Rcpp::wrap(vsi_read_dir(path, max_files, recursive));
+    Rcpp::traits::input_parameter< bool >::type all_files(all_filesSEXP);
+    rcpp_result_gen = Rcpp::wrap(vsi_read_dir(path, max_files, recursive, all_files));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1670,7 +1671,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_addFileInZip", (DL_FUNC) &_gdalraster_addFileInZip, 6},
     {"_gdalraster_vsi_copy_file", (DL_FUNC) &_gdalraster_vsi_copy_file, 3},
     {"_gdalraster_vsi_curl_clear_cache", (DL_FUNC) &_gdalraster_vsi_curl_clear_cache, 3},
-    {"_gdalraster_vsi_read_dir", (DL_FUNC) &_gdalraster_vsi_read_dir, 3},
+    {"_gdalraster_vsi_read_dir", (DL_FUNC) &_gdalraster_vsi_read_dir, 4},
     {"_gdalraster_vsi_sync", (DL_FUNC) &_gdalraster_vsi_sync, 4},
     {"_gdalraster_vsi_mkdir", (DL_FUNC) &_gdalraster_vsi_mkdir, 3},
     {"_gdalraster_vsi_rmdir", (DL_FUNC) &_gdalraster_vsi_rmdir, 2},

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -158,8 +158,10 @@ void vsi_curl_clear_cache(bool partial = false,
 //' files whose name does not start with a dot). If ‘TRUE’, all file names
 //' will be returned.
 //' @returns A character vector containing the names of files and directories
-//' in the directory given by `path`. An empty string (`""`) is returned if
-//' `path` does not exist.
+//' in the directory given by `path`. The listing is in alphabetical order, and
+//' does not include the special entries '.' and '..' even if they are present
+//' in the directory. An empty string (`""`) is returned if `path` does not
+//' exist.
 //'
 //' @note
 //' If `max_files` is set to a positive number, directory listing will stop

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -184,12 +184,13 @@ Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
 
     int nItems = CSLCount(papszFiles);
     if (nItems > 0) {
-        Rcpp::CharacterVector files(nItems);
+        std::vector<std::string> files{};
         for (int i=0; i < nItems; ++i) {
-            files(i) = papszFiles[i];
+            if (!EQUAL(papszFiles[i], ".") && !EQUAL(papszFiles[i], ".."))
+                files.push_back(papszFiles[i]);
         }
         CSLDestroy(papszFiles);
-        return files;
+        return Rcpp::wrap(files);
     }
     else {
         CSLDestroy(papszFiles);

--- a/src/gdal_vsi.h
+++ b/src/gdal_vsi.h
@@ -16,9 +16,8 @@ int vsi_copy_file(Rcpp::CharacterVector src_file,
 void vsi_curl_clear_cache(bool partial, Rcpp::CharacterVector file_prefix,
                           bool quiet);
 
-Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path,
-                                   int max_files,
-                                   bool recursive);
+Rcpp::CharacterVector vsi_read_dir(Rcpp::CharacterVector path, int max_files,
+                                   bool recursive, bool all_files);
 
 bool vsi_sync(Rcpp::CharacterVector src,
               Rcpp::CharacterVector target,


### PR DESCRIPTION
Omit `"."` and `".."` from the listing.
Add argument `all_files`, `TRUE` to include hidden files.
Sort the listing alphabetically.

Omitting `"."` and `".."` is a behavior change.


