### PR TITLE
Implement ogr_ds_create() and ogr_layer_create() as GDALVector object factories

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2378,14 +2378,6 @@ bbox_to_wkt <- function(bbox, extend_x = 0, extend_y = 0) {
     .Call(`_gdalraster_ogr_ds_test_cap`, dsn, with_update)
 }
 
-#' Create a vector dataset. Optionally create a layer in the dataset.
-#' A field is also created optionally (name and type only).
-#'
-#' @noRd
-.create_ogr <- function(format, dst_filename, xsize, ysize, nbands, dataType, layer, geom_type, srs = "", fld_name = "", fld_type = "OFTInteger", dsco = NULL, lco = NULL, layer_defn = NULL) {
-    .Call(`_gdalraster_create_ogr`, format, dst_filename, xsize, ysize, nbands, dataType, layer, geom_type, srs, fld_name, fld_type, dsco, lco, layer_defn)
-}
-
 #' Get number of layers in a dataset
 #'
 #' @noRd
@@ -2412,13 +2404,6 @@ bbox_to_wkt <- function(bbox, extend_x = 0, extend_y = 0) {
 #' @noRd
 .ogr_layer_test_cap <- function(dsn, layer, with_update = TRUE) {
     .Call(`_gdalraster_ogr_layer_test_cap`, dsn, layer, with_update)
-}
-
-#' Create a layer in a vector dataset
-#'
-#' @noRd
-.ogr_layer_create <- function(dsn, layer, layer_defn = NULL, geom_type = "UNKNOWN", srs = "", options = NULL) {
-    .Call(`_gdalraster_ogr_layer_create`, dsn, layer, layer_defn, geom_type, srs, options)
 }
 
 #' Rename a layer in a vector dataset

--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -414,15 +414,15 @@ ogr_ds_create <- function(format, dsn, layer = NULL, layer_defn = NULL,
     }
 
     if (is.null(layer_defn)) {
-        lyr <- .create_ogr(format, dsn, 0, 0, 0, "Unknown",
-                           layer, geom_type, srs, fld_name, fld_type,
-                           dsco, lco, NULL)
+        # signature for create_ogr() object factory
+        lyr <- new(GDALVector, format, dsn, layer, geom_type, srs, fld_name,
+                   fld_type, dsco, lco, NULL)
 
     } else {
-        lyr <- .create_ogr(format, dsn, 0, 0, 0, "Unknown",
-                           layer = layer, geom_type = "", srs = "",
-                           fld_name = "", fld_type = "",
-                           dsco = dsco, lco = lco, layer_defn = layer_defn)
+        # signature for create_ogr() object factory
+        lyr <- new(GDALVector, format, dsn, layer = layer, geom_type = "",
+                   srs = "", fld_name = "", fld_type = "", dsco = dsco,
+                   lco = lco, layer_defn = layer_defn)
     }
 
     if (return_obj) {
@@ -543,12 +543,8 @@ ogr_layer_create <- function(dsn, layer, layer_defn = NULL, geom_type = NULL,
     if (!is.logical(return_obj) || length(return_obj) > 1)
         stop("'return_obj' must be a logical scalar", call. = FALSE)
 
-    lyr <- .ogr_layer_create(dsn = dsn,
-                             layer = layer,
-                             layer_defn = layer_defn,
-                             geom_type = geom_type,
-                             srs = srs,
-                             options = lco)
+    # signature for ogr_layer_create() object factory
+    lyr <- new(GDALVector, dsn, layer, layer_defn, geom_type, srs, lco, TRUE)
 
     if (return_obj) {
         return(lyr)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1401,250 +1401,210 @@ BEGIN_RCPP
 END_RCPP
 }
 // ogr_ds_exists
-bool ogr_ds_exists(std::string dsn, bool with_update);
+bool ogr_ds_exists(const std::string& dsn, bool with_update);
 RcppExport SEXP _gdalraster_ogr_ds_exists(SEXP dsnSEXP, SEXP with_updateSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
     Rcpp::traits::input_parameter< bool >::type with_update(with_updateSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_ds_exists(dsn, with_update));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_ds_format
-std::string ogr_ds_format(std::string dsn);
+std::string ogr_ds_format(const std::string& dsn);
 RcppExport SEXP _gdalraster_ogr_ds_format(SEXP dsnSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_ds_format(dsn));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_ds_test_cap
-SEXP ogr_ds_test_cap(std::string dsn, bool with_update);
+SEXP ogr_ds_test_cap(const std::string& dsn, bool with_update);
 RcppExport SEXP _gdalraster_ogr_ds_test_cap(SEXP dsnSEXP, SEXP with_updateSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
     Rcpp::traits::input_parameter< bool >::type with_update(with_updateSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_ds_test_cap(dsn, with_update));
     return rcpp_result_gen;
 END_RCPP
 }
-// create_ogr
-GDALVector create_ogr(std::string format, std::string dst_filename, int xsize, int ysize, int nbands, std::string dataType, std::string layer, std::string geom_type, std::string srs, std::string fld_name, std::string fld_type, Rcpp::Nullable<Rcpp::CharacterVector> dsco, Rcpp::Nullable<Rcpp::CharacterVector> lco, Rcpp::Nullable<Rcpp::List> layer_defn);
-RcppExport SEXP _gdalraster_create_ogr(SEXP formatSEXP, SEXP dst_filenameSEXP, SEXP xsizeSEXP, SEXP ysizeSEXP, SEXP nbandsSEXP, SEXP dataTypeSEXP, SEXP layerSEXP, SEXP geom_typeSEXP, SEXP srsSEXP, SEXP fld_nameSEXP, SEXP fld_typeSEXP, SEXP dscoSEXP, SEXP lcoSEXP, SEXP layer_defnSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type format(formatSEXP);
-    Rcpp::traits::input_parameter< std::string >::type dst_filename(dst_filenameSEXP);
-    Rcpp::traits::input_parameter< int >::type xsize(xsizeSEXP);
-    Rcpp::traits::input_parameter< int >::type ysize(ysizeSEXP);
-    Rcpp::traits::input_parameter< int >::type nbands(nbandsSEXP);
-    Rcpp::traits::input_parameter< std::string >::type dataType(dataTypeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< std::string >::type geom_type(geom_typeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type srs(srsSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_name(fld_nameSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_type(fld_typeSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type dsco(dscoSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type lco(lcoSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> >::type layer_defn(layer_defnSEXP);
-    rcpp_result_gen = Rcpp::wrap(create_ogr(format, dst_filename, xsize, ysize, nbands, dataType, layer, geom_type, srs, fld_name, fld_type, dsco, lco, layer_defn));
-    return rcpp_result_gen;
-END_RCPP
-}
 // ogr_ds_layer_count
-int ogr_ds_layer_count(std::string dsn);
+int ogr_ds_layer_count(const std::string& dsn);
 RcppExport SEXP _gdalraster_ogr_ds_layer_count(SEXP dsnSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_ds_layer_count(dsn));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_ds_layer_names
-SEXP ogr_ds_layer_names(std::string dsn);
+SEXP ogr_ds_layer_names(const std::string& dsn);
 RcppExport SEXP _gdalraster_ogr_ds_layer_names(SEXP dsnSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_ds_layer_names(dsn));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_layer_exists
-bool ogr_layer_exists(std::string dsn, std::string layer);
+bool ogr_layer_exists(const std::string& dsn, const std::string& layer);
 RcppExport SEXP _gdalraster_ogr_layer_exists(SEXP dsnSEXP, SEXP layerSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_layer_exists(dsn, layer));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_layer_test_cap
-SEXP ogr_layer_test_cap(std::string dsn, std::string layer, bool with_update);
+SEXP ogr_layer_test_cap(const std::string& dsn, const std::string& layer, bool with_update);
 RcppExport SEXP _gdalraster_ogr_layer_test_cap(SEXP dsnSEXP, SEXP layerSEXP, SEXP with_updateSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
     Rcpp::traits::input_parameter< bool >::type with_update(with_updateSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_layer_test_cap(dsn, layer, with_update));
     return rcpp_result_gen;
 END_RCPP
 }
-// ogr_layer_create
-GDALVector ogr_layer_create(std::string dsn, std::string layer, Rcpp::Nullable<Rcpp::List> layer_defn, std::string geom_type, std::string srs, Rcpp::Nullable<Rcpp::CharacterVector> options);
-RcppExport SEXP _gdalraster_ogr_layer_create(SEXP dsnSEXP, SEXP layerSEXP, SEXP layer_defnSEXP, SEXP geom_typeSEXP, SEXP srsSEXP, SEXP optionsSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::List> >::type layer_defn(layer_defnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type geom_type(geom_typeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type srs(srsSEXP);
-    Rcpp::traits::input_parameter< Rcpp::Nullable<Rcpp::CharacterVector> >::type options(optionsSEXP);
-    rcpp_result_gen = Rcpp::wrap(ogr_layer_create(dsn, layer, layer_defn, geom_type, srs, options));
-    return rcpp_result_gen;
-END_RCPP
-}
 // ogr_layer_rename
-bool ogr_layer_rename(std::string dsn, std::string layer, std::string new_name);
+bool ogr_layer_rename(const std::string& dsn, const std::string& layer, const std::string& new_name);
 RcppExport SEXP _gdalraster_ogr_layer_rename(SEXP dsnSEXP, SEXP layerSEXP, SEXP new_nameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< std::string >::type new_name(new_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type new_name(new_nameSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_layer_rename(dsn, layer, new_name));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_layer_delete
-bool ogr_layer_delete(std::string dsn, std::string layer);
+bool ogr_layer_delete(const std::string& dsn, const std::string& layer);
 RcppExport SEXP _gdalraster_ogr_layer_delete(SEXP dsnSEXP, SEXP layerSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_layer_delete(dsn, layer));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_layer_field_names
-SEXP ogr_layer_field_names(std::string dsn, std::string layer);
+SEXP ogr_layer_field_names(const std::string& dsn, const std::string& layer);
 RcppExport SEXP _gdalraster_ogr_layer_field_names(SEXP dsnSEXP, SEXP layerSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_layer_field_names(dsn, layer));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_field_index
-int ogr_field_index(std::string dsn, std::string layer, std::string fld_name);
+int ogr_field_index(const std::string& dsn, const std::string& layer, const std::string& fld_name);
 RcppExport SEXP _gdalraster_ogr_field_index(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_name(fld_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_name(fld_nameSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_field_index(dsn, layer, fld_name));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_field_create
-bool ogr_field_create(std::string dsn, std::string layer, std::string fld_name, std::string fld_type, std::string fld_subtype, int fld_width, int fld_precision, bool is_nullable, bool is_unique, std::string default_value);
+bool ogr_field_create(const std::string& dsn, const std::string& layer, const std::string& fld_name, const std::string& fld_type, const std::string& fld_subtype, int fld_width, int fld_precision, bool is_nullable, bool is_unique, const std::string& default_value);
 RcppExport SEXP _gdalraster_ogr_field_create(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP, SEXP fld_typeSEXP, SEXP fld_subtypeSEXP, SEXP fld_widthSEXP, SEXP fld_precisionSEXP, SEXP is_nullableSEXP, SEXP is_uniqueSEXP, SEXP default_valueSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_name(fld_nameSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_type(fld_typeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_subtype(fld_subtypeSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_name(fld_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_type(fld_typeSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_subtype(fld_subtypeSEXP);
     Rcpp::traits::input_parameter< int >::type fld_width(fld_widthSEXP);
     Rcpp::traits::input_parameter< int >::type fld_precision(fld_precisionSEXP);
     Rcpp::traits::input_parameter< bool >::type is_nullable(is_nullableSEXP);
     Rcpp::traits::input_parameter< bool >::type is_unique(is_uniqueSEXP);
-    Rcpp::traits::input_parameter< std::string >::type default_value(default_valueSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type default_value(default_valueSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_field_create(dsn, layer, fld_name, fld_type, fld_subtype, fld_width, fld_precision, is_nullable, is_unique, default_value));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_geom_field_create
-bool ogr_geom_field_create(std::string dsn, std::string layer, std::string fld_name, std::string geom_type, std::string srs, bool is_nullable);
+bool ogr_geom_field_create(const std::string& dsn, const std::string& layer, const std::string& fld_name, const std::string& geom_type, const std::string& srs, bool is_nullable);
 RcppExport SEXP _gdalraster_ogr_geom_field_create(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP, SEXP geom_typeSEXP, SEXP srsSEXP, SEXP is_nullableSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_name(fld_nameSEXP);
-    Rcpp::traits::input_parameter< std::string >::type geom_type(geom_typeSEXP);
-    Rcpp::traits::input_parameter< std::string >::type srs(srsSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_name(fld_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type geom_type(geom_typeSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
     Rcpp::traits::input_parameter< bool >::type is_nullable(is_nullableSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_geom_field_create(dsn, layer, fld_name, geom_type, srs, is_nullable));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_field_rename
-bool ogr_field_rename(std::string dsn, std::string layer, std::string fld_name, std::string new_name);
+bool ogr_field_rename(const std::string& dsn, const std::string& layer, const std::string& fld_name, const std::string& new_name);
 RcppExport SEXP _gdalraster_ogr_field_rename(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP, SEXP new_nameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_name(fld_nameSEXP);
-    Rcpp::traits::input_parameter< std::string >::type new_name(new_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_name(fld_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type new_name(new_nameSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_field_rename(dsn, layer, fld_name, new_name));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_field_delete
-bool ogr_field_delete(std::string dsn, std::string layer, std::string fld_name);
+bool ogr_field_delete(const std::string& dsn, const std::string& layer, const std::string& fld_name);
 RcppExport SEXP _gdalraster_ogr_field_delete(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type layer(layerSEXP);
-    Rcpp::traits::input_parameter< std::string >::type fld_name(fld_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_name(fld_nameSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_field_delete(dsn, layer, fld_name));
     return rcpp_result_gen;
 END_RCPP
 }
 // ogr_execute_sql
-SEXP ogr_execute_sql(std::string dsn, std::string sql, std::string spatial_filter, std::string dialect);
+SEXP ogr_execute_sql(const std::string& dsn, const std::string& sql, const std::string& spatial_filter, const std::string& dialect);
 RcppExport SEXP _gdalraster_ogr_execute_sql(SEXP dsnSEXP, SEXP sqlSEXP, SEXP spatial_filterSEXP, SEXP dialectSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< std::string >::type dsn(dsnSEXP);
-    Rcpp::traits::input_parameter< std::string >::type sql(sqlSEXP);
-    Rcpp::traits::input_parameter< std::string >::type spatial_filter(spatial_filterSEXP);
-    Rcpp::traits::input_parameter< std::string >::type dialect(dialectSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type sql(sqlSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type spatial_filter(spatial_filterSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type dialect(dialectSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_execute_sql(dsn, sql, spatial_filter, dialect));
     return rcpp_result_gen;
 END_RCPP
@@ -2066,12 +2026,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_ogr_ds_exists", (DL_FUNC) &_gdalraster_ogr_ds_exists, 2},
     {"_gdalraster_ogr_ds_format", (DL_FUNC) &_gdalraster_ogr_ds_format, 1},
     {"_gdalraster_ogr_ds_test_cap", (DL_FUNC) &_gdalraster_ogr_ds_test_cap, 2},
-    {"_gdalraster_create_ogr", (DL_FUNC) &_gdalraster_create_ogr, 14},
     {"_gdalraster_ogr_ds_layer_count", (DL_FUNC) &_gdalraster_ogr_ds_layer_count, 1},
     {"_gdalraster_ogr_ds_layer_names", (DL_FUNC) &_gdalraster_ogr_ds_layer_names, 1},
     {"_gdalraster_ogr_layer_exists", (DL_FUNC) &_gdalraster_ogr_layer_exists, 2},
     {"_gdalraster_ogr_layer_test_cap", (DL_FUNC) &_gdalraster_ogr_layer_test_cap, 3},
-    {"_gdalraster_ogr_layer_create", (DL_FUNC) &_gdalraster_ogr_layer_create, 6},
     {"_gdalraster_ogr_layer_rename", (DL_FUNC) &_gdalraster_ogr_layer_rename, 3},
     {"_gdalraster_ogr_layer_delete", (DL_FUNC) &_gdalraster_ogr_layer_delete, 2},
     {"_gdalraster_ogr_layer_field_names", (DL_FUNC) &_gdalraster_ogr_layer_field_names, 2},

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -1933,8 +1933,8 @@ std::string GDALVector::getMetadataItem(std::string mdi_name) const {
 }
 
 bool GDALVector::layerIntersection(
-        GDALVector method_layer,
-        GDALVector result_layer,
+        GDALVector* const &method_layer,
+        GDALVector* const &result_layer,
         bool quiet,
         const Rcpp::Nullable<const Rcpp::CharacterVector> &options) {
 
@@ -1951,8 +1951,8 @@ bool GDALVector::layerIntersection(
     bool ret = false;
     OGRErr err = OGR_L_Intersection(
                     m_hLayer,
-                    method_layer.getOGRLayerH_(),
-                    result_layer.getOGRLayerH_(),
+                    method_layer->getOGRLayerH_(),
+                    result_layer->getOGRLayerH_(),
                     opt_list.data(),
                     quiet ? nullptr : GDALTermProgressR,
                     nullptr);
@@ -1970,8 +1970,8 @@ bool GDALVector::layerIntersection(
 }
 
 bool GDALVector::layerUnion(
-        GDALVector method_layer,
-        GDALVector result_layer,
+        GDALVector* const &method_layer,
+        GDALVector* const &result_layer,
         bool quiet,
         const Rcpp::Nullable<const Rcpp::CharacterVector> &options) {
 
@@ -1988,8 +1988,8 @@ bool GDALVector::layerUnion(
     bool ret = false;
     OGRErr err = OGR_L_Union(
                     m_hLayer,
-                    method_layer.getOGRLayerH_(),
-                    result_layer.getOGRLayerH_(),
+                    method_layer->getOGRLayerH_(),
+                    result_layer->getOGRLayerH_(),
                     opt_list.data(),
                     quiet ? nullptr : GDALTermProgressR,
                     nullptr);
@@ -2007,8 +2007,8 @@ bool GDALVector::layerUnion(
 }
 
 bool GDALVector::layerSymDifference(
-        GDALVector method_layer,
-        GDALVector result_layer,
+        GDALVector* const &method_layer,
+        GDALVector* const &result_layer,
         bool quiet,
         const Rcpp::Nullable<const Rcpp::CharacterVector> &options) {
 
@@ -2025,8 +2025,8 @@ bool GDALVector::layerSymDifference(
     bool ret = false;
     OGRErr err = OGR_L_SymDifference(
                     m_hLayer,
-                    method_layer.getOGRLayerH_(),
-                    result_layer.getOGRLayerH_(),
+                    method_layer->getOGRLayerH_(),
+                    result_layer->getOGRLayerH_(),
                     opt_list.data(),
                     quiet ? nullptr : GDALTermProgressR,
                     nullptr);
@@ -2044,8 +2044,8 @@ bool GDALVector::layerSymDifference(
 }
 
 bool GDALVector::layerIdentity(
-        GDALVector method_layer,
-        GDALVector result_layer,
+        GDALVector* const &method_layer,
+        GDALVector* const &result_layer,
         bool quiet,
         const Rcpp::Nullable<const Rcpp::CharacterVector> &options) {
 
@@ -2062,8 +2062,8 @@ bool GDALVector::layerIdentity(
     bool ret = false;
     OGRErr err = OGR_L_Identity(
                     m_hLayer,
-                    method_layer.getOGRLayerH_(),
-                    result_layer.getOGRLayerH_(),
+                    method_layer->getOGRLayerH_(),
+                    result_layer->getOGRLayerH_(),
                     opt_list.data(),
                     quiet ? nullptr : GDALTermProgressR,
                     nullptr);
@@ -2081,8 +2081,8 @@ bool GDALVector::layerIdentity(
 }
 
 bool GDALVector::layerUpdate(
-        GDALVector method_layer,
-        GDALVector result_layer,
+        GDALVector* const &method_layer,
+        GDALVector* const &result_layer,
         bool quiet,
         const Rcpp::Nullable<const Rcpp::CharacterVector> &options) {
 
@@ -2099,8 +2099,8 @@ bool GDALVector::layerUpdate(
     bool ret = false;
     OGRErr err = OGR_L_Update(
                     m_hLayer,
-                    method_layer.getOGRLayerH_(),
-                    result_layer.getOGRLayerH_(),
+                    method_layer->getOGRLayerH_(),
+                    result_layer->getOGRLayerH_(),
                     opt_list.data(),
                     quiet ? nullptr : GDALTermProgressR,
                     nullptr);
@@ -2118,8 +2118,8 @@ bool GDALVector::layerUpdate(
 }
 
 bool GDALVector::layerClip(
-        GDALVector method_layer,
-        GDALVector result_layer,
+        GDALVector* const &method_layer,
+        GDALVector* const &result_layer,
         bool quiet,
         const Rcpp::Nullable<const Rcpp::CharacterVector> &options) {
 
@@ -2136,8 +2136,8 @@ bool GDALVector::layerClip(
     bool ret = false;
     OGRErr err = OGR_L_Clip(
                     m_hLayer,
-                    method_layer.getOGRLayerH_(),
-                    result_layer.getOGRLayerH_(),
+                    method_layer->getOGRLayerH_(),
+                    result_layer->getOGRLayerH_(),
                     opt_list.data(),
                     quiet ? nullptr : GDALTermProgressR,
                     nullptr);
@@ -2155,8 +2155,8 @@ bool GDALVector::layerClip(
 }
 
 bool GDALVector::layerErase(
-        GDALVector method_layer,
-        GDALVector result_layer,
+        GDALVector* const &method_layer,
+        GDALVector* const &result_layer,
         bool quiet,
         const Rcpp::Nullable<const Rcpp::CharacterVector> &options) {
 
@@ -2173,8 +2173,8 @@ bool GDALVector::layerErase(
     bool ret = false;
     OGRErr err = OGR_L_Erase(
                     m_hLayer,
-                    method_layer.getOGRLayerH_(),
-                    result_layer.getOGRLayerH_(),
+                    method_layer->getOGRLayerH_(),
+                    result_layer->getOGRLayerH_(),
                     opt_list.data(),
                     quiet ? nullptr : GDALTermProgressR,
                     nullptr);
@@ -3352,6 +3352,20 @@ RCPP_MODULE(mod_GDALVector) {
                  Rcpp::Nullable<Rcpp::CharacterVector>, std::string,
                  std::string>
         ("Usage: new(GDALVector, dsn, layer, read_only, open_options, spatial_filter, dialect)")
+
+    // create_ogr() object factory with 10 parameters
+    .factory<const std::string&, const std::string&, const std::string&,
+             const std::string&, const std::string&, const std::string&,
+             const std::string&, const Rcpp::Nullable<Rcpp::CharacterVector>&,
+             const Rcpp::Nullable<Rcpp::CharacterVector>&,
+             const Rcpp::Nullable<Rcpp::List>&>
+             (create_ogr)
+    // ogr_layer_create() object factory with 7 parameters
+    .factory<const std::string&, const std::string&,
+             const Rcpp::Nullable<Rcpp::List>&,
+             const std::string&, const std::string&,
+             const Rcpp::Nullable<Rcpp::CharacterVector>&, bool>
+             (ogr_layer_create)
 
     // undocumented read-only fields for internal use
     .field_readonly("m_layer_name", &GDALVector::m_layer_name)

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -76,6 +76,7 @@ GDALVector::GDALVector(Rcpp::CharacterVector dsn, std::string layer,
 
 GDALVector::~GDALVector() {
     releaseArrowStream();
+    close();
 }
 
 void GDALVector::open(bool read_only) {

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -113,38 +113,38 @@ class GDALVector {
     std::string getMetadataItem(std::string mdi_name) const;
 
     bool layerIntersection(
-            GDALVector method_layer,
-            GDALVector result_layer,
+            GDALVector* const &method_layer,
+            GDALVector* const &result_layer,
             bool quiet,
             const Rcpp::Nullable<const Rcpp::CharacterVector> &options);
     bool layerUnion(
-            GDALVector method_layer,
-            GDALVector result_layer,
+            GDALVector* const &method_layer,
+            GDALVector* const &result_layer,
             bool quiet,
             const Rcpp::Nullable<const Rcpp::CharacterVector> &options);
     bool layerSymDifference(
-            GDALVector method_layer,
-            GDALVector result_layer,
+            GDALVector* const &method_layer,
+            GDALVector* const &result_layer,
             bool quiet,
             const Rcpp::Nullable<const Rcpp::CharacterVector> &options);
     bool layerIdentity(
-            GDALVector method_layer,
-            GDALVector result_layer,
+            GDALVector* const &method_layer,
+            GDALVector* const &result_layer,
             bool quiet,
             const Rcpp::Nullable<const Rcpp::CharacterVector> &options);
     bool layerUpdate(
-            GDALVector method_layer,
-            GDALVector result_layer,
+            GDALVector* const &method_layer,
+            GDALVector* const &result_layer,
             bool quiet,
             const Rcpp::Nullable<const Rcpp::CharacterVector> &options);
     bool layerClip(
-            GDALVector method_layer,
-            GDALVector result_layer,
+            GDALVector* const &method_layer,
+            GDALVector* const &result_layer,
             bool quiet,
             const Rcpp::Nullable<const Rcpp::CharacterVector> &options);
     bool layerErase(
-            GDALVector method_layer,
-            GDALVector result_layer,
+            GDALVector* const &method_layer,
+            GDALVector* const &result_layer,
             bool quiet,
             const Rcpp::Nullable<const Rcpp::CharacterVector> &options);
 

--- a/src/ogr_util.h
+++ b/src/ogr_util.h
@@ -119,7 +119,7 @@ const std::map<std::string, OGRFieldSubType, _ci_less> MAP_OGR_FLD_SUBTYPE{
 
 // Internal lookup of OGRwkbGeometryType by string descriptor
 // Returns wkbUnknown if no match
-OGRwkbGeometryType getWkbGeomType_(std::string geom_type);
+OGRwkbGeometryType getWkbGeomType_(const std::string &geom_type);
 
 // Internal lookup of geometry type string by OGRwkbGeometryType
 // Returns "UNKNOWN" if no match
@@ -127,7 +127,7 @@ std::string getWkbGeomString_(OGRwkbGeometryType eType);
 
 // Internal lookup of OGRFieldType by string descriptor
 // Error if no match
-OGRFieldType getOFT_(std::string fld_type);
+OGRFieldType getOFT_(const std::string &fld_type);
 
 // Internal lookup of OGR field type string by OGRFieldType
 // Returns empty string if no match, with warning emitted
@@ -135,85 +135,95 @@ std::string getOFTString_(OGRFieldType eType);
 
 // Internal lookup of OGRFieldSubType by string descriptor
 // Returns OFSTNone if no match
-OGRFieldSubType getOFTSubtype_(std::string fld_subtype);
+OGRFieldSubType getOFTSubtype_(const std::string &fld_subtype);
 
 // Internal lookup of OGR field subtype string by OGRFieldSubType
 // Returns "OFSTNone" if no match
 std::string getOFTSubtypeString_(OGRFieldSubType eType);
 
 
-bool ogr_ds_exists(std::string dsn, bool with_update);
+bool ogr_ds_exists(const std::string &dsn, bool with_update);
 
-std::string ogr_ds_format(std::string dsn);
+std::string ogr_ds_format(const std::string &dsn);
 
-SEXP ogr_ds_test_cap(std::string dsn, bool with_update);
+SEXP ogr_ds_test_cap(const std::string &dsn, bool with_update);
 
-GDALVector create_ogr(std::string format, std::string dst_filename,
-                      int xsize, int ysize, int nbands, std::string dataType,
-                      std::string layer, std::string geom_type,
-                      std::string srs, std::string fld_name,
-                      std::string fld_type,
-                      Rcpp::Nullable<Rcpp::CharacterVector> dsco,
-                      Rcpp::Nullable<Rcpp::CharacterVector> lco,
-                      Rcpp::Nullable<Rcpp::List> layer_defn);
+GDALVector *create_ogr(const std::string &format,
+                       const std::string &dst_filename,
+                       const std::string &layer,
+                       const std::string &geom_type,
+                       const std::string &srs,
+                       const std::string &fld_name,
+                       const std::string &fld_type,
+                       const Rcpp::Nullable<Rcpp::CharacterVector> &dsco,
+                       const Rcpp::Nullable<Rcpp::CharacterVector> &lco,
+                       const Rcpp::Nullable<Rcpp::List> &layer_defn);
 
-int ogr_ds_layer_count(std::string dsn);
+int ogr_ds_layer_count(const std::string &dsn);
 
-SEXP ogr_ds_layer_names(std::string dsn);
+SEXP ogr_ds_layer_names(const std::string &dsn);
 
-bool ogr_layer_exists(std::string dsn, std::string layer);
+bool ogr_layer_exists(const std::string &dsn, const std::string &layer);
 
-SEXP ogr_layer_test_cap(std::string dsn, std::string layer,
+SEXP ogr_layer_test_cap(const std::string &dsn, const std::string &layer,
                          bool with_update);
 
 // internal CreateLayer
-OGRLayerH CreateLayer_(GDALDatasetH hDS, std::string layer,
+OGRLayerH CreateLayer_(GDALDatasetH hDS, const std::string &layer,
                        Rcpp::Nullable<Rcpp::List> layer_defn,
-                       std::string geom_type, std::string srs,
+                       const std::string &geom_type, const std::string &srs,
                        Rcpp::Nullable<Rcpp::CharacterVector> options);
 
-GDALVector ogr_layer_create(std::string dsn, std::string layer,
-                            Rcpp::Nullable<Rcpp::List> layer_defn,
-                            std::string geom_type, std::string srs,
-                            Rcpp::Nullable<Rcpp::CharacterVector> options);
+GDALVector *ogr_layer_create(
+        const std::string &dsn, const std::string &layer,
+        const Rcpp::Nullable<Rcpp::List> &layer_defn,
+        const std::string &geom_type, const std::string &srs,
+        const Rcpp::Nullable<Rcpp::CharacterVector> &options,
+        bool reserved1);
 
-bool ogr_layer_rename(std::string dsn, std::string layer,
-                      std::string new_name);
+bool ogr_layer_rename(const std::string &dsn, const std::string &layer,
+                      const std::string &new_name);
 
-bool ogr_layer_delete(std::string dsn, std::string layer);
+bool ogr_layer_delete(const std::string &dsn, const std::string &layer);
 
-SEXP ogr_layer_field_names(std::string dsn, std::string layer);
+SEXP ogr_layer_field_names(const std::string &dsn, const std::string &layer);
 
-int ogr_field_index(std::string dsn, std::string layer, std::string fld_name);
+int ogr_field_index(const std::string &dsn, const std::string &layer,
+                    const std::string &fld_name);
 
 // internal CreateField
-bool CreateField_(GDALDatasetH hDS, OGRLayerH hLayer, std::string fld_name,
-                  std::string fld_type, std::string fld_subtype, int fld_width,
-                  int fld_precision, bool is_nullable, bool is_unique,
-                  std::string default_value);
+bool CreateField_(GDALDatasetH hDS, OGRLayerH hLayer,
+                  const std::string &fld_name,
+                  const std::string &fld_type, const std::string &fld_subtype,
+                  int fld_width, int fld_precision, bool is_nullable,
+                  bool is_unique, const std::string &default_value);
 
-bool ogr_field_create(std::string dsn, std::string layer,
-                      std::string fld_name, std::string fld_type,
-                      std::string fld_subtype, int fld_width ,
+bool ogr_field_create(const std::string &dsn, const std::string &layer,
+                      const std::string &fld_name, const std::string &fld_type,
+                      const std::string &fld_subtype, int fld_width ,
                       int fld_precision, bool is_nullable,
-                      bool is_unique, std::string default_value);
+                      bool is_unique, const std::string &default_value);
 
 // internal CreateGeomField
-bool CreateGeomField_(GDALDatasetH hDS, OGRLayerH hLayer, std::string fld_name,
-                      OGRwkbGeometryType eGeomType, std::string srs,
+bool CreateGeomField_(GDALDatasetH hDS, OGRLayerH hLayer,
+                      const std::string &fld_name,
+                      OGRwkbGeometryType eGeomType, const std::string &srs,
                       bool is_nullable);
 
-bool ogr_geom_field_create(std::string dsn, std::string layer,
-                           std::string fld_name, std::string geom_type,
-                           std::string srs, bool is_nullable);
+bool ogr_geom_field_create(const std::string &dsn, const std::string &layer,
+                           const std::string &fld_name,
+                           const std::string &geom_type,
+                           const std::string &srs, bool is_nullable);
 
-bool ogr_field_rename(std::string dsn, std::string layer,
-                      std::string fld_name, std::string new_name);
+bool ogr_field_rename(const std::string &dsn, const std::string &layer,
+                      const std::string &fld_name,
+                      const std::string &new_name);
 
-bool ogr_field_delete(std::string dsn, std::string layer,
-                      std::string fld_name);
+bool ogr_field_delete(const std::string &dsn, const std::string &layer,
+                      const std::string &fld_name);
 
-SEXP ogr_execute_sql(std::string dsn, std::string sql,
-                     std::string spatial_filter, std::string dialect);
+SEXP ogr_execute_sql(const std::string &dsn, const std::string &sql,
+                     const std::string &spatial_filter,
+                     const std::string &dialect);
 
 #endif  // SRC_OGR_UTIL_H_


### PR DESCRIPTION
allocate on the heap and return a pointer (internal C++ functions `create_ogr()` and `ogr_layer_create()` registered as object factories via `RCPP_MODULE(mod_GDALVector)`)

C++ functions that accept `GDALVector` objects now use pass by const reference (`GDALVector* const&` )

adds explicit `GDALVector::~GDALVector()`, releasing the underlying dataset if needed