### PR TITLE
`GDALVector::testCapability()`: add `FastGetArrowStream` and `FastWriteArrowBatch` in the returned list of layer capabilities

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -258,9 +258,12 @@
 #' `FALSE`. The returned list contains the following named elements:
 #' `RandomRead`, `SequentialWrite`, `RandomWrite`, `UpsertFeature`,
 #' `FastSpatialFilter`, `FastFeatureCount`, `FastGetExtent`,
-#' `FastSetNextByIndex`, `CreateField`, `CreateGeomField`, `DeleteField`,
-#' `ReorderFields`, `AlterFieldDefn`, `AlterGeomFieldDefn`, `DeleteFeature`,
-#' `StringsAsUTF8`, `Transactions`, `CurveGeometries`.
+#' `FastSetNextByIndex`, `FastGetArrowStream`, `FastWriteArrowBatch`,
+#' `CreateField`, `CreateGeomField`, `DeleteField`, `ReorderFields`,
+#' `AlterFieldDefn`, `AlterGeomFieldDefn`, `DeleteFeature`, `StringsAsUTF8`,
+#' `Transactions`, `CurveGeometries`.
+#' Note that some layer capabilities are GDAL version dependent and may not
+#' be listed if not supported by the GDAL version currently in use.
 #' (See the GDAL documentation for
 #' [`OGR_L_TestCapability()`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc).)
 #'
@@ -500,7 +503,7 @@
 #' calling this method (see above). An error is raised if an array stream
 #' on the layer cannot be obtained.
 #' Generally, only one ArrowArrayStream can be active at a time on a given
-#' layer (that is the last active one must be explicitly released before a next
+#' layer (i.e., the last active one must be explicitly released before a next
 #' one is asked). Changing attribute or spatial filters, ignored columns,
 #' modifying the schema or using `$resetReading()`/`$getNextFeature()` while
 #' using an ArrowArrayStream is strongly discouraged and may lead to unexpected
@@ -508,9 +511,18 @@
 #' layer should be called on the layer while an ArrowArrayStream on it is
 #' active. Methods available on the stream object are: `$get_schema()`,
 #' `$get_next()` and `$release()` (see Examples).
+#'
 #' The stream should be released once reading is complete. Calling the release
-#' method as soon as you can after consuming a stream is recommended in the
-#' nanoarrow documentation.
+#' method as soon as you can after consuming a stream is recommended by the
+#' \pkg{nanoarrow} documentation.
+#'
+#' See also the `$testCapability()` method above to check whether the format
+#' driver provides a specialized implementation (`FastGetArrowStream`), as
+#' opposed to the (slower) default implementation. Note however that
+#' specialized implementations may fallback to the default when attribute or
+#' spatlal filters are in use.
+#' (See the GDAL documentation for
+#' [`OGR_L_GetArrowStream()`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_GetArrowStream9OGRLayerHP16ArrowArrayStreamPPc).)
 #'
 #' \code{$releaseArrowStream()}\cr
 #' Releases the Arrow C stream returned by `$getArrowStream()` and clears the

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -275,9 +275,12 @@ read/write access. Returns a list of capabilities with values \code{TRUE} or
 \code{FALSE}. The returned list contains the following named elements:
 \code{RandomRead}, \code{SequentialWrite}, \code{RandomWrite}, \code{UpsertFeature},
 \code{FastSpatialFilter}, \code{FastFeatureCount}, \code{FastGetExtent},
-\code{FastSetNextByIndex}, \code{CreateField}, \code{CreateGeomField}, \code{DeleteField},
-\code{ReorderFields}, \code{AlterFieldDefn}, \code{AlterGeomFieldDefn}, \code{DeleteFeature},
-\code{StringsAsUTF8}, \code{Transactions}, \code{CurveGeometries}.
+\code{FastSetNextByIndex}, \code{FastGetArrowStream}, \code{FastWriteArrowBatch},
+\code{CreateField}, \code{CreateGeomField}, \code{DeleteField}, \code{ReorderFields},
+\code{AlterFieldDefn}, \code{AlterGeomFieldDefn}, \code{DeleteFeature}, \code{StringsAsUTF8},
+\code{Transactions}, \code{CurveGeometries}.
+Note that some layer capabilities are GDAL version dependent and may not
+be listed if not supported by the GDAL version currently in use.
 (See the GDAL documentation for
 \href{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_TestCapability9OGRLayerHPKc}{\code{OGR_L_TestCapability()}}.)
 
@@ -519,7 +522,7 @@ The writable field \verb{$arrowStreamOptions} can be used to set options before
 calling this method (see above). An error is raised if an array stream
 on the layer cannot be obtained.
 Generally, only one ArrowArrayStream can be active at a time on a given
-layer (that is the last active one must be explicitly released before a next
+layer (i.e., the last active one must be explicitly released before a next
 one is asked). Changing attribute or spatial filters, ignored columns,
 modifying the schema or using \verb{$resetReading()}/\verb{$getNextFeature()} while
 using an ArrowArrayStream is strongly discouraged and may lead to unexpected
@@ -527,9 +530,18 @@ results. As a rule of thumb, no OGRLayer methods that affect the state of a
 layer should be called on the layer while an ArrowArrayStream on it is
 active. Methods available on the stream object are: \verb{$get_schema()},
 \verb{$get_next()} and \verb{$release()} (see Examples).
+
 The stream should be released once reading is complete. Calling the release
-method as soon as you can after consuming a stream is recommended in the
-nanoarrow documentation.
+method as soon as you can after consuming a stream is recommended by the
+\pkg{nanoarrow} documentation.
+
+See also the \verb{$testCapability()} method above to check whether the format
+driver provides a specialized implementation (\code{FastGetArrowStream}), as
+opposed to the (slower) default implementation. Note however that
+specialized implementations may fallback to the default when attribute or
+spatlal filters are in use.
+(See the GDAL documentation for
+\href{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_GetArrowStream9OGRLayerHP16ArrowArrayStreamPPc}{\code{OGR_L_GetArrowStream()}}.)
 
 \code{$releaseArrowStream()}\cr
 Releases the Arrow C stream returned by \verb{$getArrowStream()} and clears the

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -300,6 +300,12 @@ Rcpp::List GDALVector::testCapability() const {
             OGR_L_TestCapability(m_hLayer, OLCFastGetExtent)),
         Rcpp::Named("FastSetNextByIndex") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCFastSetNextByIndex)),
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 6, 0)
+        Rcpp::Named("FastGetArrowStream") = static_cast<bool>(
+            OGR_L_TestCapability(m_hLayer, OLCFastGetArrowStream)),
+        Rcpp::Named("FastWriteArrowBatch") = static_cast<bool>(
+            OGR_L_TestCapability(m_hLayer, OLCFastWriteArrowBatch)),
+#endif
         Rcpp::Named("CreateField") = static_cast<bool>(
             OGR_L_TestCapability(m_hLayer, OLCCreateField)),
         Rcpp::Named("CreateGeomField") = static_cast<bool>(


### PR DESCRIPTION
GDAL >= 3.6

Also adds to the `GDALVector` class documentation for the `$getArrowStream()` method:

>See also the `$testCapability()` method above to check whether the format
driver provides a specialized implementation (`FastGetArrowStream`), as
opposed to the (slower) default implementation. Note however that
specialized implementations may fallback to the default when attribute or
spatlal filters are in use.
(See the GDAL documentation for [`OGR_L_GetArrowStream()`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_GetArrowStream9OGRLayerHP16ArrowArrayStreamPPc).)
