### PR TITLE
GDALVector: add get/set metadata methods for layer-level metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9482
+Version: 1.11.1.9483
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9482 (dev)
+# gdalraster 1.11.1.9483 (dev)
+
+* `GDALVector`: add get/set metadata methods for layer-level metadata if the format supports it (2024-09-19)
 
 * `transform_xy()` and `inv_project()`: accept SRS arguments in any format supported by `srs_to_wkt()` (previously required SRS arguments in WKT format) (2024-09-19)
 

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -558,24 +558,18 @@
 #' or if the data source does not support transactions.
 #'
 #' \code{$getMetadata()}\cr
-#' Returns a character vector of all metadata `NAME=VALUE` pairs or empty
-#' string (`""`) if there are no metadata items.
+#' Returns a character vector of all metadata `NAME=VALUE` pairs for the
+#' layer or empty string (`""`) if there are no metadata items.
 #'
 #' \code{$setMetadata(metadata)}\cr
-#' Sets metadata. The \code{metadata} argument is given as a character vector
-#' of `NAME=VALUE` pairs.
+#' Sets metadata on the layer if the format supports it. The \code{metadata}
+#' argument is given as a character vector of `NAME=VALUE` pairs.
 #' Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
 #' not be set.
 #'
 #' \code{$getMetadataItem(mdi_name)}\cr
 #' Returns the value of a specific metadata item named \code{mdi_name}, or empty
 #' string (`""`) if no matching item is found.
-#'
-#' \code{$setMetadataItem(mdi_name, mdi_value)}\cr
-#' Sets the value (\code{mdi_value}) of a specific metadata item named
-#' \code{mdi_name}.
-#' Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
-#' not be set.
 #'
 #' \code{$close()}\cr
 #' Closes the vector dataset (no return value, called for side effects).

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -112,6 +112,11 @@
 #' lyr$commitTransaction()
 #' lyr$rollbackTransaction()
 #'
+#' ds$getMetadata()
+#' ds$setMetadata(metadata)
+#' ds$getMetadataItem(mdi_name)
+#' ds$setMetadataItem(mdi_name, mdi_value)
+#'
 #' lyr$close()
 #' }
 #' @section Details:
@@ -551,6 +556,26 @@
 #' Returns a logical value, `TRUE` if the transaction is successfully rolled
 #' back. Returns `FALSE` if no transaction is active, or the rollback fails,
 #' or if the data source does not support transactions.
+#'
+#' \code{$getMetadata()}\cr
+#' Returns a character vector of all metadata `NAME=VALUE` pairs or empty
+#' string (`""`) if there are no metadata items.
+#'
+#' \code{$setMetadata(metadata)}\cr
+#' Sets metadata. The \code{metadata} argument is given as a character vector
+#' of `NAME=VALUE` pairs.
+#' Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+#' not be set.
+#'
+#' \code{$getMetadataItem(mdi_name)}\cr
+#' Returns the value of a specific metadata item named \code{mdi_name}, or empty
+#' string (`""`) if no matching item is found.
+#'
+#' \code{$setMetadataItem(mdi_name, mdi_value)}\cr
+#' Sets the value (\code{mdi_value}) of a specific metadata item named
+#' \code{mdi_name}.
+#' Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+#' not be set.
 #'
 #' \code{$close()}\cr
 #' Closes the vector dataset (no return value, called for side effects).

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -577,24 +577,18 @@ back. Returns \code{FALSE} if no transaction is active, or the rollback fails,
 or if the data source does not support transactions.
 
 \code{$getMetadata()}\cr
-Returns a character vector of all metadata \code{NAME=VALUE} pairs or empty
-string (\code{""}) if there are no metadata items.
+Returns a character vector of all metadata \code{NAME=VALUE} pairs for the
+layer or empty string (\code{""}) if there are no metadata items.
 
 \code{$setMetadata(metadata)}\cr
-Sets metadata. The \code{metadata} argument is given as a character vector
-of \code{NAME=VALUE} pairs.
+Sets metadata on the layer if the format supports it. The \code{metadata}
+argument is given as a character vector of \code{NAME=VALUE} pairs.
 Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
 not be set.
 
 \code{$getMetadataItem(mdi_name)}\cr
 Returns the value of a specific metadata item named \code{mdi_name}, or empty
 string (\code{""}) if no matching item is found.
-
-\code{$setMetadataItem(mdi_name, mdi_value)}\cr
-Sets the value (\code{mdi_value}) of a specific metadata item named
-\code{mdi_name}.
-Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
-not be set.
 
 \code{$close()}\cr
 Closes the vector dataset (no return value, called for side effects).

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -122,6 +122,11 @@ lyr$startTransaction(force)
 lyr$commitTransaction()
 lyr$rollbackTransaction()
 
+ds$getMetadata()
+ds$setMetadata(metadata)
+ds$getMetadataItem(mdi_name)
+ds$setMetadataItem(mdi_name, mdi_value)
+
 lyr$close()
 }
 }
@@ -570,6 +575,26 @@ transaction, if transactions are supported by the data source.
 Returns a logical value, \code{TRUE} if the transaction is successfully rolled
 back. Returns \code{FALSE} if no transaction is active, or the rollback fails,
 or if the data source does not support transactions.
