### PR TITLE
Fix test for VSIFile: open with w+ to create file for read/write

### DIFF
--- a/tests/testthat/test-VSIFile-class.R
+++ b/tests/testthat/test-VSIFile-class.R
@@ -72,7 +72,7 @@ test_that("VSIFile works", {
     # write to an in-memory file
     lcp_size <- vsi_stat(lcp_file, "size")
     mem_file <- "/vsimem/storml_copy.lcp"
-    vf <- new(VSIFile, mem_file, "w")
+    vf <- new(VSIFile, mem_file, "w+")
     expect_equal(vf$write(bytes), bit64::as.integer64(lcp_size))
     expect_equal(vf$flush(), 0)
     expect_equal(vf$tell(), bit64::as.integer64(lcp_size))
@@ -135,7 +135,7 @@ test_that("VSIFile works", {
 
     # re-open and test eof
     expect_equal(vf$get_filename(), mem_file)
-    expect_equal(vf$get_access(), "w")
+    expect_equal(vf$get_access(), "w+")
     expect_equal(vf$set_access("r+"), 0)
     expect_no_error(vf$open())
     vf$seek(0, SEEK_END)


### PR DESCRIPTION
Previously we had a test that created a file with:
```r
 vf <- new(VSIFile, mem_file, "w")
```

and after writing data, also tested subsequent reads under the same file handle/access. This worked without error on GDAL <= 3.8.4 and probably later (e.g., 3.9.0?), but the subsequent read does not work under GDAL 3.10.0dev-892f3ecc8d3c6b99004c1575f49fc04ddee9b90a, released 2024/10/13. This PR fixes the test by changing to:
```r
vf <- new(VSIFile, mem_file, "w+")
```

This seems like correct behavior, but also seems to be a behavior change somewhere between GDAL 3.8.4 and 3.10dev.