### PR TITLE
Class VSIFille: call VSIFCloseL() in the destructor instead of class method close()

### DIFF
--- a/src/vsifile.cpp
+++ b/src/vsifile.cpp
@@ -37,7 +37,8 @@ VSIFile::VSIFile(Rcpp::CharacterVector filename, std::string access,
 }
 
 VSIFile::~VSIFile() {
-    close();
+    if (m_fp)
+        VSIFCloseL(m_fp);
 }
 
 void VSIFile::open() {


### PR DESCRIPTION
since `VSIFille::close()` has a return value