### PR TITLE
Ensure `geom_format` is `"NONE"` in the gis attributes for `OGRFeature` and `OGRFeatureSet` if no geometry column is present, and support BBOX geom in plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.11.1.9500
+Version: 1.11.1.9501
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # gdalraster 1.11.1.9501 (dev)
 
-* ensure `geom_format` is set to `"NONE"` in gis attributes for `OGRFeature` and `OGRFeatureSet` if no geometry column is present (2024-09-30)
-
 * `GDALVector`: add a `BBOX` option for the per-object setting `$returnGeomAs` (2024-10-03)
 
 * add minimal S3 classes `OGRFeature` and `OGRFeatureSet` with methods for `print()` and `plot()` (2024-09-28)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.11.1.9500 (dev)
+# gdalraster 1.11.1.9501 (dev)
+
+* ensure `geom_format` is set to `"NONE"` in gis attributes for `OGRFeature` and `OGRFeatureSet` if no geometry column is present (2024-09-30)
 
 * add minimal S3 classes `OGRFeature` and `OGRFeatureSet` with methods for `print()` and `plot()` (2024-09-28)
 

--- a/R/s3_methods.R
+++ b/R/s3_methods.R
@@ -9,7 +9,7 @@ print.OGRFeature <- function(x, ...) {
     geom_column <- attr(x, "gis")$geom_column
     geom_format <- toupper(attr(x, "gis")$geom_format)
 
-    if (geom_format == "NONE")
+    if (geom_format == "NONE" || length(geom_column) == 0)
         cat("OGR feature (attributes)\n")
     else
         cat("OGR feature\n")
@@ -65,7 +65,7 @@ print.OGRFeatureSet <- function(x, ...) {
     geom_column <- attr(x, "gis")$geom_column
     geom_format <- toupper(attr(x, "gis")$geom_format)
 
-    if (geom_format == "NONE")
+    if (geom_format == "NONE" || length(geom_column) == 0)
         cat("OGR feature set (attribute table)\n")
     else
         cat("OGR feature set\n")
@@ -114,12 +114,17 @@ print.OGRFeatureSet <- function(x, ...) {
 #' @export
 #' @method plot OGRFeature
 plot.OGRFeature <- function(x, ...) {
+    if (length(attr(x, "gis")$geom_column) == 0)
+        stop("no geometry column")
+    else
+        geom_column <- attr(x, "gis")$geom_column[1]
+
     geom_format <- toupper(attr(x, "gis")$geom_format)
     if (!geom_format %in% c("WKB", "WKB_ISO", "WKT", "WKT_ISO"))
-        stop("no geometry column")
+        stop("no supported geometry format for plot")
 
-    geom_column <- attr(x, "gis")$geom_column[1]
     srs <- attr(x, "gis")$geom_col_srs[1]
+
     if (startsWith(geom_format, "WKB"))
         wk_obj <- wk::wkb(list(x[[geom_column]]), crs = srs)
     else
@@ -138,12 +143,17 @@ plot.OGRFeature <- function(x, ...) {
 #' @export
 #' @method plot OGRFeatureSet
 plot.OGRFeatureSet <- function(x, ...) {
+    if (length(attr(x, "gis")$geom_column) == 0)
+        stop("no geometry column")
+    else
+        geom_column <- attr(x, "gis")$geom_column[1]
+
     geom_format <- toupper(attr(x, "gis")$geom_format)
     if (!geom_format %in% c("WKB", "WKB_ISO", "WKT", "WKT_ISO"))
-        stop("no geometry column")
+        stop("no supported geometry format for plot")
 
-    geom_column <- attr(x, "gis")$geom_column[1]
     srs <- attr(x, "gis")$geom_col_srs[1]
+
     if (startsWith(geom_format, "WKB"))
         wk_obj <- wk::wkb(x[[geom_column]], crs = srs)
     else

--- a/R/s3_methods.R
+++ b/R/s3_methods.R
@@ -120,15 +120,19 @@ plot.OGRFeature <- function(x, ...) {
         geom_column <- attr(x, "gis")$geom_column[1]
 
     geom_format <- toupper(attr(x, "gis")$geom_format)
-    if (!geom_format %in% c("WKB", "WKB_ISO", "WKT", "WKT_ISO"))
+    if (!geom_format %in% c("WKB", "WKB_ISO", "WKT", "WKT_ISO", "BBOX"))
         stop("no supported geometry format for plot")
 
     srs <- attr(x, "gis")$geom_col_srs[1]
 
-    if (startsWith(geom_format, "WKB"))
+    if (geom_format == "BBOX") {
+        bb <- x[[geom_column]]
+        wk_obj <- wk::rct(bb[1], bb[2], bb[3], bb[4], crs = srs)
+    } else if (startsWith(geom_format, "WKB")) {
         wk_obj <- wk::wkb(list(x[[geom_column]]), crs = srs)
-    else
+    } else {
         wk_obj <- wk::wkt(x[[geom_column]], crs = srs)
+    }
 
     wk::wk_plot(wk_obj, ...)
 
@@ -149,15 +153,19 @@ plot.OGRFeatureSet <- function(x, ...) {
         geom_column <- attr(x, "gis")$geom_column[1]
 
     geom_format <- toupper(attr(x, "gis")$geom_format)
-    if (!geom_format %in% c("WKB", "WKB_ISO", "WKT", "WKT_ISO"))
+    if (!geom_format %in% c("WKB", "WKB_ISO", "WKT", "WKT_ISO", "BBOX"))
         stop("no supported geometry format for plot")
 
     srs <- attr(x, "gis")$geom_col_srs[1]
 
-    if (startsWith(geom_format, "WKB"))
+    if (geom_format == "BBOX") {
+        wk_obj <- matrix(unlist(x[[geom_column]]), ncol = 4, byrow = TRUE) |>
+            wk::as_rct()
+    } else if (startsWith(geom_format, "WKB")) {
         wk_obj <- wk::wkb(x[[geom_column]], crs = srs)
-    else
+    } else {
         wk_obj <- wk::wkt(x[[geom_column]], crs = srs)
+    }
 
     wk::wk_plot(wk_obj, ...)
 

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -771,7 +771,7 @@ Rcpp::DataFrame GDALVector::fetch(double n) {
 
     Rcpp::DataFrame df = createDF_(fetch_num);
 
-    if (include_geom) {
+    if (include_geom && nGeomFields > 0) {
         // get gis attributes
         geom_format = this->returnGeomAs;
 
@@ -811,9 +811,6 @@ Rcpp::DataFrame GDALVector::fetch(double n) {
         }
     }
     else {
-        geom_column = "";
-        geom_col_type = "";
-        geom_col_srs = "";
         geom_format = "NONE";
     }
 

--- a/tests/testthat/test-s3_methods.R
+++ b/tests/testthat/test-s3_methods.R
@@ -26,6 +26,12 @@ test_that("plot.OGRFeature / plot.OGRFeatureSet work", {
     feat_set <- lyr$fetch(3)
     expect_identical(plot(feat_set), feat_set)
 
+    lyr$returnGeomAs <- "BBOX"
+    feat <- lyr$getNextFeature()
+    expect_identical(plot(feat), feat)
+    feat_set <- lyr$fetch(3)
+    expect_identical(plot(feat_set), feat_set)
+
     lyr$close()
 })
 
@@ -52,6 +58,12 @@ test_that("print.OGRFeature / print.OGRFeatureSet work", {
     expect_identical(print(feat_set), feat_set)
 
     lyr$returnGeomAs <- "WKT_ISO"
+    feat <- lyr$getNextFeature()
+    expect_identical(print(feat), feat)
+    feat_set <- lyr$fetch(3)
+    expect_identical(print(feat_set), feat_set)
+
+    lyr$returnGeomAs <- "BBOX"
     feat <- lyr$getNextFeature()
     expect_identical(print(feat), feat)
     feat_set <- lyr$fetch(3)


### PR DESCRIPTION
Accounts for the case when `$returnGeomAs` may have the default value `"WKB"` but the layer was opened with a SQL SELECT statement that does not include a geometry column.