### PR TITLE
GDALVector: initialize the default constructor

### DIFF
--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -23,7 +23,14 @@
 #include "ogr_util.h"
 
 
-GDALVector::GDALVector() {}
+GDALVector::GDALVector() :
+            m_layer_name(""),
+            m_dialect(""),
+            m_open_options(Rcpp::CharacterVector::create()),
+            m_spatial_filter(""),
+            m_hDataset(nullptr),
+            m_eAccess(GA_ReadOnly),
+            m_hLayer(nullptr) {}
 
 GDALVector::GDALVector(Rcpp::CharacterVector dsn) :
 
@@ -3165,6 +3172,8 @@ OGRFeatureH GDALVector::OGRFeatureFromList_(
 RCPP_MODULE(mod_GDALVector) {
     Rcpp::class_<GDALVector>("GDALVector")
 
+    .constructor
+        ("Default constructor, no dataset opened")
     .constructor<Rcpp::CharacterVector>
         ("Usage: new(GDALVector, dsn)")
     .constructor<Rcpp::CharacterVector, std::string>


### PR DESCRIPTION
This doesn't really have user facing implications, but the default constructor might be needed e.g. to allocate `std::vector<GDALVector>`. In case a user did instantiate in R with `lyr <- new(GDALVector)` then the object should be well behaved.