+
+\code{$getMetadata()}\cr
+Returns a character vector of all metadata \code{NAME=VALUE} pairs or empty
+string (\code{""}) if there are no metadata items.
+
+\code{$setMetadata(metadata)}\cr
+Sets metadata. The \code{metadata} argument is given as a character vector
+of \code{NAME=VALUE} pairs.
+Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+not be set.
+
+\code{$getMetadataItem(mdi_name)}\cr
+Returns the value of a specific metadata item named \code{mdi_name}, or empty
+string (\code{""}) if no matching item is found.
+
+\code{$setMetadataItem(mdi_name, mdi_value)}\cr
+Sets the value (\code{mdi_value}) of a specific metadata item named
+\code{mdi_name}.
+Returns logical \code{TRUE} on success or \code{FALSE} if metadata could
+not be set.
 
 \code{$close()}\cr
 Closes the vector dataset (no return value, called for side effects).

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -1520,26 +1520,6 @@ std::string GDALVector::getMetadataItem(std::string mdi_name) const {
     return mdi;
 }
 
-bool GDALVector::setMetadataItem(std::string mdi_name, std::string mdi_value) {
-
-    checkAccess_(GA_ReadOnly);
-
-    CPLErr err = CE_None;
-    err = GDALSetMetadataItem(m_hDataset, mdi_name.c_str(), mdi_value.c_str(),
-                              nullptr);
-
-    // TODO: support quiet as object-level field setting
-    bool quiet = false;
-    if (err != CE_None) {
-        if (!quiet)
-            Rcpp::Rcerr << CPLGetLastErrorMsg() << std::endl;
-        return false;
-    }
-    else {
-        return true;
-    }
-}
-
 bool GDALVector::layerIntersection(
         GDALVector method_layer,
         GDALVector result_layer,
@@ -2936,8 +2916,6 @@ RCPP_MODULE(mod_GDALVector) {
         "Set metadata from a list of name=value")
     .const_method("getMetadataItem", &GDALVector::getMetadataItem,
         "Return the value of a metadata item")
-    .method("setMetadataItem", &GDALVector::setMetadataItem,
-        "Set metadata item name=value")
     .method("layerIntersection", &GDALVector::layerIntersection,
         "Intersection of this layer with a method layer")
     .method("layerUnion", &GDALVector::layerUnion,

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -98,7 +98,6 @@ class GDALVector {
     Rcpp::CharacterVector getMetadata() const;
     bool setMetadata(const Rcpp::CharacterVector metadata);
     std::string getMetadataItem(std::string mdi_name) const;
-    bool setMetadataItem(std::string mdi_name, std::string mdi_value);
 
     bool layerIntersection(
             GDALVector method_layer,

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -95,6 +95,11 @@ class GDALVector {
     bool commitTransaction();
     bool rollbackTransaction();
 
+    Rcpp::CharacterVector getMetadata() const;
+    bool setMetadata(const Rcpp::CharacterVector metadata);
+    std::string getMetadataItem(std::string mdi_name) const;
+    bool setMetadataItem(std::string mdi_name, std::string mdi_value);
+
     bool layerIntersection(
             GDALVector method_layer,
             GDALVector result_layer,

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -959,15 +959,8 @@ test_that("get/set metadata works", {
 
     # close and re-open
     lyr$open(read_only = TRUE)
+    expect_equal(lyr$getMetadataItem(mdi_name = "TEST_ITEM_1"), "test 1 string")
     expect_equal(lyr$getMetadataItem(mdi_name = "TEST_ITEM_2"), "test 2 string")
-
-    # write a single item
-    lyr$open(read_only = FALSE)
-    expect_true(lyr$setMetadataItem("TEST_ITEM_3", "test 3 string"))
-
-    # close and re-open
-    lyr$open(read_only = TRUE)
-    expect_equal(lyr$getMetadataItem(mdi_name = "TEST_ITEM_3"), "test 3 string")
 
     lyr$close()
     deleteDataset(dsn)

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -941,3 +941,34 @@ test_that("feature write methods work", {
     rm(lyr)
     rm(dsn5)
 })
+
+test_that("get/set metadata works", {
+    f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")
+    dsn <- file.path(tempdir(), basename(f))
+    file.copy(f, dsn, overwrite = TRUE)
+
+    lyr <- new(GDALVector, dsn, "mtbs_perims", read_only = FALSE)
+
+    expect_no_error(lyr$getMetadata())
+    expect_equal(lyr$getMetadataItem(mdi_name = "DESCRIPTION"),
+                 "MTBS fire perims 1984-2022 clipped to YNP bbox")
+
+    # write metadata
+    md <- c("TEST_ITEM_1=test 1 string", "TEST_ITEM_2=test 2 string")
+    expect_true(lyr$setMetadata(md))
+
+    # close and re-open
+    lyr$open(read_only = TRUE)
+    expect_equal(lyr$getMetadataItem(mdi_name = "TEST_ITEM_2"), "test 2 string")
+
+    # write a single item
+    lyr$open(read_only = FALSE)
+    expect_true(lyr$setMetadataItem("TEST_ITEM_3", "test 3 string"))
+
+    # close and re-open
+    lyr$open(read_only = TRUE)
+    expect_equal(lyr$getMetadataItem(mdi_name = "TEST_ITEM_3"), "test 3 string")
+
+    lyr$close()
+    deleteDataset(dsn)
+})


### PR DESCRIPTION
`$getMetadata()`
#' Returns a character vector of all metadata `NAME=VALUE` pairs for the
#' layer or empty string (`""`) if there are no metadata items.
#'

`$setMetadata(metadata)`
#' Sets metadata on the layer if the format supports it. The \code{metadata}
#' argument is given as a character vector of `NAME=VALUE` pairs.
#' Returns logical `TRUE` on success or `FALSE` if metadata could
#' not be set.
#'

`$getMetadataItem(mdi_name)`
#' Returns the value of a specific metadata item named `mdi_name`, or empty
#' string (`""`) if no matching item is found.