### PR TITLE
GDALVector: set the member variable m_layer_name when opening a default layer first by index

### DIFF
--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -138,6 +138,11 @@ void GDALVector::open(bool read_only) {
         OGR_L_ResetReading(m_hLayer);
     }
 
+    if (m_layer_name == "") {
+        // default layer first by index was opened
+        m_layer_name = OGR_L_GetName(m_hLayer);
+    }
+
     if (hGeom_filter != nullptr)
         OGR_G_DestroyGeometry(hGeom_filter);
 }

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -1082,5 +1082,11 @@ test_that("info() prints output to the console", {
     expect_output(lyr$info())
     lyr$close()
 
+    # default layer first by index
+    lyr <- new(GDALVector, dsn)
+    expect_no_warning(lyr$info())
+    expect_output(lyr$info())
+    lyr$close()
+
     unlink(dsn)
 })


### PR DESCRIPTION
fixes #589 