### PR TITLE
Fix potential integer overflow when multiplying raster dimensions in R without explicit as.numeric()

### DIFF
--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -861,13 +861,15 @@ Rcpp::NumericVector flip_vertical(const Rcpp::NumericVector& v,
 
     Rcpp::NumericVector out(v.size());
 
-    const size_t num_pixels = xsize * ysize;
+    const size_t num_pixels = static_cast<size_t>(xsize) * ysize;
     for (int b = 0; b < nbands; ++b) {
         const size_t band_offset = b * num_pixels;
         for (int line = 0; line < ysize; ++line) {
-            const size_t line_offset = band_offset + (line * xsize);
+            const size_t line_offset = band_offset +
+                                       line * static_cast<size_t>(xsize);
+
             const size_t dst_offset = band_offset + num_pixels -
-                                      ((line + 1) * xsize);
+                                      ((line + 1) * static_cast<size_t>(xsize));
 
             std::copy_n(v.cbegin() + line_offset, xsize,
                         out.begin() + dst_offset);
@@ -1094,8 +1096,8 @@ Rcpp::DataFrame combine(Rcpp::CharacterVector src_files,
         src_ds[i] = std::make_unique<GDALRaster>(std::string(src_files[i]));
         // use the first raster as reference
         if (i == 0) {
-            nrows = src_ds[i]->getRasterYSize();
-            ncols = src_ds[i]->getRasterXSize();
+            nrows = static_cast<int>(src_ds[i]->getRasterYSize());
+            ncols = static_cast<int>(src_ds[i]->getRasterXSize());
             gt = src_ds[i]->getGeoTransform();
             srs = src_ds[i]->getProjectionRef();
         }
@@ -1163,8 +1165,8 @@ Rcpp::DataFrame combine(Rcpp::CharacterVector src_files,
 Rcpp::DataFrame value_count(const GDALRaster* const &src_ds, int band = 1,
                             bool quiet = false) {
 
-    int nrows = src_ds->getRasterYSize();
-    int ncols = src_ds->getRasterXSize();
+    int nrows = static_cast<int>(src_ds->getRasterYSize());
+    int ncols = static_cast<int>(src_ds->getRasterXSize());
     GDALProgressFunc pfnProgress = nullptr;
     void *pProgressData = nullptr;
     if (!quiet)

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -117,8 +117,8 @@ class GDALRaster {
     std::string getDriverShortName() const;
     std::string getDriverLongName() const;
 
-    int getRasterXSize() const;
-    int getRasterYSize() const;
+    double getRasterXSize() const;
+    double getRasterYSize() const;
     std::vector<double> getGeoTransform() const;
     bool setGeoTransform(std::vector<double> transform);
     int getRasterCount() const;
@@ -131,7 +131,7 @@ class GDALRaster {
 
     std::vector<double> bbox() const;
     std::vector<double> res() const;
-    std::vector<int> dim() const;
+    std::vector<double> dim() const;
     Rcpp::NumericMatrix apply_geotransform(const Rcpp::RObject& col_row) const;
     Rcpp::IntegerMatrix get_pixel_line(const Rcpp::RObject& xy) const;
     Rcpp::NumericMatrix pixel_extract(const Rcpp::RObject& xy,

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -802,3 +802,21 @@ test_that("pixel extract cubic/cublicspline interpolation", {
 
     ds$close()
 })
+
+test_that("raster dimensions multiply without int overflow", {
+    f <- "/vsimem/file.tif"
+    ds <- create("GTiff", f, 86400, 43200, nbands = 1, dataType = "Byte",
+                 options = c("SPARSE_OK=YES"), return_obj = TRUE)
+
+    dm <- ds$dim()
+    expect_no_warning(dm[1] * dm[2])  # no warning for NAs produced by overflow
+    expect_equal(dm[1] * dm[2], 3732480000)
+
+    xsize <- ds$getRasterXSize()
+    ysize <- ds$getRasterYSize()
+    expect_no_warning(xsize * ysize)
+    expect_equal(xsize * ysize, 3732480000)
+
+    ds$close()
+    vsi_unlink(f)
+})


### PR DESCRIPTION
closes #613 

The return value of `GDALRaster::getRasterXSize()` / `GDALRaster::getRasterYSize()` was previously `int`, only because the underlying API calls to `GDALGetRasterXSize(()` / `GDALGetRasterYSize()` return `int`. And then `GDALRaster::dim()` returned `std::vector<int>` so when it gets back to R it has `storage.mode` of `integer` and R tries to do an integer operation as documented

`?Arithmetic`
>If either argument is complex the result will be complex, otherwise if one or both arguments are numeric, the result will be numeric.  If both arguments are of type integer, the type of the result of ‘/’ and ‘^’ is numeric and for the other operators it is integer (with overflow, which occurs at +/- (2^31 - 1), returned as ‘NA_integer_’ with a warning).

The PR mainly changes the return value of `GDALRaster::getRasterXSize()` / `GDALRaster::getRasterYSize()` to `double`, and `GDALRaster::dim()`  to `std::vector<double>` so that these become R `numeric` / R `double`, and avoid the need for explicit `as.numeric()` in R before multiplying large raster dims.

This PR also fixes some internal cases of static_cast when multiplying, changing, e.g., `static_cast<size_t>(out_xsize * out_ysize)` to `static_cast<size_t>(out_xsize) * out_ysize`, and also new `static_cast` to accommodate the new return types internally. 