### PR TITLE
GDALVector::info(): maintain fallback giving minimal info if GDAL < 3.7

### DIFF
--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -186,18 +186,28 @@ Rcpp::CharacterVector GDALVector::getFileList() const {
 }
 
 void GDALVector::info() const {
-  checkAccess_(GA_ReadOnly);
-  
-  if (m_is_sql) {
-    Rcpp::Rcout << ogrinfo(m_dsn, R_NilValue,
-                           Rcpp::CharacterVector::create("-so", "-nomd", "-sql", m_layer_name),
-                           m_open_options, true, false);
-  }
-  else {
-    Rcpp::Rcout << ogrinfo(m_dsn, Rcpp::wrap(m_layer_name),
-                           Rcpp::CharacterVector::create("-so", "-nomd"),
-                           m_open_options, true, false);
-  }
+    checkAccess_(GA_ReadOnly);
+
+    if (GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 7, 0)) {
+        if (m_is_sql) {
+            Rcpp::Rcout << ogrinfo(m_dsn, R_NilValue,
+                                   Rcpp::CharacterVector::create(
+                                        "-so", "-nomd", "-sql", m_layer_name),
+                                   m_open_options, true, false);
+        }
+        else {
+            Rcpp::Rcout << ogrinfo(m_dsn, Rcpp::wrap(m_layer_name),
+                                   Rcpp::CharacterVector::create(
+                                        "-so", "-nomd"),
+                                   m_open_options, true, false);
+        }
+    }
+    else {
+        // fallback for GDAL < 3.7
+        Rcpp::Rcout << "ogrinfo() requires GDAL >= 3.7" << std::endl;
+        Rcpp::Rcout << " DSN:   " << m_dsn << std::endl;
+        Rcpp::Rcout << " Layer: " << m_layer_name << std::endl;
+    }
 }
 
 std::string GDALVector::getDriverShortName() const {

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -1079,7 +1079,12 @@ test_that("info() prints output to the console", {
     lyr$close()
 
     lyr <- new(GDALVector, dsn, "SELECT * FROM mtbs_perims LIMIT 10")
-    expect_output(lyr$info(), "Feature Count: 10")
+    if (.gdal_version_num() >= 3070000) {
+        expect_output(lyr$info(), "Feature Count: 10")
+    } else {
+        # we only get the fallback minimal info
+        expect_output(lyr$info(), "Layer")
+    }
     lyr$close()
 
     # default layer first by index


### PR DESCRIPTION
avoids test failure if GDAL < 3.7, and still prints some minimal info when `ogrinfo()` is unavailable via API on GDAL < 3.7