### PR TITLE
Doc: mass update GDAL URLs

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -38,7 +38,7 @@ gdal_version <- function() {
 #'
 #' @note
 #' Virtual I/O refers to operations on GDAL Virtual File Systems. See
-#' \url{https://gdal.org/user/virtual_file_systems.html#virtual-file-systems}.
+#' \url{https://gdal.org/en/stable/user/virtual_file_systems.html#virtual-file-systems}.
 #'
 #' @examples
 #' nrow(gdal_formats())
@@ -56,7 +56,7 @@ gdal_formats <- function(format = "") {
 #' They are used to alter the default behavior of certain raster format
 #' drivers, and in some cases the GDAL core. For a full description and
 #' listing of available options see
-#' \url{https://gdal.org/user/configoptions.html}.
+#' \url{https://gdal.org/en/stable/user/configoptions.html}.
 #'
 #' @param key Character name of a configuration option.
 #' @returns Character. The value of a (key, value) option previously set with
@@ -82,7 +82,7 @@ get_config_option <- function(key) {
 #' They are used to alter the default behavior of certain raster format
 #' drivers, and in some cases the GDAL core. For a full description and
 #' listing of available options see
-#' \url{https://gdal.org/user/configoptions.html}.
+#' \url{https://gdal.org/en/stable/user/configoptions.html}.
 #'
 #' @param key Character name of a configuration option.
 #' @param value Character value to set for the option.
@@ -258,7 +258,7 @@ get_usable_physical_ram <- function() {
 #' [ogrinfo()], [ogr_execute_sql()]
 #'
 #' OGR SQL dialect and SQLITE SQL dialect:\cr
-#' \url{https://gdal.org/user/ogr_sql_sqlite_dialect.html}
+#' \url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html}
 #'
 #' @examples
 #' has_spatialite()
@@ -446,7 +446,7 @@ autoCreateWarpedVRT <- function(src_ds, dst_wkt, resample_alg, src_wkt = "", max
 #' `buildVRT()` is a wrapper of the \command{gdalbuildvrt} command-line
 #' utility for building a VRT (Virtual Dataset) that is a mosaic of the list
 #' of input GDAL datasets
-#' (see \url{https://gdal.org/programs/gdalbuildvrt.html}).
+#' (see \url{https://gdal.org/en/stable/programs/gdalbuildvrt.html}).
 #'
 #' @details
 #' Several command-line options are described in the GDAL documentation at the
@@ -582,7 +582,7 @@ fillNodata <- function(filename, band, mask_file = "", max_dist = 100, smooth_it
 #' Compute footprint of a raster
 #'
 #' `footprint()` is a wrapper of the \command{gdal_footprint} command-line
-#' utility (see \url{https://gdal.org/programs/gdal_footprint.html}).
+#' utility (see \url{https://gdal.org/en/stable/programs/gdal_footprint.html}).
 #' The function can be used to compute the footprint of a raster file, taking
 #' into account nodata values (or more generally the mask band attached to
 #' the raster bands), and generating polygons/multipolygons corresponding to
@@ -630,7 +630,7 @@ footprint <- function(src_filename, dst_filename, cl_arg = NULL) {
 #' Convert vector data between different formats
 #'
 #' `ogr2ogr()` is a wrapper of the \command{ogr2ogr} command-line
-#' utility (see \url{https://gdal.org/programs/ogr2ogr.html}).
+#' utility (see \url{https://gdal.org/en/stable/programs/ogr2ogr.html}).
 #' This function can be used to convert simple features data between file
 #' formats. It can also perform various operations during the process, such
 #' as spatial or attribute selection, reducing the set of attributes, setting
@@ -704,7 +704,7 @@ ogr2ogr <- function(src_dsn, dst_dsn, src_layers = NULL, cl_arg = NULL, open_opt
 #' Retrieve information about a vector data source
 #'
 #' `ogrinfo()` is a wrapper of the \command{ogrinfo} command-line
-#' utility (see \url{https://gdal.org/programs/ogrinfo.html}).
+#' utility (see \url{https://gdal.org/en/stable/programs/ogrinfo.html}).
 #' This function lists information about an OGR-supported data source.
 #' It is also possible to edit data with SQL statements.
 #' Refer to the GDAL documentation at the URL above for a description of
@@ -874,7 +874,7 @@ sieveFilter <- function(src_filename, src_band, dst_filename, dst_band, size_thr
 #' Convert raster data between different formats
 #'
 #' `translate()` is a wrapper of the \command{gdal_translate} command-line
-#' utility (see \url{https://gdal.org/programs/gdal_translate.html}).
+#' utility (see \url{https://gdal.org/en/stable/programs/gdal_translate.html}).
 #'
 #' Called from and documented in R/gdal_util.R
 #'
@@ -887,7 +887,7 @@ sieveFilter <- function(src_filename, src_band, dst_filename, dst_band, size_thr
 #'
 #' `warp()` is a wrapper of the \command{gdalwarp} command-line utility for
 #' raster mosaicing, reprojection and warping
-#' (see \url{https://gdal.org/programs/gdalwarp.html}).
+#' (see \url{https://gdal.org/en/stable/programs/gdalwarp.html}).
 #'
 #' Called from and documented in R/gdal_util.R
 #'
@@ -923,7 +923,7 @@ sieveFilter <- function(src_filename, src_band, dst_filename, dst_band, size_thr
 #' A color entry value to end the ramp (e.g., RGB values).
 #' @param palette_interp One of "Gray", "RGB" (the default), "CMYK" or "HLS"
 #' describing interpretation of `start_color` and `end_color` values
-#' (see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL
+#' (see \href{https://gdal.org/en/stable/user/raster_data_model.html#color-table}{GDAL
 #' Color Table}).
 #' @returns Integer matrix with five columns containing the color ramp from
 #' `start_index` to `end_index`, with raster index values in column 1 and
@@ -1230,7 +1230,7 @@ identifyDriver <- function(filename, raster = TRUE, vector = TRUE, allowed_drive
 #' `vsi_copy_file()` is a wrapper for `VSICopyFile()` in the GDAL Common
 #' Portability Library. The GDAL VSI functions allow virtualization of disk
 #' I/O so that non file data sources can be made to appear as files.
-#' See \url{https://gdal.org/user/virtual_file_systems.html}.
+#' See \url{https://gdal.org/en/stable/user/virtual_file_systems.html}.
 #' Requires GDAL >= 3.7.
 #'
 #' @details
@@ -1618,7 +1618,7 @@ vsi_unlink_batch <- function(filenames) {
 #'
 #' @seealso
 #' GDAL Virtual File Systems:\cr
-#' \url{https://gdal.org/user/virtual_file_systems.html}
+#' \url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 #'
 #' @examples
 #' data_dir <- system.file("extdata", package="gdalraster")
@@ -1693,7 +1693,7 @@ vsi_rename <- function(oldpath, newpath) {
 #' @seealso
 #' [vsi_get_fs_options()]
 #'
-#' \url{https://gdal.org/user/virtual_file_systems.html}
+#' \url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 #'
 #' @examples
 #' vsi_get_fs_prefixes()

--- a/R/gdal_create.R
+++ b/R/gdal_create.R
@@ -29,7 +29,7 @@
 #' @note
 #' `dst_filename` may be an empty string (`""`) with `format = "MEM"` and
 #' `return_obj = TRUE` to create an In-memory Raster
-#' (\url{https://gdal.org/drivers/raster/mem.html}).
+#' (\url{https://gdal.org/en/stable/drivers/raster/mem.html}).
 #' @seealso
 #' [`GDALRaster-class`][GDALRaster], [createCopy()], [getCreationOptions()],
 #' [rasterFromRaster()]
@@ -110,7 +110,7 @@ create <- function(format, dst_filename, xsize, ysize, nbands, dataType,
 #' @note
 #' `dst_filename` may be an empty string (`""`) with `format = "MEM"` and
 #' `return_obj = TRUE` to create an In-memory Raster
-#' (\url{https://gdal.org/drivers/raster/mem.html}).
+#' (\url{https://gdal.org/en/stable/drivers/raster/mem.html}).
 #' @seealso
 #' [`GDALRaster-class`][GDALRaster], [create()], [getCreationOptions()],
 #' [rasterFromRaster()], [translate()]

--- a/R/gdal_helpers.R
+++ b/R/gdal_helpers.R
@@ -9,7 +9,7 @@
 #' in the GDAL Common Portability Library, but optionally creates a new ZIP
 #' file first (with `CPLCreateZip()`). It provides a subset of functionality
 #' in the GDAL `sozip` command-line utility
-#' (\url{https://gdal.org/programs/sozip.html}). Requires GDAL >= 3.7.
+#' (\url{https://gdal.org/en/stable/programs/sozip.html}). Requires GDAL >= 3.7.
 #'
 #' @details
 #' A Seek-Optimized ZIP file (SOZip) contains one or more compressed files
@@ -83,7 +83,7 @@
 #'   print(unzip(zip_file, list=TRUE))
 #'
 #'   # Open with GDAL using Virtual File System handler '/vsizip/'
-#'   # see: https://gdal.org/user/virtual_file_systems.html#vsizip-zip-archives
+#'   # see: https://gdal.org/en/stable/user/virtual_file_systems.html#vsizip-zip-archives
 #'   lcp_in_zip <- file.path("/vsizip", zip_file, "storm_lake.lcp")
 #'   print("SOZip metadata:")
 #'   print(vsi_get_file_metadata(lcp_in_zip, domain="ZIP"))
@@ -280,7 +280,7 @@ getCreationOptions <- function(format, filter=NULL) {
 #' @seealso
 #' [set_config_option()], [vsi_get_fs_prefixes()]
 #'
-#' \url{https://gdal.org/user/virtual_file_systems.html}
+#' \url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 #'
 #' @examples
 #' vsi_get_fs_options("/vsimem/")
@@ -501,7 +501,7 @@ dump_open_datasets <- function() {
 #'@note
 #' Subdataset names are the character strings that can be used to
 #' instantiate `GDALRaster` objects.
-#' See https://gdal.org/en/latest/user/raster_data_model.html#subdatasets-domain.
+#' See https://gdal.org/en/stable/en/latest/user/raster_data_model.html#subdatasets-domain.
 #'
 #' @seealso
 #' [gdal_formats()], [identifyDriver()]

--- a/R/gdal_util.R
+++ b/R/gdal_util.R
@@ -4,7 +4,7 @@
 #' Convert raster data between different formats
 #'
 #' `translate()` is a wrapper of the \command{gdal_translate} command-line
-#' utility (see \url{https://gdal.org/programs/gdal_translate.html}).
+#' utility (see \url{https://gdal.org/en/stable/programs/gdal_translate.html}).
 #' The function can be used to convert raster data between different
 #' formats, potentially performing some operations like subsetting,
 #' resampling, and rescaling pixels in the process. Refer to the GDAL
@@ -88,7 +88,7 @@ translate <- function(src_filename, dst_filename, cl_arg = NULL,
 #'
 #' `warp()` is a wrapper of the \command{gdalwarp} command-line utility for
 #' raster reprojection and warping
-#' (see \url{https://gdal.org/programs/gdalwarp.html}).
+#' (see \url{https://gdal.org/en/stable/programs/gdalwarp.html}).
 #' The function can reproject to any supported spatial reference system (SRS).
 #' It can also be used to crop, mosaic, resample, and optionally write output
 #' to a different raster format. See Details for a list of commonly used
@@ -127,7 +127,7 @@ translate <- function(src_filename, dst_filename, cl_arg = NULL,
 #'   higher quality resampling method).
 #'   * `-wo <NAME>=<VALUE>`\cr
 #'   Set a warp option as described in the GDAL documentation for
-#'   [`GDALWarpOptions`](https://gdal.org/api/gdalwarp_cpp.html#_CPPv415GDALWarpOptions)
+#'   [`GDALWarpOptions`](https://gdal.org/en/stable/api/gdalwarp_cpp.html#_CPPv415GDALWarpOptions)
 #'   Multiple `-wo` may be given. See also `-multi` below.
 #'   * `-ot <type>`\cr
 #'   Force the output raster bands to have a specific data type supported by
@@ -199,7 +199,7 @@ translate <- function(src_filename, dst_filename, cl_arg = NULL,
 #'   For example, the GeoTIFF driver supports creation options to control
 #'   compression, and whether the file should be tiled.
 #'   [getCreationOptions()] can be used to look up available creation options,
-#'   but the GDAL [Raster drivers](https://gdal.org/drivers/raster/index.html)
+#'   but the GDAL [Raster drivers](https://gdal.org/en/stable/drivers/raster/index.html)
 #'   documentation is the definitive reference for format specific options.
 #'   Multiple `-co` may be given, e.g.,
 #'   \preformatted{ c("-co", "COMPRESS=LZW", "-co", "BIGTIFF=YES") }
@@ -209,7 +209,7 @@ translate <- function(src_filename, dst_filename, cl_arg = NULL,
 #'   is not specified and the output file already exists, it will be updated
 #'   in place.
 #'
-#' The documentation for [`gdalwarp`](https://gdal.org/programs/gdalwarp.html)
+#' The documentation for [`gdalwarp`](https://gdal.org/en/stable/programs/gdalwarp.html)
 #' describes additional command-line options related to spatial reference
 #' systems, alpha bands, masking with polygon cutlines including blending,
 #' and more.

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -8,7 +8,7 @@
 #' @description
 #' `GDALRaster` provides an interface for accessing a raster dataset via GDAL
 #' and calling methods on the underlying `GDALDataset`, `GDALDriver` and
-#' `GDALRasterBand` objects. See \url{https://gdal.org/api/index.html} for
+#' `GDALRasterBand` objects. See \url{https://gdal.org/en/stable/api/index.html} for
 #' details of the GDAL Raster API.
 #'
 #' @param filename Character string containing the file name of a raster
@@ -17,7 +17,7 @@
 #' contain format-specific information on how to access a dataset such
 #' as database connection string, URL, /vsiPREFIX/, etc. (see GDAL
 #' raster format descriptions:
-#' \url{https://gdal.org/drivers/raster/index.html}).
+#' \url{https://gdal.org/en/stable/drivers/raster/index.html}).
 #' @param read_only Logical. `TRUE` to open the dataset read-only (the default),
 #' or `FALSE` to open with write access.
 #' @param open_options Optional character vector of `NAME=VALUE` pairs
@@ -252,7 +252,7 @@
 #' Returns the affine transformation coefficients for transforming between
 #' pixel/line raster space (column/row) and projection coordinate space
 #' (geospatial x/y). The return value is a numeric vector of length six.
-#' See \url{https://gdal.org/tutorials/geotransforms_tut.html}
+#' See \url{https://gdal.org/en/stable/tutorials/geotransforms_tut.html}
 #' for details of the affine transformation. \emph{With 1-based indexing
 #' in R}, the geotransform vector contains (in map units of the raster spatial
 #' reference system):
@@ -376,7 +376,7 @@
 #' (e.g., `set_config_option("COMPRESS_OVERVIEW", "LZW")`).
 #' Since GDAL 3.6, `COMPRESS_OVERVIEW` is honoured when creating internal
 #' overviews of GTiff files. The [GDAL documentation for
-#' `gdaladdo`](https://gdal.org/programs/gdaladdo.html) command-line utility
+#' `gdaladdo`](https://gdal.org/en/stable/programs/gdaladdo.html) command-line utility
 #' describes additional configuration for overview building.
 #' See also [set_config_option()]. No return value, called for side effects.
 #'
@@ -442,7 +442,7 @@
 #' be treated as valid data). But masks may not be regular raster bands on the
 #' datasource, such as an implied mask from a band nodata value or the
 #' `ALL_VALID` mask. See RFC 15: Band Masks for more details
-#' (\url{https://gdal.org/development/rfc/rfc15_nodatabitmask.html}.
+#' (\url{https://gdal.org/en/stable/development/rfc/rfc15_nodatabitmask.html}.
 #'
 #' Returns a named list of GDAL mask flags and their logical values, with the
 #' following definitions:
@@ -597,7 +597,7 @@
 #' Returns a character vector of all metadata `NAME=VALUE` pairs that exist in
 #' the specified \code{domain}, or empty string (`""`) if there are no
 #' metadata items in \code{domain} (metadata in the context of the GDAL
-#' Raster Data Model: \url{https://gdal.org/user/raster_data_model.html}).
+#' Raster Data Model: \url{https://gdal.org/en/stable/user/raster_data_model.html}).
 #' Set \code{band = 0} to retrieve dataset-level metadata, or to an integer
 #' band number to retrieve band-level metadata.
 #' Set \code{domain = ""} (empty string) to retrieve metadata in the
@@ -694,7 +694,7 @@
 #' integer matrix with five columns. To associate a color with a raster pixel,
 #' the pixel value is used as a subscript into the color table. This means that
 #' the colors are always applied starting at zero and ascending
-#' (see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL
+#' (see \href{https://gdal.org/en/stable/user/raster_data_model.html#color-table}{GDAL
 #' Color Table}).
 #' Column 1 contains the pixel values. Interpretation of columns 2:5 depends
 #' on the value of `$getPaletteInterp()` (see below). For "RGB", columns 2:5
@@ -713,7 +713,7 @@
 #'
 #' \code{$setColorTable(band, col_tbl, palette_interp)}\cr
 #' Sets the raster color table for \code{band}
-#' (see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL
+#' (see \href{https://gdal.org/en/stable/user/raster_data_model.html#color-table}{GDAL
 #' Color Table}).
 #' \code{col_tbl} is an integer matrix or data frame with either four or five
 #' columns (see \code{$getColorTable()} above). Column 1 contains the pixel
@@ -846,7 +846,7 @@
 #' ds$getNoDataValue(band = 1)
 #'
 #' ## LCP driver reports several dataset- and band-level metadata
-#' ## see the format description at https://gdal.org/drivers/raster/lcp.html
+#' ## see the format description at https://gdal.org/en/stable/drivers/raster/lcp.html
 #' ## set band = 0 to retrieve dataset-level metadata
 #' ## set domain = "" (empty string) for the default metadata domain
 #' ds$getMetadata(band = 0, domain = "")
@@ -906,7 +906,7 @@
 #' \dontshow{deleteDataset(new_file)}
 #' \donttest{
 #' ## using a GDAL Virtual File System handler '/vsicurl/'
-#' ## see: https://gdal.org/user/virtual_file_systems.html
+#' ## see: https://gdal.org/en/stable/user/virtual_file_systems.html
 #' url <- "/vsicurl/https://raw.githubusercontent.com/"
 #' url <- paste0(url, "usdaforestservice/gdalraster/main/sample-data/")
 #' url <- paste0(url, "lf_elev_220_mt_hood_utm.tif")

--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -38,7 +38,7 @@ DEFAULT_NODATA <- list(
 #' @seealso
 #' [dem_proc()]
 #'
-#' \url{https://gdal.org/programs/gdaldem.html} for a description of all
+#' \url{https://gdal.org/en/stable/programs/gdaldem.html} for a description of all
 #' available command-line options for each processing mode
 #' @export
 DEFAULT_DEM_PROC <- list(
@@ -414,7 +414,7 @@ rasterFromRaster <- function(srcfile, dstfile, fmt=NULL, nbands=NULL,
 #' elements of the XML schema describe how the source data will be read, along
 #' with algorithms potentially applied and so forth. Documentation of the XML
 #' format for .vrt is at:
-#' \url{https://gdal.org/drivers/raster/vrt.html}.
+#' \url{https://gdal.org/en/stable/drivers/raster/vrt.html}.
 #'
 #' Since .vrt is a small plain-text file it is fast to write and requires
 #' little storage space. Read performance is not degraded for certain simple
@@ -1365,7 +1365,7 @@ combine <- function(rasterfiles, var.names=NULL, bands=NULL,
 #' @description
 #' `dem_proc()` generates DEM derivatives from an input elevation raster. This
 #' function is a wrapper for the \command{gdaldem} command-line utility.
-#' See \url{https://gdal.org/programs/gdaldem.html} for details.
+#' See \url{https://gdal.org/en/stable/programs/gdaldem.html} for details.
 #'
 #' @param mode Character. Name of the DEM processing mode. One of hillshade,
 #' slope, aspect, color-relief, TRI, TPI or roughness.
@@ -1383,7 +1383,7 @@ combine <- function(rasterfiles, var.names=NULL, bands=NULL,
 #' @note
 #' Band 1 of the source elevation raster is read by default, but this can be
 #' changed by including a `-b` command-line argument in `mode_options`.
-#' See the \href{https://gdal.org/programs/gdaldem.html}{documentation for
+#' See the \href{https://gdal.org/en/stable/programs/gdaldem.html}{documentation for
 #' `gdaldem`} for a description of all available options for each processing
 #' mode.
 #'
@@ -1423,7 +1423,7 @@ dem_proc <- function(mode,
 #' exist, otherwise it will try to append to an existing one.
 #' This function is a wrapper of `GDALPolygonize` in the GDAL Algorithms API.
 #' It provides essentially the same functionality as the `gdal_polygonize.py`
-#' command-line program (\url{https://gdal.org/programs/gdal_polygonize.html}).
+#' command-line program (\url{https://gdal.org/en/stable/programs/gdal_polygonize.html}).
 #'
 #' @details
 #' Polygon features will be created on the output layer, with polygon
@@ -1627,7 +1627,7 @@ polygonize <- function(raster_file,
 #' the band(s) of a raster dataset. Vectors are read from any GDAL
 #' OGR-supported vector format.
 #' This function is a wrapper for the \command{gdal_rasterize} command-line
-#' utility (\url{https://gdal.org/programs/gdal_rasterize.html}).
+#' utility (\url{https://gdal.org/en/stable/programs/gdal_rasterize.html}).
 #'
 #' @param src_dsn Data source name for the input vector layer (filename or
 #' connection string).

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -11,7 +11,7 @@
 #' An object of class `GDALVector` persists an open connection to the dataset,
 #' and exposes methods for retrieving layer information, setting attribute and
 #' spatial filters, and reading/writing feature data.
-#' See \url{https://gdal.org/api/index.html} for details of the GDAL
+#' See \url{https://gdal.org/en/stable/api/index.html} for details of the GDAL
 #' Vector API.
 #'
 #' **Class `GDALVector` is currently under development**. An initial
@@ -232,7 +232,7 @@
 #' `ReorderFields`, `AlterFieldDefn`, `AlterGeomFieldDefn`, `DeleteFeature`,
 #' `StringsAsUTF8`, `Transactions`, `CurveGeometries`.
 #' (See the GDAL documentation for
-#' [`OGR_L_TestCapability()`](https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc).)
+#' [`OGR_L_TestCapability()`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc).)
 #'
 #' \code{$getFIDColumn()}\cr
 #' Returns the name of the underlying database column being used as the FID
@@ -286,7 +286,7 @@
 #' `$getNextFeature()` or `$fetch()` methods.
 #' Only features for which `query` evaluates as true will be returned.
 #' The query string should be in the format of an SQL WHERE clause, described
-#' in the ["WHERE"](https://gdal.org/user/ogr_sql_dialect.html#where)
+#' in the ["WHERE"](https://gdal.org/en/stable/user/ogr_sql_dialect.html#where)
 #' section of the OGR SQL dialect documentation (e.g.,
 #' `"population > 1000000 and population < 5000000"`, where `population` is an
 #' attribute in the layer).
@@ -606,10 +606,10 @@
 #' [ogr_define], [ogr_manage], [ogr2ogr()], [ogrinfo()]
 #'
 #' GDAL vector format descriptions:\cr
-#' \url{https://gdal.org/drivers/vector/index.html}
+#' \url{https://gdal.org/en/stable/drivers/vector/index.html}
 #'
 #' GDAL-supported SQL dialects:\cr
-#' \url{https://gdal.org/user/ogr_sql_sqlite_dialect.html})
+#' \url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html})
 #'
 #' @examples
 #' ## MTBS fire perimeters in Yellowstone National Park 1984-2022

--- a/R/ogr_define.R
+++ b/R/ogr_define.R
@@ -76,7 +76,7 @@
 #' Common types include: `Point`, `LineString`, `Polygon`, `MultiPoint`,
 #' `MultiLineString`, `MultiPolygon`. See the GDAL documentation for a list
 #' of all supported geometry types:\cr
-#' \url{https://gdal.org/api/vector_c_api.html#_CPPv418OGRwkbGeometryType}
+#' \url{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv418OGRwkbGeometryType}
 #'
 #' Format drivers may or may not support not-null constraints on attribute and
 #' geometry fields. If they support creating fields with not-null constraints,
@@ -110,8 +110,8 @@
 #' The feature id (FID) is a special property of a feature and not treated as
 #' an attribute of the feature. Additional information is given in the GDAL
 #' documentation for the
-#' [OGR SQL](https://gdal.org/user/ogr_sql_dialect.html#feature-id-fid) and
-#' [SQLite](https://gdal.org/user/sql_sqlite_dialect.html#feature-id-fid)
+#' [OGR SQL](https://gdal.org/en/stable/user/ogr_sql_dialect.html#feature-id-fid) and
+#' [SQLite](https://gdal.org/en/stable/user/sql_sqlite_dialect.html#feature-id-fid)
 #' SQL dialects. Implications for SQL statements and result sets may depend
 #' on the dialect used.
 #'

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -15,7 +15,7 @@
 #' vector data management. They are also intended to support vector I/O in a
 #' future release of gdalraster. Bindings to OGR wrap portions of the GDAL
 #' Vector API (ogr_core.h and ogr_api.h,
-#' \url{https://gdal.org/api/vector_c_api.html}).
+#' \url{https://gdal.org/en/stable/api/vector_c_api.html}).
 #'
 #' `ogr_ds_exists()` tests whether a vector dataset can be opened from the
 #' given data source name (DSN), potentially testing for update access.
@@ -76,7 +76,7 @@
 #' `ReorderFields`, `AlterFieldDefn`, `AlterGeomFieldDefn`, `IgnoreFields`,
 #' `DeleteFeature`, `Rename`, `StringsAsUTF8`, `CurveGeometries`.
 #' See the GDAL documentation for
-#' [`OGR_L_TestCapability()`](https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc).
+#' [`OGR_L_TestCapability()`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc).
 #'
 #' `ogr_layer_create()` creates a new layer in an existing vector data source,
 #' with a specified geometry type and spatial reference definition.
@@ -213,7 +213,7 @@
 #'
 #' Other SQL dialects may also be present for some vector formats.
 #' For example, the `"INDIRECT_SQLITE"` dialect might potentially be used with
-#' GeoPackage format (\url{https://gdal.org/drivers/vector/gpkg.html#sql}).
+#' GeoPackage format (\url{https://gdal.org/en/stable/drivers/vector/gpkg.html#sql}).
 #'
 #' The function [ogrinfo()] can also be used to edit data with SQL statements
 #' (GDAL >= 3.7).
@@ -227,7 +227,7 @@
 #  [ogr_define] helper functions, [ogrinfo()], [ogr2ogr()]
 #'
 #' OGR SQL dialect and SQLite SQL dialect:\cr
-#' \url{https://gdal.org/user/ogr_sql_sqlite_dialect.html}
+#' \url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html}
 #'
 #' @examples
 #' ## Create GeoPackage and manage schema

--- a/R/ogr_proc.R
+++ b/R/ogr_proc.R
@@ -14,7 +14,7 @@
 #' be appended to an existing layer, or written to an existing empty layer that
 #' has a custom schema defined.
 #' `ogr_proc()` is basically a port of the
-#' [`ogr_layer_algebra`](https://gdal.org/programs/ogr_layer_algebra.html#ogr-layer-algebra)
+#' [`ogr_layer_algebra`](https://gdal.org/en/stable/programs/ogr_layer_algebra.html#ogr-layer-algebra)
 #' utility in the GDAL Python bindings.
 #'
 #' @details

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -22,7 +22,7 @@ SEEK_END <- "SEEK_END"
 #' @description
 #' `VSIFile` provides bindings to the GDAL VSIVirtualHandle API. Encapsulates a
 #' `VSIVirtualHandle`
-#' (\url{https://gdal.org/api/cpl_cpp.html#_CPPv416VSIVirtualHandle}).
+#' (\url{https://gdal.org/en/stable/api/cpl_cpp.html#_CPPv416VSIVirtualHandle}).
 #' This API abstracts binary file I/O across "regular" file systems, URLs,
 #' cloud storage services, Zip/GZip/7z/RAR, and in-memory files.
 #' It provides analogs of several Standard C file I/O functions, allowing
@@ -31,7 +31,7 @@ SEEK_END <- "SEEK_END"
 #'
 #' @param filename Character string containing the filename to open. It may be
 #' a file in a regular local filesystem, or a filename with a GDAL /vsiPREFIX/
-#' (see \url{https://gdal.org/user/virtual_file_systems.html}).
+#' (see \url{https://gdal.org/en/stable/user/virtual_file_systems.html}).
 #' @param access Character string containing the access requested (i.e., `"r"`,
 #' `"r+"`, `"w"`, `"w+`). Defaults to `"r"`. Binary access is always implied
 #' and the "b" does not need to be included in `access`.
@@ -217,13 +217,13 @@ SEEK_END <- "SEEK_END"
 #' @seealso
 #' GDAL Virtual File Systems (compressed, network hosted, etc...):\cr
 #' /vsimem, /vsizip, /vsitar, /vsicurl, ...\cr
-#' \url{https://gdal.org/user/virtual_file_systems.html}
+#' \url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 #'
 #' [vsi_copy_file()], [vsi_read_dir()], [vsi_stat()], [vsi_unlink()]
 #'
 #' @examples
 #' # The examples make use of the FARSITE LCP format specification at:
-#' # https://gdal.org/drivers/raster/lcp.html
+#' # https://gdal.org/en/stable/drivers/raster/lcp.html
 #' # An LCP file is a raw format with a 7,316-byte header. The format
 #' # specification gives byte offets and data types for fields in the header.
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-**gdalraster** is an R interface to the [Raster API](https://gdal.org/api/raster_c_api.html) of the Geospatial Data Abstraction Library ([GDAL](https://gdal.org/)). Bindings to a subset of the GDAL [Vector API](https://gdal.org/api/vector_c_api.html) are included to provide utilities for managing vector data sources. Bindings to the GDAL Virtual Systems Interface ([VSI](https://gdal.org/api/cpl.html#cpl-vsi-h)) support file system operations and binary I/O on URLs, cloud storage services, Zip/GZip/7z/RAR, and in-memory files, as well as regular file systems. Calling signatures resemble the native C, C++ and Python APIs provided by the GDAL project.
+**gdalraster** is an R interface to the [Raster API](https://gdal.org/en/stable/en/stable/api/raster_c_api.html) of the Geospatial Data Abstraction Library ([GDAL](https://gdal.org/en/stable/)). Bindings to a subset of the GDAL [Vector API](https://gdal.org/en/stable/api/vector_c_api.html) are included to provide utilities for managing vector data sources. Bindings to the GDAL Virtual Systems Interface ([VSI](https://gdal.org/en/stable/api/cpl.html#cpl-vsi-h)) support file system operations and binary I/O on URLs, cloud storage services, Zip/GZip/7z/RAR, and in-memory files, as well as regular file systems. Calling signatures resemble the native C, C++ and Python APIs provided by the GDAL project.
 
 Bindings to GDAL are implemented in the exposed C++ class [`GDALRaster`](https://usdaforestservice.github.io/gdalraster/reference/GDALRaster-class.html) along with several [stand-alone functions](https://usdaforestservice.github.io/gdalraster/reference/index.html#stand-alone-functions), supporting:
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Scorecard](https://api.scorecard.dev/projects/github.com/USDAForestService/gdalr
 ## Overview
 
 **gdalraster** is an R interface to the [Raster
-API](https://gdal.org/api/raster_c_api.html) of the Geospatial Data
-Abstraction Library ([GDAL](https://gdal.org/)). Bindings to a subset of
-the GDAL [Vector API](https://gdal.org/api/vector_c_api.html) are
+API](https://gdal.org/en/stable/api/raster_c_api.html) of the Geospatial Data
+Abstraction Library ([GDAL](https://gdal.org/en/stable/)). Bindings to a subset of
+the GDAL [Vector API](https://gdal.org/en/stable/api/vector_c_api.html) are
 included to provide utilities for managing vector data sources. Bindings
 to the GDAL Virtual Systems Interface
-([VSI](https://gdal.org/api/cpl.html#cpl-vsi-h)) support file system
+([VSI](https://gdal.org/en/stable/api/cpl.html#cpl-vsi-h)) support file system
 operations and binary I/O on URLs, cloud storage services,
 Zip/GZip/7z/RAR, and in-memory files, as well as regular file systems.
 Calling signatures resemble the native C, C++ and Python APIs provided

--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -1,12 +1,12 @@
 =====GDAL API documentation ===================================================
 Much of the documentation for class 'GDALRaster' and several GDAL wrapper
-functions was copied from the GDAL API documentation at: https://gdal.org/api/.
+functions was copied from the GDAL API documentation at: https://gdal.org/en/stable/api/.
 
 The package vignette is an R port of the GDAL Raster API Tutorial at:
-https://gdal.org/tutorials/raster_api_tut.html.
+https://gdal.org/en/stable/tutorials/raster_api_tut.html.
 
 Copyright 1998-2025 Frank Warmerdam, Even Rouault, and others.
-https://gdal.org/license.html
+https://gdal.org/en/stable/license.html
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to deal

--- a/man/DEFAULT_DEM_PROC.Rd
+++ b/man/DEFAULT_DEM_PROC.Rd
@@ -28,7 +28,7 @@ These values are used in \code{dem_proc()} as the default processing options:
 \seealso{
 \code{\link[=dem_proc]{dem_proc()}}
 
-\url{https://gdal.org/programs/gdaldem.html} for a description of all
+\url{https://gdal.org/en/stable/programs/gdaldem.html} for a description of all
 available command-line options for each processing mode
 }
 \keyword{datasets}

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -13,7 +13,7 @@ In some cases, \code{filename} may not refer to a local file system, but instead
 contain format-specific information on how to access a dataset such
 as database connection string, URL, /vsiPREFIX/, etc. (see GDAL
 raster format descriptions:
-\url{https://gdal.org/drivers/raster/index.html}).}
+\url{https://gdal.org/en/stable/drivers/raster/index.html}).}
 
 \item{read_only}{Logical. \code{TRUE} to open the dataset read-only (the default),
 or \code{FALSE} to open with write access.}
@@ -34,7 +34,7 @@ the \code{$} operator. The read/write fields can be used for per-object settings
 \description{
 \code{GDALRaster} provides an interface for accessing a raster dataset via GDAL
 and calling methods on the underlying \code{GDALDataset}, \code{GDALDriver} and
-\code{GDALRasterBand} objects. See \url{https://gdal.org/api/index.html} for
+\code{GDALRasterBand} objects. See \url{https://gdal.org/en/stable/api/index.html} for
 details of the GDAL Raster API.
 }
 \note{
@@ -287,7 +287,7 @@ or \code{FALSE} if a band could not be added.
 Returns the affine transformation coefficients for transforming between
 pixel/line raster space (column/row) and projection coordinate space
 (geospatial x/y). The return value is a numeric vector of length six.
-See \url{https://gdal.org/tutorials/geotransforms_tut.html}
+See \url{https://gdal.org/en/stable/tutorials/geotransforms_tut.html}
 for details of the affine transformation. \emph{With 1-based indexing
 in R}, the geotransform vector contains (in map units of the raster spatial
 reference system):
@@ -410,7 +410,7 @@ External overviews created in GTiff format may be compressed using the
 by the GTiff driver are available
 (e.g., \code{set_config_option("COMPRESS_OVERVIEW", "LZW")}).
 Since GDAL 3.6, \code{COMPRESS_OVERVIEW} is honoured when creating internal
-overviews of GTiff files. The \href{https://gdal.org/programs/gdaladdo.html}{GDAL documentation for \code{gdaladdo}} command-line utility
+overviews of GTiff files. The \href{https://gdal.org/en/stable/programs/gdaladdo.html}{GDAL documentation for \code{gdaladdo}} command-line utility
 describes additional configuration for overview building.
 See also \code{\link[=set_config_option]{set_config_option()}}. No return value, called for side effects.
 
@@ -476,7 +476,7 @@ normal Byte alpha (transparency) band as mask (any value other than \code{0} to
 be treated as valid data). But masks may not be regular raster bands on the
 datasource, such as an implied mask from a band nodata value or the
 \code{ALL_VALID} mask. See RFC 15: Band Masks for more details
-(\url{https://gdal.org/development/rfc/rfc15_nodatabitmask.html}.
+(\url{https://gdal.org/en/stable/development/rfc/rfc15_nodatabitmask.html}.
 
 Returns a named list of GDAL mask flags and their logical values, with the
 following definitions:
@@ -637,7 +637,7 @@ bound), \verb{$max} (upper bound), \verb{$num_buckets} (number of buckets), and
 Returns a character vector of all metadata \code{NAME=VALUE} pairs that exist in
 the specified \code{domain}, or empty string (\code{""}) if there are no
 metadata items in \code{domain} (metadata in the context of the GDAL
-Raster Data Model: \url{https://gdal.org/user/raster_data_model.html}).
+Raster Data Model: \url{https://gdal.org/en/stable/user/raster_data_model.html}).
 Set \code{band = 0} to retrieve dataset-level metadata, or to an integer
 band number to retrieve band-level metadata.
 Set \code{domain = ""} (empty string) to retrieve metadata in the
@@ -734,7 +734,7 @@ there is no associated color table. The color table is returned as an
 integer matrix with five columns. To associate a color with a raster pixel,
 the pixel value is used as a subscript into the color table. This means that
 the colors are always applied starting at zero and ascending
-(see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL
+(see \href{https://gdal.org/en/stable/user/raster_data_model.html#color-table}{GDAL
 Color Table}).
 Column 1 contains the pixel values. Interpretation of columns 2:5 depends
 on the value of \verb{$getPaletteInterp()} (see below). For "RGB", columns 2:5
@@ -755,7 +755,7 @@ meanings are:
 
 \code{$setColorTable(band, col_tbl, palette_interp)}\cr
 Sets the raster color table for \code{band}
-(see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL
+(see \href{https://gdal.org/en/stable/user/raster_data_model.html#color-table}{GDAL
 Color Table}).
 \code{col_tbl} is an integer matrix or data frame with either four or five
 columns (see \code{$getColorTable()} above). Column 1 contains the pixel
@@ -861,7 +861,7 @@ ds$getDataTypeName(band = 1)
 ds$getNoDataValue(band = 1)
 
 ## LCP driver reports several dataset- and band-level metadata
-## see the format description at https://gdal.org/drivers/raster/lcp.html
+## see the format description at https://gdal.org/en/stable/drivers/raster/lcp.html
 ## set band = 0 to retrieve dataset-level metadata
 ## set domain = "" (empty string) for the default metadata domain
 ds$getMetadata(band = 0, domain = "")
@@ -921,7 +921,7 @@ ds_new$close()
 \dontshow{deleteDataset(new_file)}
 \donttest{
 ## using a GDAL Virtual File System handler '/vsicurl/'
-## see: https://gdal.org/user/virtual_file_systems.html
+## see: https://gdal.org/en/stable/user/virtual_file_systems.html
 url <- "/vsicurl/https://raw.githubusercontent.com/"
 url <- paste0(url, "usdaforestservice/gdalraster/main/sample-data/")
 url <- paste0(url, "lf_elev_220_mt_hood_utm.tif")

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -45,7 +45,7 @@ dataset and calling methods on the underlying \code{OGRLayer} object.
 An object of class \code{GDALVector} persists an open connection to the dataset,
 and exposes methods for retrieving layer information, setting attribute and
 spatial filters, and reading/writing feature data.
-See \url{https://gdal.org/api/index.html} for details of the GDAL
+See \url{https://gdal.org/en/stable/api/index.html} for details of the GDAL
 Vector API.
 
 \strong{Class \code{GDALVector} is currently under development}. An initial
@@ -247,7 +247,7 @@ read/write access. Returns a list of capabilities with values \code{TRUE} or
 \code{ReorderFields}, \code{AlterFieldDefn}, \code{AlterGeomFieldDefn}, \code{DeleteFeature},
 \code{StringsAsUTF8}, \code{Transactions}, \code{CurveGeometries}.
 (See the GDAL documentation for
-\href{https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc}{\code{OGR_L_TestCapability()}}.)
+\href{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc}{\code{OGR_L_TestCapability()}}.)
 
 \code{$getFIDColumn()}\cr
 Returns the name of the underlying database column being used as the FID
@@ -301,7 +301,7 @@ Sets an attribute query string to be used when fetching features via the
 \verb{$getNextFeature()} or \verb{$fetch()} methods.
 Only features for which \code{query} evaluates as true will be returned.
 The query string should be in the format of an SQL WHERE clause, described
-in the \href{https://gdal.org/user/ogr_sql_dialect.html#where}{"WHERE"}
+in the \href{https://gdal.org/en/stable/user/ogr_sql_dialect.html#where}{"WHERE"}
 section of the OGR SQL dialect documentation (e.g.,
 \code{"population > 1000000 and population < 5000000"}, where \code{population} is an
 attribute in the layer).
@@ -832,8 +832,8 @@ lyr$close()
 \link{ogr_define}, \link{ogr_manage}, \code{\link[=ogr2ogr]{ogr2ogr()}}, \code{\link[=ogrinfo]{ogrinfo()}}
 
 GDAL vector format descriptions:\cr
-\url{https://gdal.org/drivers/vector/index.html}
+\url{https://gdal.org/en/stable/drivers/vector/index.html}
 
 GDAL-supported SQL dialects:\cr
-\url{https://gdal.org/user/ogr_sql_sqlite_dialect.html})
+\url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html})
 }

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -9,7 +9,7 @@
 \arguments{
 \item{filename}{Character string containing the filename to open. It may be
 a file in a regular local filesystem, or a filename with a GDAL /vsiPREFIX/
-(see \url{https://gdal.org/user/virtual_file_systems.html}).}
+(see \url{https://gdal.org/en/stable/user/virtual_file_systems.html}).}
 
 \item{access}{Character string containing the access requested (i.e., \code{"r"},
 \code{"r+"}, \code{"w"}, \verb{"w+}). Defaults to \code{"r"}. Binary access is always implied
@@ -35,7 +35,7 @@ Details. \code{VSIFile} is a C++ class exposed directly to R (via
 \description{
 \code{VSIFile} provides bindings to the GDAL VSIVirtualHandle API. Encapsulates a
 \code{VSIVirtualHandle}
-(\url{https://gdal.org/api/cpl_cpp.html#_CPPv416VSIVirtualHandle}).
+(\url{https://gdal.org/en/stable/api/cpl_cpp.html#_CPPv416VSIVirtualHandle}).
 This API abstracts binary file I/O across "regular" file systems, URLs,
 cloud storage services, Zip/GZip/7z/RAR, and in-memory files.
 It provides analogs of several Standard C file I/O functions, allowing
@@ -219,7 +219,7 @@ Returns \code{0} on success or \code{-1} on error.
 
 \examples{
 # The examples make use of the FARSITE LCP format specification at:
-# https://gdal.org/drivers/raster/lcp.html
+# https://gdal.org/en/stable/drivers/raster/lcp.html
 # An LCP file is a raw format with a 7,316-byte header. The format
 # specification gives byte offets and data types for fields in the header.
 
@@ -321,7 +321,7 @@ ds$close()
 \seealso{
 GDAL Virtual File Systems (compressed, network hosted, etc...):\cr
 /vsimem, /vsizip, /vsitar, /vsicurl, ...\cr
-\url{https://gdal.org/user/virtual_file_systems.html}
+\url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 
 \code{\link[=vsi_copy_file]{vsi_copy_file()}}, \code{\link[=vsi_read_dir]{vsi_read_dir()}}, \code{\link[=vsi_stat]{vsi_stat()}}, \code{\link[=vsi_unlink]{vsi_unlink()}}
 }

--- a/man/addFilesInZip.Rd
+++ b/man/addFilesInZip.Rd
@@ -65,7 +65,7 @@ extension. This function is basically a wrapper for \code{CPLAddFileInZip()}
 in the GDAL Common Portability Library, but optionally creates a new ZIP
 file first (with \code{CPLCreateZip()}). It provides a subset of functionality
 in the GDAL \code{sozip} command-line utility
-(\url{https://gdal.org/programs/sozip.html}). Requires GDAL >= 3.7.
+(\url{https://gdal.org/en/stable/programs/sozip.html}). Requires GDAL >= 3.7.
 }
 \details{
 A Seek-Optimized ZIP file (SOZip) contains one or more compressed files
@@ -107,7 +107,7 @@ if (as.integer(gdal_version()[2]) >= 3070000) {
   print(unzip(zip_file, list=TRUE))
 
   # Open with GDAL using Virtual File System handler '/vsizip/'
-  # see: https://gdal.org/user/virtual_file_systems.html#vsizip-zip-archives
+  # see: https://gdal.org/en/stable/user/virtual_file_systems.html#vsizip-zip-archives
   lcp_in_zip <- file.path("/vsizip", zip_file, "storm_lake.lcp")
   print("SOZip metadata:")
   print(vsi_get_file_metadata(lcp_in_zip, domain="ZIP"))

--- a/man/buildVRT.Rd
+++ b/man/buildVRT.Rd
@@ -25,7 +25,7 @@ An error is raised if the operation fails.
 \code{buildVRT()} is a wrapper of the \command{gdalbuildvrt} command-line
 utility for building a VRT (Virtual Dataset) that is a mosaic of the list
 of input GDAL datasets
-(see \url{https://gdal.org/programs/gdalbuildvrt.html}).
+(see \url{https://gdal.org/en/stable/programs/gdalbuildvrt.html}).
 }
 \details{
 Several command-line options are described in the GDAL documentation at the

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -53,7 +53,7 @@ output dataset will be returned if \code{return_obj = TRUE}.
 \note{
 \code{dst_filename} may be an empty string (\code{""}) with \code{format = "MEM"} and
 \code{return_obj = TRUE} to create an In-memory Raster
-(\url{https://gdal.org/drivers/raster/mem.html}).
+(\url{https://gdal.org/en/stable/drivers/raster/mem.html}).
 }
 \examples{
 new_file <- file.path(tempdir(), "newdata.tif")

--- a/man/createColorRamp.Rd
+++ b/man/createColorRamp.Rd
@@ -25,7 +25,7 @@ A color entry value to end the ramp (e.g., RGB values).}
 
 \item{palette_interp}{One of "Gray", "RGB" (the default), "CMYK" or "HLS"
 describing interpretation of \code{start_color} and \code{end_color} values
-(see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL
+(see \href{https://gdal.org/en/stable/user/raster_data_model.html#color-table}{GDAL
 Color Table}).}
 }
 \value{

--- a/man/createCopy.Rd
+++ b/man/createCopy.Rd
@@ -55,7 +55,7 @@ geotransform are all copied from the source raster.
 \note{
 \code{dst_filename} may be an empty string (\code{""}) with \code{format = "MEM"} and
 \code{return_obj = TRUE} to create an In-memory Raster
-(\url{https://gdal.org/drivers/raster/mem.html}).
+(\url{https://gdal.org/en/stable/drivers/raster/mem.html}).
 }
 \examples{
 lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")

--- a/man/dem_proc.Rd
+++ b/man/dem_proc.Rd
@@ -37,12 +37,12 @@ An error is raised if the operation fails.
 \description{
 \code{dem_proc()} generates DEM derivatives from an input elevation raster. This
 function is a wrapper for the \command{gdaldem} command-line utility.
-See \url{https://gdal.org/programs/gdaldem.html} for details.
+See \url{https://gdal.org/en/stable/programs/gdaldem.html} for details.
 }
 \note{
 Band 1 of the source elevation raster is read by default, but this can be
 changed by including a \code{-b} command-line argument in \code{mode_options}.
-See the \href{https://gdal.org/programs/gdaldem.html}{documentation for
+See the \href{https://gdal.org/en/stable/programs/gdaldem.html}{documentation for
 \code{gdaldem}} for a description of all available options for each processing
 mode.
 }

--- a/man/footprint.Rd
+++ b/man/footprint.Rd
@@ -22,7 +22,7 @@ An error is raised if the operation fails.
 }
 \description{
 \code{footprint()} is a wrapper of the \command{gdal_footprint} command-line
-utility (see \url{https://gdal.org/programs/gdal_footprint.html}).
+utility (see \url{https://gdal.org/en/stable/programs/gdal_footprint.html}).
 The function can be used to compute the footprint of a raster file, taking
 into account nodata values (or more generally the mask band attached to
 the raster bands), and generating polygons/multipolygons corresponding to

--- a/man/gdal_formats.Rd
+++ b/man/gdal_formats.Rd
@@ -23,7 +23,7 @@ formats, with information about the capabilities of each format driver.
 }
 \note{
 Virtual I/O refers to operations on GDAL Virtual File Systems. See
-\url{https://gdal.org/user/virtual_file_systems.html#virtual-file-systems}.
+\url{https://gdal.org/en/stable/user/virtual_file_systems.html#virtual-file-systems}.
 }
 \examples{
 nrow(gdal_formats())

--- a/man/gdalraster-package.Rd
+++ b/man/gdalraster-package.Rd
@@ -8,7 +8,7 @@
   \code{gdalraster} is an interface to the Geospatial Data Abstraction
   Library (GDAL) for low level raster I/O. Calling signatures resemble those
   of the native C, C++ and Python APIs provided by the GDAL project.
-  See \url{https://gdal.org/api/} for details of the GDAL Raster API.
+  See \url{https://gdal.org/en/stable/api/} for details of the GDAL Raster API.
 }
 \details{
   Core functionality is contained in class \code{GDALRaster} and several
@@ -183,21 +183,22 @@ Maintainer: Chris Toney <chris.toney at usda.gov>
 }
 \seealso{
   GDAL Raster Data Model:\cr
-  \url{https://gdal.org/user/raster_data_model.html}
+  \url{https://gdal.org/en/stable/user/raster_data_model.html}
 
   Raster format descriptions:\cr
-  \url{https://gdal.org/drivers/raster/index.html}
+  \url{https://gdal.org/en/stable/drivers/raster/index.html}
 
   Geotransform tutorial:\cr
-  \url{https://gdal.org/tutorials/geotransforms_tut.html}
+  \url{https://gdal.org/en/stable/tutorials/geotransforms_tut.html}
 
   GDAL Virtual File Systems:\cr
-  \url{https://gdal.org/user/virtual_file_systems.html}
+  \url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 }
 \note{
   Documentation for \code{GDALRaster-class} and several wrapper functions
   borrows from the GDAL API documentation, (c) 1998-2025, Frank Warmerdam,
-  Even Rouault, and others, \href{https://gdal.org/license.html}{MIT license}.
+  Even Rouault, and others,
+  \href{https://gdal.org/en/stable/license.html}{MIT license}.
 
   Sample datasets included with the package are used in examples throughout
   the documentation. The sample data include

--- a/man/get_config_option.Rd
+++ b/man/get_config_option.Rd
@@ -20,7 +20,7 @@ Configuration options are essentially global variables the user can set.
 They are used to alter the default behavior of certain raster format
 drivers, and in some cases the GDAL core. For a full description and
 listing of available options see
-\url{https://gdal.org/user/configoptions.html}.
+\url{https://gdal.org/en/stable/user/configoptions.html}.
 }
 \examples{
 ## this option is set during initialization of the gdalraster package

--- a/man/has_spatialite.Rd
+++ b/man/has_spatialite.Rd
@@ -41,5 +41,5 @@ has_spatialite()
 \code{\link[=ogrinfo]{ogrinfo()}}, \code{\link[=ogr_execute_sql]{ogr_execute_sql()}}
 
 OGR SQL dialect and SQLITE SQL dialect:\cr
-\url{https://gdal.org/user/ogr_sql_sqlite_dialect.html}
+\url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html}
 }

--- a/man/inspectDataset.Rd
+++ b/man/inspectDataset.Rd
@@ -42,7 +42,7 @@ The return value is a list with named elements.
 \note{
 Subdataset names are the character strings that can be used to
 instantiate \code{GDALRaster} objects.
-See https://gdal.org/en/latest/user/raster_data_model.html#subdatasets-domain.
+See https://gdal.org/en/stable/en/latest/user/raster_data_model.html#subdatasets-domain.
 }
 \examples{
 src <- system.file("extdata/ynp_fires_1984_2022.gpkg", package="gdalraster")

--- a/man/ogr2ogr.Rd
+++ b/man/ogr2ogr.Rd
@@ -33,7 +33,7 @@ An error is raised if the operation fails.
 }
 \description{
 \code{ogr2ogr()} is a wrapper of the \command{ogr2ogr} command-line
-utility (see \url{https://gdal.org/programs/ogr2ogr.html}).
+utility (see \url{https://gdal.org/en/stable/programs/ogr2ogr.html}).
 This function can be used to convert simple features data between file
 formats. It can also perform various operations during the process, such
 as spatial or attribute selection, reducing the set of attributes, setting

--- a/man/ogr_define.Rd
+++ b/man/ogr_define.Rd
@@ -125,7 +125,7 @@ Geometry types are specified as a character string containing OGC WKT.
 Common types include: \code{Point}, \code{LineString}, \code{Polygon}, \code{MultiPoint},
 \code{MultiLineString}, \code{MultiPolygon}. See the GDAL documentation for a list
 of all supported geometry types:\cr
-\url{https://gdal.org/api/vector_c_api.html#_CPPv418OGRwkbGeometryType}
+\url{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv418OGRwkbGeometryType}
 
 Format drivers may or may not support not-null constraints on attribute and
 geometry fields. If they support creating fields with not-null constraints,
@@ -138,8 +138,8 @@ example, GeoPackage format has a layer creation option
 The feature id (FID) is a special property of a feature and not treated as
 an attribute of the feature. Additional information is given in the GDAL
 documentation for the
-\href{https://gdal.org/user/ogr_sql_dialect.html#feature-id-fid}{OGR SQL} and
-\href{https://gdal.org/user/sql_sqlite_dialect.html#feature-id-fid}{SQLite}
+\href{https://gdal.org/en/stable/user/ogr_sql_dialect.html#feature-id-fid}{OGR SQL} and
+\href{https://gdal.org/en/stable/user/sql_sqlite_dialect.html#feature-id-fid}{SQLite}
 SQL dialects. Implications for SQL statements and result sets may depend
 on the dialect used.
 

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -206,7 +206,7 @@ These functions are complementary to \code{ogrinfo()} and \code{ogr2ogr()} for
 vector data management. They are also intended to support vector I/O in a
 future release of gdalraster. Bindings to OGR wrap portions of the GDAL
 Vector API (ogr_core.h and ogr_api.h,
-\url{https://gdal.org/api/vector_c_api.html}).
+\url{https://gdal.org/en/stable/api/vector_c_api.html}).
 
 \code{ogr_ds_exists()} tests whether a vector dataset can be opened from the
 given data source name (DSN), potentially testing for update access.
@@ -269,7 +269,7 @@ cannot be found. The returned list contains the following named elements:
 \code{ReorderFields}, \code{AlterFieldDefn}, \code{AlterGeomFieldDefn}, \code{IgnoreFields},
 \code{DeleteFeature}, \code{Rename}, \code{StringsAsUTF8}, \code{CurveGeometries}.
 See the GDAL documentation for
-\href{https://gdal.org/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc}{\code{OGR_L_TestCapability()}}.
+\href{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc}{\code{OGR_L_TestCapability()}}.
 
 \code{ogr_layer_create()} creates a new layer in an existing vector data source,
 with a specified geometry type and spatial reference definition.
@@ -336,7 +336,7 @@ functions. The GDAL document for SQLite dialect has detailed information.
 
 Other SQL dialects may also be present for some vector formats.
 For example, the \code{"INDIRECT_SQLITE"} dialect might potentially be used with
-GeoPackage format (\url{https://gdal.org/drivers/vector/gpkg.html#sql}).
+GeoPackage format (\url{https://gdal.org/en/stable/drivers/vector/gpkg.html#sql}).
 
 The function \code{\link[=ogrinfo]{ogrinfo()}} can also be used to edit data with SQL statements
 (GDAL >= 3.7).
@@ -432,5 +432,5 @@ ogr_layer_field_names(dsn = perims_shp, layer = "mtbs_perims")
 }
 \seealso{
 OGR SQL dialect and SQLite SQL dialect:\cr
-\url{https://gdal.org/user/ogr_sql_sqlite_dialect.html}
+\url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html}
 }

--- a/man/ogr_proc.Rd
+++ b/man/ogr_proc.Rd
@@ -87,7 +87,7 @@ The output layer will be created if it does not exist, but output can also
 be appended to an existing layer, or written to an existing empty layer that
 has a custom schema defined.
 \code{ogr_proc()} is basically a port of the
-\href{https://gdal.org/programs/ogr_layer_algebra.html#ogr-layer-algebra}{\code{ogr_layer_algebra}}
+\href{https://gdal.org/en/stable/programs/ogr_layer_algebra.html#ogr-layer-algebra}{\code{ogr_layer_algebra}}
 utility in the GDAL Python bindings.
 }
 \details{

--- a/man/ogrinfo.Rd
+++ b/man/ogrinfo.Rd
@@ -38,7 +38,7 @@ vector dataset, or empty string (\code{""}) in case of error.
 }
 \description{
 \code{ogrinfo()} is a wrapper of the \command{ogrinfo} command-line
-utility (see \url{https://gdal.org/programs/ogrinfo.html}).
+utility (see \url{https://gdal.org/en/stable/programs/ogrinfo.html}).
 This function lists information about an OGR-supported data source.
 It is also possible to edit data with SQL statements.
 Refer to the GDAL documentation at the URL above for a description of

--- a/man/polygonize.Rd
+++ b/man/polygonize.Rd
@@ -76,7 +76,7 @@ The function will create the output vector layer if it does not already
 exist, otherwise it will try to append to an existing one.
 This function is a wrapper of \code{GDALPolygonize} in the GDAL Algorithms API.
 It provides essentially the same functionality as the \code{gdal_polygonize.py}
-command-line program (\url{https://gdal.org/programs/gdal_polygonize.html}).
+command-line program (\url{https://gdal.org/en/stable/programs/gdal_polygonize.html}).
 }
 \details{
 Polygon features will be created on the output layer, with polygon

--- a/man/rasterToVRT.Rd
+++ b/man/rasterToVRT.Rd
@@ -99,7 +99,7 @@ the same directory as the source file and uses \code{basename(srcfile)}. The
 elements of the XML schema describe how the source data will be read, along
 with algorithms potentially applied and so forth. Documentation of the XML
 format for .vrt is at:
-\url{https://gdal.org/drivers/raster/vrt.html}.
+\url{https://gdal.org/en/stable/drivers/raster/vrt.html}.
 
 Since .vrt is a small plain-text file it is fast to write and requires
 little storage space. Read performance is not degraded for certain simple

--- a/man/rasterize.Rd
+++ b/man/rasterize.Rd
@@ -110,7 +110,7 @@ An error is raised if the operation fails.
 the band(s) of a raster dataset. Vectors are read from any GDAL
 OGR-supported vector format.
 This function is a wrapper for the \command{gdal_rasterize} command-line
-utility (\url{https://gdal.org/programs/gdal_rasterize.html}).
+utility (\url{https://gdal.org/en/stable/programs/gdal_rasterize.html}).
 }
 \note{
 The function creates a new target raster when any of the \code{fmt}, \code{dstnodata},

--- a/man/set_config_option.Rd
+++ b/man/set_config_option.Rd
@@ -22,7 +22,7 @@ Configuration options are essentially global variables the user can set.
 They are used to alter the default behavior of certain raster format
 drivers, and in some cases the GDAL core. For a full description and
 listing of available options see
-\url{https://gdal.org/user/configoptions.html}.
+\url{https://gdal.org/en/stable/user/configoptions.html}.
 }
 \examples{
 set_config_option("GDAL_CACHEMAX", "10\%")

--- a/man/translate.Rd
+++ b/man/translate.Rd
@@ -24,7 +24,7 @@ An error is raised if the operation fails.
 }
 \description{
 \code{translate()} is a wrapper of the \command{gdal_translate} command-line
-utility (see \url{https://gdal.org/programs/gdal_translate.html}).
+utility (see \url{https://gdal.org/en/stable/programs/gdal_translate.html}).
 The function can be used to convert raster data between different
 formats, potentially performing some operations like subsetting,
 resampling, and rescaling pixels in the process. Refer to the GDAL

--- a/man/vsi_copy_file.Rd
+++ b/man/vsi_copy_file.Rd
@@ -22,7 +22,7 @@ displayed (the size of \code{src_file} will be retrieved in GDAL with
 \code{vsi_copy_file()} is a wrapper for \code{VSICopyFile()} in the GDAL Common
 Portability Library. The GDAL VSI functions allow virtualization of disk
 I/O so that non file data sources can be made to appear as files.
-See \url{https://gdal.org/user/virtual_file_systems.html}.
+See \url{https://gdal.org/en/stable/user/virtual_file_systems.html}.
 Requires GDAL >= 3.7.
 }
 \details{

--- a/man/vsi_get_fs_options.Rd
+++ b/man/vsi_get_fs_options.Rd
@@ -34,5 +34,5 @@ vsi_get_fs_options("/vsizip/", as_list = FALSE)
 \seealso{
 \code{\link[=set_config_option]{set_config_option()}}, \code{\link[=vsi_get_fs_prefixes]{vsi_get_fs_prefixes()}}
 
-\url{https://gdal.org/user/virtual_file_systems.html}
+\url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 }

--- a/man/vsi_get_fs_prefixes.Rd
+++ b/man/vsi_get_fs_prefixes.Rd
@@ -21,5 +21,5 @@ vsi_get_fs_prefixes()
 \seealso{
 \code{\link[=vsi_get_fs_options]{vsi_get_fs_options()}}
 
-\url{https://gdal.org/user/virtual_file_systems.html}
+\url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 }

--- a/man/vsi_stat.Rd
+++ b/man/vsi_stat.Rd
@@ -66,5 +66,5 @@ vsi_stat(url_file, "size")
 }
 \seealso{
 GDAL Virtual File Systems:\cr
-\url{https://gdal.org/user/virtual_file_systems.html}
+\url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 }

--- a/man/warp.Rd
+++ b/man/warp.Rd
@@ -32,7 +32,7 @@ An error is raised if the operation fails.
 \description{
 \code{warp()} is a wrapper of the \command{gdalwarp} command-line utility for
 raster reprojection and warping
-(see \url{https://gdal.org/programs/gdalwarp.html}).
+(see \url{https://gdal.org/en/stable/programs/gdalwarp.html}).
 The function can reproject to any supported spatial reference system (SRS).
 It can also be used to crop, mosaic, resample, and optionally write output
 to a different raster format. See Details for a list of commonly used
@@ -71,7 +71,7 @@ with a low quality resampling method, and the warping is done using a
 higher quality resampling method).
 \item \verb{-wo <NAME>=<VALUE>}\cr
 Set a warp option as described in the GDAL documentation for
-\href{https://gdal.org/api/gdalwarp_cpp.html#_CPPv415GDALWarpOptions}{\code{GDALWarpOptions}}
+\href{https://gdal.org/en/stable/api/gdalwarp_cpp.html#_CPPv415GDALWarpOptions}{\code{GDALWarpOptions}}
 Multiple \code{-wo} may be given. See also \code{-multi} below.
 \item \verb{-ot <type>}\cr
 Force the output raster bands to have a specific data type supported by
@@ -143,7 +143,7 @@ Set one or more format specific creation options for the output dataset.
 For example, the GeoTIFF driver supports creation options to control
 compression, and whether the file should be tiled.
 \code{\link[=getCreationOptions]{getCreationOptions()}} can be used to look up available creation options,
-but the GDAL \href{https://gdal.org/drivers/raster/index.html}{Raster drivers}
+but the GDAL \href{https://gdal.org/en/stable/drivers/raster/index.html}{Raster drivers}
 documentation is the definitive reference for format specific options.
 Multiple \code{-co} may be given, e.g.,
 \preformatted{ c("-co", "COMPRESS=LZW", "-co", "BIGTIFF=YES") }
@@ -154,7 +154,7 @@ is not specified and the output file already exists, it will be updated
 in place.
 }
 
-The documentation for \href{https://gdal.org/programs/gdalwarp.html}{\code{gdalwarp}}
+The documentation for \href{https://gdal.org/en/stable/programs/gdalwarp.html}{\code{gdalwarp}}
 describes additional command-line options related to spatial reference
 systems, alpha bands, masking with polygon cutlines including blending,
 and more.

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -72,7 +72,7 @@ int gdal_version_num() {
 //'
 //' @note
 //' Virtual I/O refers to operations on GDAL Virtual File Systems. See
-//' \url{https://gdal.org/user/virtual_file_systems.html#virtual-file-systems}.
+//' \url{https://gdal.org/en/stable/user/virtual_file_systems.html#virtual-file-systems}.
 //'
 //' @examples
 //' nrow(gdal_formats())
@@ -152,7 +152,7 @@ Rcpp::DataFrame gdal_formats(std::string format = "") {
 //' They are used to alter the default behavior of certain raster format
 //' drivers, and in some cases the GDAL core. For a full description and
 //' listing of available options see
-//' \url{https://gdal.org/user/configoptions.html}.
+//' \url{https://gdal.org/en/stable/user/configoptions.html}.
 //'
 //' @param key Character name of a configuration option.
 //' @returns Character. The value of a (key, value) option previously set with
@@ -182,7 +182,7 @@ std::string get_config_option(std::string key) {
 //' They are used to alter the default behavior of certain raster format
 //' drivers, and in some cases the GDAL core. For a full description and
 //' listing of available options see
-//' \url{https://gdal.org/user/configoptions.html}.
+//' \url{https://gdal.org/en/stable/user/configoptions.html}.
 //'
 //' @param key Character name of a configuration option.
 //' @param value Character value to set for the option.
@@ -409,7 +409,7 @@ Rcpp::NumericVector get_usable_physical_ram() {
 //' [ogrinfo()], [ogr_execute_sql()]
 //'
 //' OGR SQL dialect and SQLITE SQL dialect:\cr
-//' \url{https://gdal.org/user/ogr_sql_sqlite_dialect.html}
+//' \url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html}
 //'
 //' @examples
 //' has_spatialite()
@@ -923,7 +923,7 @@ GDALRaster autoCreateWarpedVRT(GDALRaster src_ds, std::string dst_wkt,
 //' `buildVRT()` is a wrapper of the \command{gdalbuildvrt} command-line
 //' utility for building a VRT (Virtual Dataset) that is a mosaic of the list
 //' of input GDAL datasets
-//' (see \url{https://gdal.org/programs/gdalbuildvrt.html}).
+//' (see \url{https://gdal.org/en/stable/programs/gdalbuildvrt.html}).
 //'
 //' @details
 //' Several command-line options are described in the GDAL documentation at the
@@ -1366,7 +1366,7 @@ bool fillNodata(Rcpp::CharacterVector filename, int band,
 //' Compute footprint of a raster
 //'
 //' `footprint()` is a wrapper of the \command{gdal_footprint} command-line
-//' utility (see \url{https://gdal.org/programs/gdal_footprint.html}).
+//' utility (see \url{https://gdal.org/en/stable/programs/gdal_footprint.html}).
 //' The function can be used to compute the footprint of a raster file, taking
 //' into account nodata values (or more generally the mask band attached to
 //' the raster bands), and generating polygons/multipolygons corresponding to
@@ -1465,7 +1465,7 @@ bool footprint(Rcpp::CharacterVector src_filename,
 //' Convert vector data between different formats
 //'
 //' `ogr2ogr()` is a wrapper of the \command{ogr2ogr} command-line
-//' utility (see \url{https://gdal.org/programs/ogr2ogr.html}).
+//' utility (see \url{https://gdal.org/en/stable/programs/ogr2ogr.html}).
 //' This function can be used to convert simple features data between file
 //' formats. It can also perform various operations during the process, such
 //' as spatial or attribute selection, reducing the set of attributes, setting
@@ -1608,7 +1608,7 @@ bool ogr2ogr(Rcpp::CharacterVector src_dsn,
 //' Retrieve information about a vector data source
 //'
 //' `ogrinfo()` is a wrapper of the \command{ogrinfo} command-line
-//' utility (see \url{https://gdal.org/programs/ogrinfo.html}).
+//' utility (see \url{https://gdal.org/en/stable/programs/ogrinfo.html}).
 //' This function lists information about an OGR-supported data source.
 //' It is also possible to edit data with SQL statements.
 //' Refer to the GDAL documentation at the URL above for a description of
@@ -2087,7 +2087,7 @@ bool sieveFilter(Rcpp::CharacterVector src_filename, int src_band,
 //' Convert raster data between different formats
 //'
 //' `translate()` is a wrapper of the \command{gdal_translate} command-line
-//' utility (see \url{https://gdal.org/programs/gdal_translate.html}).
+//' utility (see \url{https://gdal.org/en/stable/programs/gdal_translate.html}).
 //'
 //' Called from and documented in R/gdal_util.R
 //'
@@ -2144,7 +2144,7 @@ bool translate(GDALRaster src_ds,
 //'
 //' `warp()` is a wrapper of the \command{gdalwarp} command-line utility for
 //' raster mosaicing, reprojection and warping
-//' (see \url{https://gdal.org/programs/gdalwarp.html}).
+//' (see \url{https://gdal.org/en/stable/programs/gdalwarp.html}).
 //'
 //' Called from and documented in R/gdal_util.R
 //'
@@ -2262,7 +2262,7 @@ GDALRaster warp(const Rcpp::List& src_datasets,
 //' A color entry value to end the ramp (e.g., RGB values).
 //' @param palette_interp One of "Gray", "RGB" (the default), "CMYK" or "HLS"
 //' describing interpretation of `start_color` and `end_color` values
-//' (see \href{https://gdal.org/user/raster_data_model.html#color-table}{GDAL
+//' (see \href{https://gdal.org/en/stable/user/raster_data_model.html#color-table}{GDAL
 //' Color Table}).
 //' @returns Integer matrix with five columns containing the color ramp from
 //' `start_index` to `end_index`, with raster index values in column 1 and

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -19,7 +19,7 @@
 //' `vsi_copy_file()` is a wrapper for `VSICopyFile()` in the GDAL Common
 //' Portability Library. The GDAL VSI functions allow virtualization of disk
 //' I/O so that non file data sources can be made to appear as files.
-//' See \url{https://gdal.org/user/virtual_file_systems.html}.
+//' See \url{https://gdal.org/en/stable/user/virtual_file_systems.html}.
 //' Requires GDAL >= 3.7.
 //'
 //' @details
@@ -562,7 +562,7 @@ SEXP vsi_unlink_batch(Rcpp::CharacterVector filenames) {
 //'
 //' @seealso
 //' GDAL Virtual File Systems:\cr
-//' \url{https://gdal.org/user/virtual_file_systems.html}
+//' \url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 //'
 //' @examples
 //' data_dir <- system.file("extdata", package="gdalraster")
@@ -688,7 +688,7 @@ int vsi_rename(Rcpp::CharacterVector oldpath, Rcpp::CharacterVector newpath) {
 //' @seealso
 //' [vsi_get_fs_options()]
 //'
-//' \url{https://gdal.org/user/virtual_file_systems.html}
+//' \url{https://gdal.org/en/stable/user/virtual_file_systems.html}
 //'
 //' @examples
 //' vsi_get_fs_prefixes()

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -1,5 +1,5 @@
 /* R interface to the GDAL C API for raster
-   https://gdal.org/api/raster_c_api.html
+   https://gdal.org/en/stable/api/raster_c_api.html
 
    Chris Toney <chris.toney at usda.gov>
    Copyright (c) 2023-2024 gdalraster authors

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -1,5 +1,5 @@
 /* R interface to a subset of the GDAL C API for vector. A class for OGRLayer,
-   a layer of features in a GDALDataset. https://gdal.org/api/vector_c_api.html
+   a layer of features in a GDALDataset. https://gdal.org/en/stable/api/vector_c_api.html
 
    Chris Toney <chris.toney at usda.gov>
    Copyright (c) 2023-2024 gdalraster authors

--- a/vignettes/articles/gdal-block-cache.Rmd
+++ b/vignettes/articles/gdal-block-cache.Rmd
@@ -82,7 +82,7 @@ ds2$getBlockSize(band=1)
 ds2$close()
 ```
 
-This creates a "striped" tif with raster blocks arranged for row-level access (`TILED=NO` is the default creation option for the [GTiff format driver](https://gdal.org/drivers/raster/gtiff.html#creation-issues)). The resulting file is larger at 10.6 GB vs. 6.8 GB, since compression is not efficient for strips vs. tiles. Substituting the new file (`f2`) in the test above gives the following time to read all pixels by row:
+This creates a "striped" tif with raster blocks arranged for row-level access (`TILED=NO` is the default creation option for the [GTiff format driver](https://gdal.org/en/stable/drivers/raster/gtiff.html#creation-issues)). The resulting file is larger at 10.6 GB vs. 6.8 GB, since compression is not efficient for strips vs. tiles. Substituting the new file (`f2`) in the test above gives the following time to read all pixels by row:
 
 ```
 ## Test 2
@@ -230,8 +230,8 @@ ds$close()
 
 ## See also
 
-* [RFC 26: GDAL Block Cache Improvements](https://gdal.org/development/rfc/rfc26_blockcache.html)
-* [Configuration options for GDAL](https://gdal.org/user/configoptions.html)
-* [Performance optimization for GDAL Warp](https://gdal.org/tutorials/warp_tut.html#performance-optimization)
-* [GDALRasterBlock Class Reference](https://gdal.org/doxygen/classGDALRasterBlock.html)
+* [RFC 26: GDAL Block Cache Improvements](https://gdal.org/en/stable/development/rfc/rfc26_blockcache.html)
+* [Configuration options for GDAL](https://gdal.org/en/stable/user/configoptions.html)
+* [Performance optimization for GDAL Warp](https://gdal.org/en/stable/tutorials/warp_tut.html#performance-optimization)
+* [GDALRasterBlock Class Reference](https://gdal.org/en/stable/doxygen/classGDALRasterBlock.html)
 * [gcore/gdalrasterblock.cpp](https://github.com/OSGeo/gdal/blob/97f0c0b35c7ca5f17bdd74312bee2a0afa4d2199/gcore/gdalrasterblock.cpp)

--- a/vignettes/articles/gdalvector-draft.Rmd
+++ b/vignettes/articles/gdalvector-draft.Rmd
@@ -19,7 +19,7 @@ Comment/discussion: <https://github.com/USDAForestService/gdalraster/issues/241>
 
 This document describes R bindings to the GDAL/OGR Vector API proposed for inclusion in package **gdalraster**, analogous to its existing raster support. A package providing low-level access to both the raster and vector APIs in GDAL should be of interest to developers creating higher level interfaces. For example, custom workflows that are I/O intensive may benefit from direct access to GDAL's I/O capabilities. R bindings to the vector API would support persistent connections to the data store, cursors with attribute and spatial filtering, transactions, feature-level insert/delete, update of attributes and geometries, and OGR facilities for geoprocessing. Calling signatures of a class-based interface will resemble the C++ and Python APIs provided by the GDAL project. It is intended that bindings in **gdalraster** should provide long-term API stability while tracking changes in GDAL.
 
-A proposed interface is described in terms of the [GDAL Vector Data Model](https://gdal.org/user/vector_data_model.html), along with a draft class definition for implementation via `RCPP_EXPOSED_CLASS`.
+A proposed interface is described in terms of the [GDAL Vector Data Model](https://gdal.org/en/stable/user/vector_data_model.html), along with a draft class definition for implementation via `RCPP_EXPOSED_CLASS`.
 
 An initial implemetation supporting read access has been merged into the **gdalraster** main branch (as of v. 1.11.1.9100, 2024-07-23), with online documentation available at:
 <https://usdaforestservice.github.io/gdalraster/reference/GDALVector-class.html>

--- a/vignettes/gdal-config-quick-ref.Rmd
+++ b/vignettes/gdal-config-quick-ref.Rmd
@@ -18,7 +18,7 @@ knitr::opts_chunk$set(
 
 ## Overview
 
-Configuration options are essentially global variables the user can set. They are used to alter the default behavior of certain raster format drivers, and in some cases the GDAL core. A large number of configuration options are available. An overall discussion along with full list of available options and where they apply is in the GDAL documentation at https://gdal.org/user/configoptions.html.
+Configuration options are essentially global variables the user can set. They are used to alter the default behavior of certain raster format drivers, and in some cases the GDAL core. A large number of configuration options are available. An overall discussion along with full list of available options and where they apply is in the GDAL documentation at https://gdal.org/en/stable/user/configoptions.html.
 
 This quick reference covers a small subset of configuration options that may be useful in common scenarios, with links to topic-specific documentation provided by the GDAL project. Options can be set from R with `gdalraster::set_config_option()`. Note that specific usage is context dependent. Passing `value = ""` (empty string) will unset a value previously set by `set_config_option()`:
 
@@ -32,7 +32,7 @@ set_config_option("GDAL_NUM_THREADS", "")
 
 ## General options
 
-GDAL doc: https://gdal.org/user/configoptions.html#general-options
+GDAL doc: https://gdal.org/en/stable/user/configoptions.html#general-options
 
 **`GDAL_RASTERIO_RESAMPLING`**
 
@@ -53,7 +53,7 @@ set_config_option("CPL_TMPDIR", "<dirname>") # tmpdir to use
 
 ## Performance and caching
 
-GDAL doc: https://gdal.org/user/configoptions.html#performance-and-caching
+GDAL doc: https://gdal.org/en/stable/user/configoptions.html#performance-and-caching
 
 **`GDAL_NUM_THREADS`**
 
@@ -73,7 +73,7 @@ set_config_option("GDAL_CACHEMAX", "10%")
 
 **`GDAL_MAX_DATASET_POOL_SIZE`**
 
-The default number of datasets that can be opened simultaneously by the `GDALProxyPool` mechanism (used by VRT for example) is `100`. This can be increased to get better random I/O performance with VRT mosaics made of numerous underlying raster files. Note: on Linux systems, the number of file handles that can be opened by a process is generally limited to `1024`. This is currently clamped between `2` and `1000`. Also note that [`gdalwarp` increases the pool size to `450`](https://gdal.org/drivers/raster/vrt.html#performance-considerations):
+The default number of datasets that can be opened simultaneously by the `GDALProxyPool` mechanism (used by VRT for example) is `100`. This can be increased to get better random I/O performance with VRT mosaics made of numerous underlying raster files. Note: on Linux systems, the number of file handles that can be opened by a process is generally limited to `1024`. This is currently clamped between `2` and `1000`. Also note that [`gdalwarp` increases the pool size to `450`](https://gdal.org/en/stable/drivers/raster/vrt.html#performance-considerations):
 
 ```r
 # default is 100
@@ -82,7 +82,7 @@ set_config_option("GDAL_MAX_DATASET_POOL_SIZE", "450")
 
 **`PG_USE_COPY`**
 
-This configures PostgreSQL/PostGIS to use `COPY` for inserting data which is significantly faster than `INSERT`. This can increase performance substantially when using `gdalraster::polygonize()` to write polygons to PostGIS vector. See also [GDAL configuration options for PostgreSQL](https://gdal.org/drivers/vector/pg.html#configuration-options).
+This configures PostgreSQL/PostGIS to use `COPY` for inserting data which is significantly faster than `INSERT`. This can increase performance substantially when using `gdalraster::polygonize()` to write polygons to PostGIS vector. See also [GDAL configuration options for PostgreSQL](https://gdal.org/en/stable/drivers/vector/pg.html#configuration-options).
 
 ```r
 # use COPY for inserting to PostGIS
@@ -91,7 +91,7 @@ set_config_option("PG_USE_COPY", "YES")
 
 **`SQLITE_USE_OGR_VFS`**
 
-For the SQLite-based formats GeoPackage (.gpkg) and Spatialite (.sqlite), setting `SQLITE_USE_OGR_VFS` enables extra buffering/caching by the GDAL/OGR I/O layer and can speed up I/O. Be aware that no file locking will occur if this option is activated, so concurrent edits may lead to database corruption. This setting may increase performance substantially when using `gdalraster::polygonize()` to write polygons to a vector layer in these formats. Additional configuration and performance hints for SQLite databases are in the driver documentation at: https://gdal.org/drivers/vector/sqlite.html#configuration-options.
+For the SQLite-based formats GeoPackage (.gpkg) and Spatialite (.sqlite), setting `SQLITE_USE_OGR_VFS` enables extra buffering/caching by the GDAL/OGR I/O layer and can speed up I/O. Be aware that no file locking will occur if this option is activated, so concurrent edits may lead to database corruption. This setting may increase performance substantially when using `gdalraster::polygonize()` to write polygons to a vector layer in these formats. Additional configuration and performance hints for SQLite databases are in the driver documentation at: https://gdal.org/en/stable/drivers/vector/sqlite.html#configuration-options.
 
 ```r
 # SQLite: GPKG (.gpkg) and Spatialite (.sqlite)
@@ -120,7 +120,7 @@ set_config_option("OGR_SQLITE_JOURNAL", "MEMORY")
 
 ## Networking
 
-GDAL doc: https://gdal.org/user/configoptions.html#networking-options
+GDAL doc: https://gdal.org/en/stable/user/configoptions.html#networking-options
 
 **`CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE`**
 
@@ -133,7 +133,7 @@ set_config_option("CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", "YES")
 
 ## PROJ
 
-GDAL doc: https://gdal.org/user/configoptions.html#proj-options
+GDAL doc: https://gdal.org/en/stable/user/configoptions.html#proj-options
 
 **`OSR_DEFAULT_AXIS_MAPPING_STRATEGY`**
 
@@ -150,7 +150,7 @@ set_config_option("OSR_WKT_FORMAT", "WKT2")
 
 ## Warp
 
-GDAL doc: https://gdal.org/programs/gdalwarp.html#memory-usage
+GDAL doc: https://gdal.org/en/stable/programs/gdalwarp.html#memory-usage
 
 The [performance and caching](#performance-and-caching) topic above generally applies to processing with `gdalraster::warp()` (reproject/resample/crop/mosaic).
 
@@ -167,7 +167,7 @@ Increasing the memory available to `warp()` may also increase performance (i.e.,
 
 Multithreading could also be enabled by including a GDAL warp option in `cl_arg` with `c("-wo", "NUM_THREADS=<value>")` greater than 1, which is equivalent to setting the `GDAL_NUM_THREADS` configuration option as shown above.
 
-This option can be combined with the [`-multi` command-line argument](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-multi) passed to `warp()` in `cl_arg`. With `-multi`, two threads will be used to process chunks of the raster and perform input/output operation simultaneously, whereas the `GDAL_NUM_THREADS` configuration option affects computation separately.
+This option can be combined with the [`-multi` command-line argument](https://gdal.org/en/stable/programs/gdalwarp.html#cmdoption-gdalwarp-multi) passed to `warp()` in `cl_arg`. With `-multi`, two threads will be used to process chunks of the raster and perform input/output operation simultaneously, whereas the `GDAL_NUM_THREADS` configuration option affects computation separately.
 
 **`GDAL_CACHEMAX`**
 
@@ -175,9 +175,9 @@ Increasing the size of the I/O block cache may also help. This can be done by se
 
 ## GeoTIFF
 
-GDAL doc: https://gdal.org/drivers/raster/gtiff.html#configuration-options
+GDAL doc: https://gdal.org/en/stable/drivers/raster/gtiff.html#configuration-options
 
-The behavior of the GTiff driver is highly configurable, including with respect to overview creation. For full discussion, see the link above and also the documentation for the [`gdaladdo`](https://gdal.org/programs/gdaladdo.html) command-line utility.
+The behavior of the GTiff driver is highly configurable, including with respect to overview creation. For full discussion, see the link above and also the documentation for the [`gdaladdo`](https://gdal.org/en/stable/programs/gdaladdo.html) command-line utility.
 
 **`GDAL_NUM_THREADS`**
 
@@ -210,7 +210,7 @@ set_config_option("PREDICTOR_OVERVIEW", "2")
 
 ## HTTP/HTTPS
 
-GDAL doc: [/vsicurl/](https://gdal.org/user/configoptions.html#networking-options) (HTTP/HTTPS random access)
+GDAL doc: [/vsicurl/](https://gdal.org/en/stable/user/configoptions.html#networking-options) (HTTP/HTTPS random access)
 
 **`GDAL_HTTP_CONNECTTIMEOUT`**
 
@@ -252,7 +252,7 @@ set_config_option("CPL_VSIL_CURL_CACHE_SIZE", "<bytes>")
 
 ## AWS S3 buckets
 
-GDAL doc: [/vsis3/](https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files) (AWS S3 file system handler)
+GDAL doc: [/vsis3/](https://gdal.org/en/stable/user/virtual_file_systems.html#vsis3-aws-s3-files) (AWS S3 file system handler)
 
 **`AWS_NO_SIGN_REQUEST`**
 
@@ -290,11 +290,11 @@ set_config_option("AWS_REGION", "us-west-2")
 
 ## Google Cloud Storage
 
-GDAL doc: [/vsigs/](https://gdal.org/user/virtual_file_systems.html#vsigs-google-cloud-storage-files) (Google Cloud Storage files)
+GDAL doc: [/vsigs/](https://gdal.org/en/stable/user/virtual_file_systems.html#vsigs-google-cloud-storage-files) (Google Cloud Storage files)
 
 ## Microsoft Azure Blob
 
-GDAL doc: [/vsiaz/](https://gdal.org/user/virtual_file_systems.html#vsiaz-microsoft-azure-blob-files) (Microsoft Azure Blob files)
+GDAL doc: [/vsiaz/](https://gdal.org/en/stable/user/virtual_file_systems.html#vsiaz-microsoft-azure-blob-files) (Microsoft Azure Blob files)
 
 Recognized filenames are of the form `/vsiaz/container/key`, where `container` is the name of the container and `key` is the object "key", i.e. a filename potentially containing subdirectories.
 
@@ -348,11 +348,11 @@ Other authentication methods are possible for Azure. See the GDAL documentation 
 
 ## Microsoft Azure Data Lake
 
-GDAL doc: [/vsiadls/](https://gdal.org/user/virtual_file_systems.html#vsiadls-microsoft-azure-data-lake-storage-gen2) (Microsoft Azure Data Lake Storage Gen2)
+GDAL doc: [/vsiadls/](https://gdal.org/en/stable/user/virtual_file_systems.html#vsiadls-microsoft-azure-data-lake-storage-gen2) (Microsoft Azure Data Lake Storage Gen2)
 
 ## SOZip
 
-GDAL doc: [/vsizip/](https://gdal.org/user/virtual_file_systems.html#vsizip-zip-archives) (Seek-Optimized ZIP files, GDAL >= 3.7)
+GDAL doc: [/vsizip/](https://gdal.org/en/stable/user/virtual_file_systems.html#vsizip-zip-archives) (Seek-Optimized ZIP files, GDAL >= 3.7)
 
 The function `gdalraster::addFilesInZip()` can be used to create new or append to existing ZIP files, potentially using the seek optimization extension. Function arguments are available for the options below, or the configuration options can be set to change the default behavior.
 

--- a/vignettes/raster-api-tutorial.Rmd
+++ b/vignettes/raster-api-tutorial.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-**gdalraster** provides bindings to the Raster API of the Geospatial Data Abstraction Library ([GDAL](https://gdal.org/)). Using the API natively enables fast and scalable raster I/O from R. This vignette is an R port of the [GDAL Raster API tutorial](https://gdal.org/tutorials/raster_api_tut.html) for C++, C and Python, (c) 1998-2025 [Frank Warmerdam](https://github.com/warmerdam), [Even Rouault](https://github.com/rouault), and [others](https://github.com/OSGeo/gdal/graphs/contributors) ([MIT license](https://gdal.org/license.html)).
+**gdalraster** provides bindings to the Raster API of the Geospatial Data Abstraction Library ([GDAL](https://gdal.org/en/stable/)). Using the API natively enables fast and scalable raster I/O from R. This vignette is an R port of the [GDAL Raster API tutorial](https://gdal.org/en/stable/tutorials/raster_api_tut.html) for C++, C and Python, (c) 1998-2025 [Frank Warmerdam](https://github.com/warmerdam), [Even Rouault](https://github.com/rouault), and [others](https://github.com/OSGeo/gdal/graphs/contributors) ([MIT license](https://gdal.org/en/stable/license.html)).
 
 ## Opening a raster dataset
 
@@ -38,9 +38,9 @@ str(ds)
 
 ## Getting dataset information
 
-As described in the [GDAL Raster Data Model](https://gdal.org/user/raster_data_model.html), a GDAL dataset contains a list of raster bands, all pertaining to the same area and having the same resolution. It also has metadata, a coordinate system, a georeferencing transform, size of raster and various other information.
+As described in the [GDAL Raster Data Model](https://gdal.org/en/stable/user/raster_data_model.html), a GDAL dataset contains a list of raster bands, all pertaining to the same area and having the same resolution. It also has metadata, a coordinate system, a georeferencing transform, size of raster and various other information.
 
-In the particular but common case of a "north up" raster without any rotation or shearing, the georeferencing transform (see [Geotransform Tutorial](https://gdal.org/tutorials/geotransforms_tut.html)) takes the following form *with 1-based indexing in R*:
+In the particular but common case of a "north up" raster without any rotation or shearing, the georeferencing transform (see [Geotransform Tutorial](https://gdal.org/en/stable/tutorials/geotransforms_tut.html)) takes the following form *with 1-based indexing in R*:
 
 ```{r}
 gt <- ds$getGeoTransform()
@@ -161,7 +161,7 @@ The function `gdal_formats()` lists all currently configured raster formats alon
 * `rw`  - read/write, supports `createCopy()`
 * `rw+` - read/write/update, supports `create()`
 
-The table of GDAL [raster format drivers](https://gdal.org/drivers/raster/index.html) can also be consulted to determine if a particular driver supports Create or CreateCopy methods. Note that a number of drivers are read-only and do not support either creation method. 
+The table of GDAL [raster format drivers](https://gdal.org/en/stable/drivers/raster/index.html) can also be consulted to determine if a particular driver supports Create or CreateCopy methods. Note that a number of drivers are read-only and do not support either creation method. 
 
 ## Using createCopy()
 

--- a/vignettes/raster-attribute-tables.Rmd
+++ b/vignettes/raster-attribute-tables.Rmd
@@ -111,7 +111,7 @@ ds$close()
 
 ## Using in QGIS
 
-QGIS since 3.30 includes [extensive support for Raster Attribute Tables](https://qgis.org/en/site/forusers/visualchangelog330/index.html#feature-raster-attribute-tables-rat-suppport).
+QGIS since 3.30 includes [extensive support for Raster Attribute Tables](https://qgis.org/project/visual-changelogs/visualchangelog330/#feature-raster-attribute-tables-rat-support).
 
 For QGIS < 3.30, the **Raster Attribute Table Plugin** can be used to edit and display RATs for discrete rasters using the paletted/unique-values renderer (QGIS-style classification on arbitrary RAT columns). With the plugin enabled, "Open Attribute Table" can be selected after right-clicking a raster layer that has an associated RAT. For the LANDFIRE EVT layer as modified above, classifying on EVT_NAME generates the following display:
 
@@ -127,7 +127,7 @@ knitr::include_graphics("qgis_rat_classify.png")
 
 * Documentation for [`gdalraster::buildRAT()`](https://usdaforestservice.github.io/gdalraster/reference/buildRAT.html)
 
-* [GDALRasterAttributeTable Class Reference](https://gdal.org/doxygen/classGDALRasterAttributeTable.html)
+* [GDALRasterAttributeTable Class Reference](https://gdal.org/en/stable/doxygen/classGDALRasterAttributeTable.html)
 
 * [Raster Attribute Table QGIS GUI](https://github.com/qgis/QGIS/pull/50687) (since QGIS 3.30; examples for different use cases and workflows)
 


### PR DESCRIPTION
Update to the new URL format for gdal.org. The existing URLs still work fine but we should use the new format, and avoids triggering CRAN incoming checks.