### PR TITLE
`GDALVector::createDF_()`: avoid clang-asan undefined-behavior error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to the 'Geospatial Data Abstraction Library' Raster API
-Version: 1.12.0.9000
+Version: 1.12.0.9001
 Authors@R: c(
     person("Chris", "Toney", email = "chris.toney@usda.gov",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gdalraster 1.12.0.9001 (dev)
 
-* `GDALVector::createDF_()`: avoid clang-asan undefined-behavior error from `RcppInt64::wrap()` when called on a `std::vector` of size 0 (2025-01-19)
+* `GDALVector::createDF_()`: avoid clang-asan undefined-behavior error from `RcppInt64::wrap()` when called on a `std::vector<int64_t>` of size `0` (2025-01-19)
 
 * `GDALVector`: add a `BBOX` option for the per-object setting `$returnGeomAs` (2024-10-03)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 1.12.0.9000 (dev)
+# gdalraster 1.12.0.9001 (dev)
+
+* `GDALVector::createDF_()`: avoid clang-asan undefined-behavior error from `RcppInt64::wrap()` when called on a `std::vector` of size 0 (2025-01-19)
 
 * `GDALVector`: add a `BBOX` option for the per-object setting `$returnGeomAs` (2024-10-03)
 

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -2047,14 +2047,22 @@ SEXP GDALVector::createDF_(R_xlen_t nrow) const {
 
     size_t col_num = 0;
 
-    std::vector<int64_t> fid{};
-    try {
-        fid.resize(nrow, NA_INTEGER64);
+    // FID column
+    if (nrow > 0) {
+        std::vector<int64_t> fid{};
+        try {
+            fid.resize(nrow, NA_INTEGER64);
+        }
+        catch (const std::exception &) {
+            Rcpp::stop("failed to allocate memory for 'fid' column");
+        }
+        df[col_num] = Rcpp::wrap(fid);
     }
-    catch (const std::exception &) {
-        Rcpp::stop("failed to allocate memory for 'fid' column");
+    else {
+        Rcpp::NumericVector fid(0);
+        fid.attr("class") = "integer64";
+        df[col_num] = fid;
     }
-    df[col_num] = Rcpp::wrap(fid);
     col_names[col_num] = "FID";
 
     for (int i = 0; i < nFields; ++i) {
@@ -2087,14 +2095,21 @@ SEXP GDALVector::createDF_(R_xlen_t nrow) const {
 
             case OFTInteger64:
             {
-                std::vector<int64_t> v{};
-                try {
-                    v.resize(nrow, NA_INTEGER64);
+                if (nrow > 0) {
+                    std::vector<int64_t> v{};
+                    try {
+                        v.resize(nrow, NA_INTEGER64);
+                    }
+                    catch (const std::exception &) {
+                        Rcpp::stop("failed to allocate integer64 column");
+                    }
+                    df[col_num] = Rcpp::wrap(v);
                 }
-                catch (const std::exception &) {
-                    Rcpp::stop("failed to allocate `integer64` column");
+                else {
+                    Rcpp::NumericVector v(0);
+                    v.attr("class") = "integer64";
+                    df[col_num] = v;
                 }
-                df[col_num] = Rcpp::wrap(v);
                 col_names[col_num] = OGR_Fld_GetNameRef(hFieldDefn);
             }
             break;


### PR DESCRIPTION
`RcppInt64::wrap()` uses `std::memcpy()`. If the input vector has size 0, clang-asan reports something like (e.g., in https://github.com/USDAForestService/gdalraster/actions/runs/12849059469):
```
> ## NULL when no more features are available
> lyr$getNextFeature()
/github/home/R/x86_64-pc-linux-gnu-library/4.5/RcppInt64/include/rcppint64_bits/as_wrap.h:102:32: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
    #0 0x7f2e9e5efa44 in SEXPREC* Rcpp::wrap<std::__1::vector<long, std::__1::allocator<long>>>(std::__1::vector<long, std::__1::allocator<long>> const&) /github/home/R/x86_64-pc-linux-gnu-library/4.5/RcppInt64/include/rcppint64_bits/as_wrap.h:102:9
    #1 0x7f2e9e6987ed in GDALVector::createDF_(long) const /__w/gdalraster/gdalraster/check/gdalraster.Rcheck/00_pkg_src/gdalraster/src/gdalvector.cpp:2057:19
    #2 0x7f2e9e693edf in GDALVector::fetch(double) /__w/gdalraster/gdalraster/check/gdalraster.Rcheck/00_pkg_src/gdalraster/src/gdalvector.cpp:1276:36
    #3 0x7f2e9e68d5f9 in GDALVector::getNextFeature() /__w/gdalraster/gdalraster/check/gdalraster.Rcheck/00_pkg_src/gdalraster/src/gdalvector.cpp:581:26
...

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /github/home/R/x86_64-pc-linux-gnu-library/4.5/RcppInt64/include/rcppint64_bits/as_wrap.h:102:32
NULL
```

cf. https://github.com/eddelbuettel/RcppInt64/blob/master/inst/include/rcppint64_bits/as_wrap.h.

If the size of `std::vector<int64_t> v` is zero, `v.data()` may or may not return a null pointer (https://en.cppreference.com/w/cpp/container/vector/data).
In `std::memcpy()`, if either `dest` or `src` is an invalid or null pointer, the behavior is undefined, even if count is zero (https://en.cppreference.com/w/cpp/string/byte/memcpy).

So we should only `wrap()` a vector with size > 0.

