### PR TITLE
Support `NULL` layer argument for certain `ogr_manage` functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9483
+Version: 1.11.1.9484
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9483 (dev)
+# gdalraster 1.11.1.9484 (dev)
+
+* the `layer` argument may be `NULL` or empty string in certain `ogr_manage` functions, defaulting to the first layer by index (mainly convenience for single-layer formats) (2024-09-19)
 
 * `GDALVector`: add get/set metadata methods for layer-level metadata if the format supports it (2024-09-19)
 

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -89,7 +89,8 @@
 #' An error is raised if the operation fails.
 #'
 #' `ogr_layer_field_names()` returns a character vector of field names on a
-#' layer, or `NULL` if no fields are found.
+#' layer, or `NULL` if no fields are found. The first layer by index is opened
+#' if `NULL` is given for the `layer` argument.
 #'
 #' `ogr_layer_rename()` renames a layer in a vector dataset. This operation is
 #' implemented only by layers that expose the `Rename` capability (see
@@ -138,6 +139,9 @@
 #' Examples of some common output formats include: `"GPKG"`, `"FlatGeobuf"`,
 #' `"ESRI Shapefile"`, `"SQLite"`.
 #' @param layer Character string for a layer name in a vector dataset.
+#' The `layer` argument may be given as empty string (`""`) in which case the
+#' first layer by index will be opened (except with `ogr_layer_delete()` and
+#' `ogr_layer_rename()` for which a layer name nust be specified).
 #' @param layer_defn A feature class definition for `layer` as a list of
 #' zero or more attribute field definitions, and at least one geometry field
 #' definition (see [ogr_define]).
