### PR TITLE
Accept one (x, y) as a vector in functions that expect matrix or data frame xy

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2368,7 +2368,7 @@ has_geos <- function() {
 #' names above.
 #'
 #' @param pts A two-column data frame or numeric matrix containing geospatial
-#' x/y coordinates.
+#' x, y coordinates (or vector of x, y for one point).
 #' @param srs Character string specifying the projected spatial reference
 #' system for `pts`. May be in WKT format or any of the formats supported by
 #' [srs_to_wkt()].
@@ -2394,7 +2394,7 @@ inv_project <- function(pts, srs, well_known_gcs = "") {
 #' `transform_xy()` transforms geospatial x/y coordinates to a new projection.
 #'
 #' @param pts A two-column data frame or numeric matrix containing geospatial
-#' x/y coordinates.
+#' x, y coordinates (or vector of x, y for one point).
 #' @param srs_from Character string specifying the spatial reference system
 #' for `pts`. May be in WKT format or any of the formats supported by
 #' [srs_to_wkt()].

--- a/R/gdal_helpers.R
+++ b/R/gdal_helpers.R
@@ -311,8 +311,9 @@ vsi_get_fs_options <- function(filename, as_list = TRUE) {
 #' georeferenced (x/y) coordinates. Wrapper of `GDALApplyGeoTransform()` in
 #' the GDAL API, operating on matrix input.
 #'
-#' @param col_row Numeric matrix of raster column/row (pixel/line) coordinates
-#' (or two-column data frame that will be coerced to numeric matrix).
+#' @param col_row Numeric matrix of raster column, row (pixel/line) coordinates
+#' (or two-column data frame that will be coerced to numeric matrix, or a
+#' vector of column, row for one coordinate).
 #' @param gt Either a numeric vector of length six containing the affine
 #' geotransform for the raster, or an object of class `GDALRaster` from
 #' which the geotransform will be obtained.
@@ -347,11 +348,16 @@ vsi_get_fs_options <- function(filename, as_list = TRUE) {
 #'
 #' ds$close()
 apply_geotransform <- function(col_row, gt) {
-    if (!(is.matrix(col_row) || is.data.frame(col_row)))
+    if (!(is.vector(col_row) || is.matrix(col_row) || is.data.frame(col_row)))
         stop("'col_row' must be a data frame or numeric matrix", call. = FALSE)
 
-    if (ncol(col_row) != 2)
+    if ((is.matrix(col_row) || is.data.frame(col_row)) && ncol(col_row) != 2)
         stop("'col_row' must have 2 columns", call. = FALSE)
+    else if (is.vector(col_row) && length(col_row) != 2)
+        stop("'col_row' as vector must have length 2", call. = FALSE)
+
+    if ((is.vector(col_row) || is.matrix(col_row)) && !is.numeric(col_row))
+        stop("'col_row' must be numeric", call. = FALSE)
 
     if (is(gt, "Rcpp_GDALRaster")) {
         return(.apply_geotransform_ds(col_row, gt))
@@ -370,9 +376,9 @@ apply_geotransform <- function(col_row, gt) {
 #' The upper left corner pixel is the raster origin (0,0) with column, row
 #' increasing left to right, top to bottom.
 #'
-#' @param xy Numeric matrix of geospatial x,y coordinates in the same spatial
+#' @param xy Numeric matrix of geospatial x, y coordinates in the same spatial
 #' reference system as \code{gt} (or two-column data frame that will be coerced
-#' to numeric matrix).
+#' to numeric matrix, or a vector x, y for one coordinate).
 #' @param gt Either a numeric vector of length six containing the affine
 #' geotransform for the raster, or an object of class `GDALRaster` from
 #' which the geotransform will be obtained (see Note).
@@ -413,11 +419,16 @@ apply_geotransform <- function(col_row, gt) {
 #'
 #' ds$close()
 get_pixel_line <- function(xy, gt) {
-    if (!(is.matrix(xy) || is.data.frame(xy)))
+    if (!(is.vector(xy) || is.matrix(xy) || is.data.frame(xy)))
         stop("'xy' must be a data frame or numeric matrix", call. = FALSE)
 
-    if (ncol(xy) != 2)
+    if ((is.matrix(xy) || is.data.frame(xy)) && ncol(xy) != 2)
         stop("'xy' must have 2 columns", call. = FALSE)
+    else if (is.vector(xy) && length(xy) != 2)
+        stop("'xy' as vector must have length 2", call. = FALSE)
+
+    if ((is.vector(xy) || is.matrix(xy)) && !is.numeric(xy))
+        stop("'xy' must be numeric", call. = FALSE)
 
     if (is(gt, "Rcpp_GDALRaster")) {
         return(.get_pixel_line_ds(xy, gt))

--- a/man/apply_geotransform.Rd
+++ b/man/apply_geotransform.Rd
@@ -7,8 +7,9 @@
 apply_geotransform(col_row, gt)
 }
 \arguments{
-\item{col_row}{Numeric matrix of raster column/row (pixel/line) coordinates
-(or two-column data frame that will be coerced to numeric matrix).}
+\item{col_row}{Numeric matrix of raster column, row (pixel/line) coordinates
+(or two-column data frame that will be coerced to numeric matrix, or a
+vector of column, row for one coordinate).}
 
 \item{gt}{Either a numeric vector of length six containing the affine
 geotransform for the raster, or an object of class \code{GDALRaster} from

--- a/man/get_pixel_line.Rd
+++ b/man/get_pixel_line.Rd
@@ -7,9 +7,9 @@
 get_pixel_line(xy, gt)
 }
 \arguments{
-\item{xy}{Numeric matrix of geospatial x,y coordinates in the same spatial
+\item{xy}{Numeric matrix of geospatial x, y coordinates in the same spatial
 reference system as \code{gt} (or two-column data frame that will be coerced
-to numeric matrix).}
+to numeric matrix, or a vector x, y for one coordinate).}
 
 \item{gt}{Either a numeric vector of length six containing the affine
 geotransform for the raster, or an object of class \code{GDALRaster} from

--- a/man/inv_project.Rd
+++ b/man/inv_project.Rd
@@ -8,7 +8,7 @@ inv_project(pts, srs, well_known_gcs = "")
 }
 \arguments{
 \item{pts}{A two-column data frame or numeric matrix containing geospatial
-x/y coordinates.}
+x, y coordinates (or vector of x, y for one point).}
 
 \item{srs}{Character string specifying the projected spatial reference
 system for \code{pts}. May be in WKT format or any of the formats supported by

--- a/man/transform_xy.Rd
+++ b/man/transform_xy.Rd
@@ -8,7 +8,7 @@ transform_xy(pts, srs_from, srs_to)
 }
 \arguments{
 \item{pts}{A two-column data frame or numeric matrix containing geospatial
-x/y coordinates.}
+x, y coordinates (or vector of x, y for one point).}
 
 \item{srs_from}{Character string specifying the spatial reference system
 for \code{pts}. May be in WKT format or any of the formats supported by

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -577,7 +577,7 @@ GDALRaster createCopy(std::string format, Rcpp::CharacterVector dst_filename,
 //' @noRd
 // [[Rcpp::export(name = ".apply_geotransform")]]
 Rcpp::NumericVector apply_geotransform_(const std::vector<double> gt,
-        double pixel, double line) {
+                                        double pixel, double line) {
 
     double geo_x, geo_y;
     GDALApplyGeoTransform((double *) (gt.data()), pixel, line, &geo_x, &geo_y);
@@ -593,17 +593,7 @@ Rcpp::NumericVector apply_geotransform_(const std::vector<double> gt,
 Rcpp::NumericMatrix apply_geotransform_gt(const Rcpp::RObject& col_row,
         const std::vector<double> gt) {
 
-    Rcpp::NumericMatrix col_row_in;
-    if (Rcpp::is<Rcpp::DataFrame>(col_row)) {
-        col_row_in = df_to_matrix_(col_row);
-    }
-    else if (Rcpp::is<Rcpp::NumericVector>(col_row)) {
-        if (Rf_isMatrix(col_row))
-            col_row_in = Rcpp::as<Rcpp::NumericMatrix>(col_row);
-    }
-    else {
-        Rcpp::stop("'col_row' must be a two-column data frame or matrix");
-    }
+    Rcpp::NumericMatrix col_row_in = xy_robject_to_matrix_(col_row);
 
     if (col_row_in.nrow() == 0)
         Rcpp::stop("input matrix is empty");
@@ -626,17 +616,7 @@ Rcpp::NumericMatrix apply_geotransform_gt(const Rcpp::RObject& col_row,
 Rcpp::NumericMatrix apply_geotransform_ds(const Rcpp::RObject& col_row,
         const GDALRaster* ds) {
 
-    Rcpp::NumericMatrix col_row_in;
-    if (Rcpp::is<Rcpp::DataFrame>(col_row)) {
-        col_row_in = df_to_matrix_(col_row);
-    }
-    else if (Rcpp::is<Rcpp::NumericVector>(col_row)) {
-        if (Rf_isMatrix(col_row))
-            col_row_in = Rcpp::as<Rcpp::NumericMatrix>(col_row);
-    }
-    else {
-        Rcpp::stop("'col_row' must be a two-column data frame or matrix");
-    }
+    Rcpp::NumericMatrix col_row_in = xy_robject_to_matrix_(col_row);
 
     if (col_row_in.nrow() == 0)
         Rcpp::stop("input matrix is empty");
@@ -720,17 +700,7 @@ Rcpp::NumericVector inv_geotransform(const std::vector<double> gt) {
 Rcpp::IntegerMatrix get_pixel_line_gt(const Rcpp::RObject& xy,
         const std::vector<double> gt) {
 
-    Rcpp::NumericMatrix xy_in;
-    if (Rcpp::is<Rcpp::DataFrame>(xy)) {
-        xy_in = df_to_matrix_(xy);
-    }
-    else if (Rcpp::is<Rcpp::NumericVector>(xy)) {
-        if (Rf_isMatrix(xy))
-            xy_in = Rcpp::as<Rcpp::NumericMatrix>(xy);
-    }
-    else {
-        Rcpp::stop("'xy' must be a two-column data frame or matrix");
-    }
+    Rcpp::NumericMatrix xy_in = xy_robject_to_matrix_(xy);
 
     if (xy_in.nrow() == 0)
         Rcpp::stop("input matrix is empty");
@@ -762,17 +732,7 @@ Rcpp::IntegerMatrix get_pixel_line_gt(const Rcpp::RObject& xy,
 Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
         const GDALRaster* ds) {
 
-    Rcpp::NumericMatrix xy_in;
-    if (Rcpp::is<Rcpp::DataFrame>(xy)) {
-        xy_in = df_to_matrix_(xy);
-    }
-    else if (Rcpp::is<Rcpp::NumericVector>(xy)) {
-        if (Rf_isMatrix(xy))
-            xy_in = Rcpp::as<Rcpp::NumericMatrix>(xy);
-    }
-    else {
-        Rcpp::stop("'xy' must be a two-column data frame or matrix");
-    }
+    Rcpp::NumericMatrix xy_in = xy_robject_to_matrix_(xy);
 
     if (xy_in.nrow() == 0)
         Rcpp::stop("input matrix is empty");

--- a/src/rcpp_util.cpp
+++ b/src/rcpp_util.cpp
@@ -41,6 +41,35 @@ Rcpp::IntegerMatrix df_to_int_matrix_(const Rcpp::DataFrame& df) {
     return m;
 }
 
+//' convert allowed xy inputs to numeric matrix
+//' @noRd
+Rcpp::NumericMatrix xy_robject_to_matrix_(const Rcpp::RObject& xy) {
+    Rcpp::NumericMatrix xy_ret;
+
+    if (Rcpp::is<Rcpp::NumericVector>(xy) ||
+        Rcpp::is<Rcpp::IntegerVector>(xy)) {
+
+        if (!Rf_isMatrix(xy)) {
+            Rcpp::NumericVector v = Rcpp::as<Rcpp::NumericVector>(xy);
+            if (v.size() != 2)
+                Rcpp::stop("coordinate input as vector must have length 2");
+
+            xy_ret = Rcpp::NumericMatrix(1, 2, v.begin());
+        }
+        else {
+            xy_ret = Rcpp::as<Rcpp::NumericMatrix>(xy);
+        }
+    }
+    else if (Rcpp::is<Rcpp::DataFrame>(xy)) {
+        xy_ret = df_to_matrix_(xy);
+    }
+    else {
+        Rcpp::stop("coordinates must be in a two-column data frame or matrix");
+    }
+
+    return xy_ret;
+}
+
 //' wrapper for base R path.expand()
 //' @noRd
 Rcpp::CharacterVector path_expand_(Rcpp::CharacterVector path) {

--- a/src/rcpp_util.h
+++ b/src/rcpp_util.h
@@ -26,12 +26,15 @@ const int64_t MAX_INT_AS_R_NUMERIC = 9007199254740991;
 
 Rcpp::NumericMatrix df_to_matrix_(const Rcpp::DataFrame& df);
 Rcpp::IntegerMatrix df_to_int_matrix_(const Rcpp::DataFrame& df);
+Rcpp::NumericMatrix xy_robject_to_matrix_(const Rcpp::RObject& xy);
+
 Rcpp::CharacterVector path_expand_(Rcpp::CharacterVector path);
 Rcpp::CharacterVector normalize_path_(Rcpp::CharacterVector path,
                                       int must_work);
 Rcpp::CharacterVector normalize_path_(Rcpp::CharacterVector path,
                                       int must_work = NA_LOGICAL);
 Rcpp::CharacterVector enc_to_utf8_(Rcpp::CharacterVector x);
+
 std::string str_toupper_(std::string s);
 
 // case-insensitive comparator for std::map

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -119,7 +119,7 @@ void setPROJEnableNetwork(int enabled) {
 //' names above.
 //'
 //' @param pts A two-column data frame or numeric matrix containing geospatial
-//' x/y coordinates.
+//' x, y coordinates (or vector of x, y for one point).
 //' @param srs Character string specifying the projected spatial reference
 //' system for `pts`. May be in WKT format or any of the formats supported by
 //' [srs_to_wkt()].
@@ -141,17 +141,7 @@ Rcpp::NumericMatrix inv_project(const Rcpp::RObject &pts,
                                 const std::string &srs,
                                 const std::string &well_known_gcs = "") {
 
-    Rcpp::NumericMatrix pts_in;
-    if (Rcpp::is<Rcpp::DataFrame>(pts)) {
-        pts_in = df_to_matrix_(pts);
-    }
-    else if (Rcpp::is<Rcpp::NumericVector>(pts)) {
-        if (Rf_isMatrix(pts))
-            pts_in = Rcpp::as<Rcpp::NumericMatrix>(pts);
-    }
-    else {
-        Rcpp::stop("'pts' must be a data frame or matrix");
-    }
+    Rcpp::NumericMatrix pts_in = xy_robject_to_matrix_(pts);
 
     if (pts_in.nrow() == 0)
         Rcpp::stop("input matrix is empty");
@@ -220,7 +210,7 @@ Rcpp::NumericMatrix inv_project(const Rcpp::RObject &pts,
 //' `transform_xy()` transforms geospatial x/y coordinates to a new projection.
 //'
 //' @param pts A two-column data frame or numeric matrix containing geospatial
-//' x/y coordinates.
+//' x, y coordinates (or vector of x, y for one point).
 //' @param srs_from Character string specifying the spatial reference system
 //' for `pts`. May be in WKT format or any of the formats supported by
 //' [srs_to_wkt()].
@@ -244,17 +234,7 @@ Rcpp::NumericMatrix transform_xy(const Rcpp::RObject &pts,
                                  const std::string &srs_from,
                                  const std::string &srs_to) {
 
-    Rcpp::NumericMatrix pts_in;
-    if (Rcpp::is<Rcpp::DataFrame>(pts)) {
-        pts_in = df_to_matrix_(pts);
-    }
-    else if (Rcpp::is<Rcpp::NumericVector>(pts)) {
-        if (Rf_isMatrix(pts))
-            pts_in = Rcpp::as<Rcpp::NumericMatrix>(pts);
-    }
-    else {
-        Rcpp::stop("'pts' must be a data frame or matrix");
-    }
+    Rcpp::NumericMatrix pts_in = xy_robject_to_matrix_(pts);
 
     if (pts_in.nrow() == 0)
         Rcpp::stop("input matrix is empty");

--- a/tests/testthat/test-gdal_helpers.R
+++ b/tests/testthat/test-gdal_helpers.R
@@ -1,3 +1,5 @@
+# apply_geotransform() and get_pixel_line() tests are in test-gdal_exp.R
+
 test_that("addFilesInZip works", {
     # requires GDAL >= 3.7
     skip_if(as.integer(gdal_version()[2]) < 3070000)

--- a/tests/testthat/test-transform.R
+++ b/tests/testthat/test-transform.R
@@ -5,18 +5,27 @@ test_that("transform/inv_project give correct results", {
     pts <- read.csv(pt_file)
     xy_alb83 <- c(-1330885, -1331408, -1331994, -1330297, -1329991, -1329167,
                   -1329903, -1329432, -1327683, -1331265,  2684892,  2684660,
-                  2685048,  2684967,  2683777,  2685212, 2685550,  2683821,
-                  2685541,  2685514)
+                   2685048,  2684967,  2683777,  2685212,  2685550,  2683821,
+                   2685541,  2685514)
+
     xy_test <- transform_xy(pts = pts[,-1],
                             srs_from = epsg_to_wkt(26912),
                             srs_to = epsg_to_wkt(5070))
-    expect_equal(as.vector(xy_test), xy_alb83, tolerance=1)
+    expect_equal(as.vector(xy_test), xy_alb83, tolerance=0.1)
+
     # as matrix
-    xy_test <- NULL
     xy_test <- transform_xy(pts = as.matrix(pts[,-1]),
                             srs_from = epsg_to_wkt(26912),
                             srs_to = epsg_to_wkt(5070))
-    expect_equal(as.vector(xy_test), xy_alb83, tolerance=1)
+    expect_equal(as.vector(xy_test), xy_alb83, tolerance=0.1)
+
+    # as vector for one point
+    xy_test <- transform_xy(pts = c(pts[1, 2], pts[1, 3]),
+                            srs_from = epsg_to_wkt(26912),
+                            srs_to = epsg_to_wkt(5070))
+    expect_equal(as.vector(xy_test), c(xy_alb83[1], xy_alb83[11]),
+                 tolerance=0.1)
+
     # errors
     expect_error(transform_xy(pts = pts[,-1],
                               srs_from = "invalid",
@@ -29,16 +38,25 @@ test_that("transform/inv_project give correct results", {
                   -113.24600, -113.25613, -113.24613, -113.22794, -113.27334,
                   46.06118, 46.05827, 46.06076, 46.06280, 46.05276, 46.06682,
                   46.06862, 46.05405, 46.07214, 46.06607)
+
     inv_test <- inv_project(pts = pts[,-1],
                             srs = epsg_to_wkt(26912),
                             well_known_gcs = "WGS84")
     expect_equal(as.vector(inv_test), xy_wgs84, tolerance = 0.001)
+
     # as matrix
-    inv_test <- NULL
     inv_test <- inv_project(pts = as.matrix(pts[,-1]),
                             srs = epsg_to_wkt(26912),
                             well_known_gcs = "WGS84")
     expect_equal(as.vector(inv_test), xy_wgs84, tolerance = 0.001)
+
+    # as vector for one point
+    inv_test <- inv_project(pts = c(pts[1, 2], pts[1, 3]),
+                            srs = epsg_to_wkt(26912),
+                            well_known_gcs = "WGS84")
+    expect_equal(as.vector(inv_test), c(xy_wgs84[1], xy_wgs84[11]),
+                 tolerance=0.001)
+
     # errors
     expect_error(inv_project(pts = as.vector(pts[,-1]),
                              srs = epsg_to_wkt(26912),


### PR DESCRIPTION
In `transform_xy()`, `inverse_proj()`, `apply_geotransform()`, `get_pixel_line()`