### PR TITLE
Handle NA in the input coordinates to transform_xy(), inv_project(), transform_bounds(), apply_geotransform() and get_pixel_line()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2386,7 +2386,7 @@ has_geos <- function() {
 #' @param well_known_gcs Optional character string containing a supported
 #' well known name of a geographic coordinate system (see Details for
 #' supported values).
-#' @returns Numeric array of longitude, latitude. An error is raised if the
+#' @returns Numeric matrix of longitude, latitude. An error is raised if the
 #' transformation cannot be performed.
 #' @seealso
 #' [transform_xy()]
@@ -2412,7 +2412,7 @@ inv_project <- function(pts, srs, well_known_gcs = "") {
 #' @param srs_to Character string specifying the output spatial reference
 #' system. May be in WKT format or any of the formats supported by
 #' [srs_to_wkt()].
-#' @returns Numeric array of geospatial x/y coordinates in the projection
+#' @returns Numeric matrix of geospatial (x, y) coordinates in the projection
 #' specified by `srs_to`.
 #'
 #' @seealso

--- a/R/gdal_helpers.R
+++ b/R/gdal_helpers.R
@@ -356,7 +356,8 @@ apply_geotransform <- function(col_row, gt) {
     else if (is.vector(col_row) && length(col_row) != 2)
         stop("'col_row' as vector must have length 2", call. = FALSE)
 
-    if ((is.vector(col_row) || is.matrix(col_row)) && !is.numeric(col_row))
+    # allow for c(NA, NA) which is logical type, NA input should return NA out
+    if ((is.vector(xy) || is.matrix(xy)) && !is.numeric(xy) && !is.logical(xy))
         stop("'col_row' must be numeric", call. = FALSE)
 
     if (is(gt, "Rcpp_GDALRaster")) {
@@ -427,7 +428,8 @@ get_pixel_line <- function(xy, gt) {
     else if (is.vector(xy) && length(xy) != 2)
         stop("'xy' as vector must have length 2", call. = FALSE)
 
-    if ((is.vector(xy) || is.matrix(xy)) && !is.numeric(xy))
+    # allow for c(NA, NA) which is logical type, NA input should return NA out
+    if ((is.vector(xy) || is.matrix(xy)) && !is.numeric(xy) && !is.logical(xy))
         stop("'xy' must be numeric", call. = FALSE)
 
     if (is(gt, "Rcpp_GDALRaster")) {

--- a/man/inv_project.Rd
+++ b/man/inv_project.Rd
@@ -19,7 +19,7 @@ well known name of a geographic coordinate system (see Details for
 supported values).}
 }
 \value{
-Numeric array of longitude, latitude. An error is raised if the
+Numeric matrix of longitude, latitude. An error is raised if the
 transformation cannot be performed.
 }
 \description{

--- a/man/transform_xy.Rd
+++ b/man/transform_xy.Rd
@@ -19,7 +19,7 @@ system. May be in WKT format or any of the formats supported by
 \code{\link[=srs_to_wkt]{srs_to_wkt()}}.}
 }
 \value{
-Numeric array of geospatial x/y coordinates in the projection
+Numeric matrix of geospatial (x, y) coordinates in the projection
 specified by \code{srs_to}.
 }
 \description{

--- a/src/rcpp_util.cpp
+++ b/src/rcpp_util.cpp
@@ -8,7 +8,7 @@
 //' convert data frame to numeric matrix in Rcpp
 //' @noRd
 Rcpp::NumericMatrix df_to_matrix_(const Rcpp::DataFrame& df) {
-    Rcpp::NumericMatrix m(df.nrows(), df.size());
+    Rcpp::NumericMatrix m = Rcpp::no_init(df.nrows(), df.size());
     for (R_xlen_t i=0; i < df.size(); ++i) {
         if (Rcpp::is<Rcpp::NumericVector>(df[i]) ||
             Rcpp::is<Rcpp::IntegerVector>(df[i]) ||
@@ -26,7 +26,7 @@ Rcpp::NumericMatrix df_to_matrix_(const Rcpp::DataFrame& df) {
 //' convert data frame to integer matrix in Rcpp
 //' @noRd
 Rcpp::IntegerMatrix df_to_int_matrix_(const Rcpp::DataFrame& df) {
-    Rcpp::IntegerMatrix m(df.nrows(), df.size());
+    Rcpp::IntegerMatrix m = Rcpp::no_init(df.nrows(), df.size());
     for (R_xlen_t i=0; i < df.size(); ++i) {
         if (Rcpp::is<Rcpp::NumericVector>(df[i]) ||
             Rcpp::is<Rcpp::IntegerVector>(df[i]) ||
@@ -47,7 +47,8 @@ Rcpp::NumericMatrix xy_robject_to_matrix_(const Rcpp::RObject& xy) {
     Rcpp::NumericMatrix xy_ret;
 
     if (Rcpp::is<Rcpp::NumericVector>(xy) ||
-        Rcpp::is<Rcpp::IntegerVector>(xy)) {
+        Rcpp::is<Rcpp::IntegerVector>(xy) ||
+        Rcpp::is<Rcpp::LogicalVector>(xy)) {
 
         if (!Rf_isMatrix(xy)) {
             Rcpp::NumericVector v = Rcpp::as<Rcpp::NumericVector>(xy);

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -114,6 +114,13 @@ test_that("apply_geotransform gives correct results", {
     dim(res) <- NULL
     expect_equal(res, xy_expected[1, ], tolerance = 0.1)
 
+    # NA input
+    res <- ds$apply_geotransform(c(NA, NA))
+    expect_true(all(is.na(res)))
+
+    res <- apply_geotransform(c(NA, NA), gt)
+    expect_true(all(is.na(res)))
+
     ds$close()
 })
 
@@ -140,6 +147,13 @@ test_that("get_pixel_line gives correct results", {
     # one coordinate as vector input
     res <- get_pixel_line(c(pts[1, 2], pts[1, 3]), gt)  # col 2 x, col 3 y
     expect_equal(as.vector(res), c(pix_line[1], pix_line[11]))
+
+    # NA input
+    res <- get_pixel_line(c(NA, NA), gt)
+    expect_true(all(is.na(res)))
+
+    res <- ds$get_pixel_line(c(NA, NA))
+    expect_true(all(is.na(res)))
 
     ds$close()
 })


### PR DESCRIPTION
fixes #587 

In the case of `transform_xy()` and `inv_project()`, related to the issue described in https://github.com/OSGeo/gdal/issues/11817 and accounts for future behavior change in https://github.com/OSGeo/gdal/pull/11819.