@@ -460,9 +464,11 @@ ogr_layer_exists <- function(dsn, layer) {
 
 #' @name ogr_manage
 #' @export
-ogr_layer_test_cap <- function(dsn, layer, with_update = TRUE) {
+ogr_layer_test_cap <- function(dsn, layer = NULL, with_update = TRUE) {
     if (!(is.character(dsn) && length(dsn) == 1))
         stop("'dsn' must be a length-1 character vector", call. = FALSE)
+    if (is.null(layer))
+        layer <- ""
     if (!(is.character(layer) && length(layer) == 1))
         stop("'layer' must be a length-1 character vector", call. = FALSE)
 
@@ -554,11 +560,14 @@ ogr_layer_create <- function(dsn, layer, layer_defn = NULL, geom_type = NULL,
 
 #' @name ogr_manage
 #' @export
-ogr_layer_field_names <- function(dsn, layer) {
+ogr_layer_field_names <- function(dsn, layer = NULL) {
     if (!(is.character(dsn) && length(dsn) == 1))
         stop("'dsn' must be a length-1 character vector", call. = FALSE)
+    if (is.null(layer))
+        layer <- ""
     if (!(is.character(layer) && length(layer) == 1))
         stop("'layer' must be a length-1 character vector", call. = FALSE)
+
 
     return(.ogr_layer_field_names(dsn, layer))
 }

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -49,7 +49,7 @@ ogr_ds_layer_names(dsn)
 
 ogr_layer_exists(dsn, layer)
 
-ogr_layer_test_cap(dsn, layer, with_update = TRUE)
+ogr_layer_test_cap(dsn, layer = NULL, with_update = TRUE)
 
 ogr_layer_create(
   dsn,
@@ -61,7 +61,7 @@ ogr_layer_create(
   return_obj = FALSE
 )
 
-ogr_layer_field_names(dsn, layer)
+ogr_layer_field_names(dsn, layer = NULL)
 
 ogr_layer_rename(dsn, layer, new_name)
 
@@ -110,7 +110,10 @@ opening the dataset, or \code{FALSE} to open read-only.}
 Examples of some common output formats include: \code{"GPKG"}, \code{"FlatGeobuf"},
 \code{"ESRI Shapefile"}, \code{"SQLite"}.}
 
-\item{layer}{Character string for a layer name in a vector dataset.}
+\item{layer}{Character string for a layer name in a vector dataset.
+The \code{layer} argument may be given as empty string (\code{""}) in which case the
+first layer by index will be opened (except with \code{ogr_layer_delete()} and
+\code{ogr_layer_rename()} for which a layer name nust be specified).}
 
 \item{layer_defn}{A feature class definition for \code{layer} as a list of
 zero or more attribute field definitions, and at least one geometry field
@@ -279,7 +282,8 @@ By default, returns logical \code{TRUE} indicating success, or an object of clas
 An error is raised if the operation fails.
 
 \code{ogr_layer_field_names()} returns a character vector of field names on a
-layer, or \code{NULL} if no fields are found.
+layer, or \code{NULL} if no fields are found. The first layer by index is opened
+if \code{NULL} is given for the \code{layer} argument.
 
 \code{ogr_layer_rename()} renames a layer in a vector dataset. This operation is
 implemented only by layers that expose the \code{Rename} capability (see

--- a/src/ogr_util.cpp
+++ b/src/ogr_util.cpp
@@ -384,7 +384,11 @@ SEXP ogr_layer_test_cap(std::string dsn, std::string layer,
     else
         hDS = GDALOpenEx(dsn_in.c_str(), GDAL_OF_VECTOR,
                          nullptr, nullptr, nullptr);
-    hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
+
+    if (layer == "")
+        hLayer = GDALDatasetGetLayer(hDS, 0);
+    else
+        hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
     CPLPopErrorHandler();
 
     if (hDS == nullptr || hLayer == nullptr)
@@ -711,7 +715,10 @@ SEXP ogr_layer_field_names(std::string dsn, std::string layer) {
     hDS = GDALOpenEx(dsn_in.c_str(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr);
     if (hDS == nullptr)
         return R_NilValue;
-    hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
+    if (layer == "")
+        hLayer = GDALDatasetGetLayer(hDS, 0);
+    else
+        hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
     CPLPopErrorHandler();
 
     if (hLayer == nullptr) {
@@ -771,7 +778,10 @@ int ogr_field_index(std::string dsn, std::string layer,
     hDS = GDALOpenEx(dsn_in.c_str(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr);
     if (hDS == nullptr)
         return -1;
-    hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
+    if (layer == "")
+        hLayer = GDALDatasetGetLayer(hDS, 0);
+    else
+        hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
     CPLPopErrorHandler();
 
     if (hLayer == nullptr) {
@@ -880,7 +890,10 @@ bool ogr_field_create(std::string dsn, std::string layer,
     if (hDS == nullptr)
         return false;
 
-    hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
+    if (layer == "")
+        hLayer = GDALDatasetGetLayer(hDS, 0);
+    else
+        hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
     CPLPopErrorHandler();
 
     if (hLayer == nullptr) {
@@ -993,7 +1006,10 @@ bool ogr_geom_field_create(std::string dsn, std::string layer,
     if (hDS == nullptr)
         return false;
 
-    hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
+    if (layer == "")
+        hLayer = GDALDatasetGetLayer(hDS, 0);
+    else
+        hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
     CPLPopErrorHandler();
 
     if (hLayer == nullptr) {
@@ -1045,7 +1061,10 @@ bool ogr_field_rename(std::string dsn, std::string layer,
     }
 
     OGRLayerH  hLayer = nullptr;
-    hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
+    if (layer == "")
+        hLayer = GDALDatasetGetLayer(hDS, 0);
+    else
+        hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
     if (hLayer == nullptr) {
         Rcpp::Rcerr << "failed to access 'layer'\n";
         GDALReleaseDataset(hDS);
@@ -1114,7 +1133,10 @@ bool ogr_field_delete(std::string dsn, std::string layer,
     }
 
     OGRLayerH  hLayer = nullptr;
-    hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
+    if (layer == "")
+        hLayer = GDALDatasetGetLayer(hDS, 0);
+    else
+        hLayer = GDALDatasetGetLayerByName(hDS, layer.c_str());
     if (hLayer == nullptr) {
         Rcpp::Rcerr << "failed to access 'layer'\n";
         GDALReleaseDataset(hDS);

--- a/tests/testthat/test-ogr_manage.R
+++ b/tests/testthat/test-ogr_manage.R
@@ -132,6 +132,12 @@ test_that("OGR management utilities work", {
                  c("field1", "field2", "field3", "GEOMETRY", "geom2"))
 
     deleteDataset(dsn)
+
+    # single-layer format, layer argument may be NULL or ""
+    dsn <- system.file("extdata/poly_multipoly.shp", package="gdalraster")
+    expect_equal(ogr_layer_field_names(dsn),
+                 c("Event_ID", "Map_ID", "Ig_Date",  ""))
+
 })
 
 test_that("create Memory format works", {


### PR DESCRIPTION
the `layer` argument may be `NULL` or empty string in certain `ogr_manage` functions, defaulting to the first layer by index (mainly convenience for single-layer formats)