### PR TITLE
Add `GDALVector::batchCreateFeature()`: write a batch of features to a layer from data frame input 

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -568,33 +568,39 @@
 #'
 #' \code{$batchCreateFeature(feature_set)}\cr
 #' Batch version of `$createFeature()`. Creates and writes a batch of new
-#' features within the layer from data frame input given in the `feature_set`
-#' argument. Column names in the data frame must match field names of the
-#' layer and have compatible data types (see specifications above for the
-#' `$fetch()` method). Returns a logical vector of length equal to the number
-#' of input features (rows of the data frame), with `TRUE` indicating success
-#' for the feature at that row index, or `FALSE` if feature creation failed.
-#' It is recommended to use transactions for batch creation of features in a
-#' layer (see `$startTransaction()` below). This will generally have large
+#' features within the layer from input passed as a data frame in the
+#' `feature_set` argument. Column names in the data frame must match field
+#' names of the layer and have compatible data types. The specifications
+#' listed above under the `$fetch()` method generally apply to input data
+#' types for writing, but integers may be passed as 'numeric', and
+#' the 'integer64' class attribute is not strictly required on 'numeric'
+#' input if it is not needed for the data being passed to an OFTInteger64
+#' field.
+#' Returns a logical vector of length equal to the number of input features
+#' (rows of the data frame), with `TRUE` indicating success for the feature at
+#' that row index, or `FALSE` if writing the feature failed.
+#' It is recommended to use transactions when batch writing features to a
+#' layer (see `$startTransaction()` below). This will generally give large
 #' performance benefit with data sources that provide efficient transaction
-#' support (e.g., RDBMS-based sources such as GeoPackage and PostGIS). Also,
-#' the vector returned by `$batchCreateFeature()` can be checked, and the
-#' transaction optionally committed or rolled back based on results of the
+#' support (e.g., RDBMS-based sources such as GeoPackage and PostGIS). In
+#' addition, the return value of `$batchCreateFeature()` can be checked, and
+#' the transaction optionally committed or rolled back based on results of the
 #' operation across the full set of input features.
 #'
 #' \code{$upsertFeature(feature)}\cr
 #' Rewrites/replaces an existing feature or creates a new feature within the
 #' layer. This method will write a feature to the layer, based on the feature
 #' id within the input feature. The `feature` argument is a named list of
-#' fields and their values, potentially including a `$FID` element referencing
-#' an existing feature to rewrite. If the feature id doesn't exist a new
-#' feature will be written. Otherwise, the existing feature will be rewritten.
+#' fields and their values (might be one row of a data frame), potentially
+#' including a `$FID` element referencing an existing feature to rewrite. If
+#' the feature id doesn't exist a new feature will be written. Otherwise, the
+#' existing feature will be rewritten.
 #' The `UpsertFeature` element in the list returned by `$testCapability()` can
 #' be checked to determine if this layer supports upsert writing. See
 #' `$setFeature()` above for a description of how omitted fields in the passed
 #' `feature` are processed.
-#' Returns logical `TRUE` upon successful completion, or `FALSE` if upserting
-#' the feature did not succeed. Requires GDAL >= 3.6.
+#' Returns logical `TRUE` upon successful completion, or `FALSE` if upsert did
+#' not succeed. Requires GDAL >= 3.6.
 #'
 #' \code{$getLastWriteFID()}\cr
 #' Returns the FID of the last feature written (either newly created or updated

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -110,6 +110,7 @@
 #'
 #' lyr$setFeature(feature)
 #' lyr$createFeature(feature)
+#' lyr$batchCreateFeature(feature_set)
 #' lyr$upsertFeature(feature)
 #' lyr$getLastWriteFID()
 #' lyr$deleteFeature(fid)
@@ -219,7 +220,7 @@
 #' No return value, called for side effects.
 #'
 #' \code{$isOpen()}\cr
-#' Returns a `logical` scalar indicating whether the vector dataset is open.
+#' Returns a `logical` value indicating whether the vector dataset is open.
 #'
 #' \code{$getDsn()}\cr
 #' Returns a character string containing the `dsn` associated with this
@@ -430,7 +431,7 @@
 #'
 #' \code{$getFeature(fid)}\cr
 #' Returns a feature by its identifier. The value of `fid` must be a numeric
-#' scalar, optionally carrying the `bit64::integer64` class attribute.
+#' value, optionally carrying the `bit64::integer64` class attribute.
 #' Success or failure of this operation is unaffected by any spatial or
 #' attribute filters that may be in effect.
 #' The `RandomRead` element in the list returned by `$testCapability()` can
@@ -553,16 +554,33 @@
 #'
 #' \code{$createFeature(feature)}\cr
 #' Creates and writes a new feature within the layer. The `feature` argument is
-#' a named list of fields and their values.
+#' a named list of fields and their values (might be one row of a data frame).
 #' The passed feature is written to the layer as a new feature, rather than
-#' overwriting an existing one. If the feature has a `$FID` element other than
-#' `NA`, then the vector format driver may use that as the feature id of the
-#' new feature, but not necessarily. The FID of the last feature written
-#' to the layer may be obtained with the method `$getLastWriteFID()` (see
-#' below).
+#' overwriting an existing one. If the feature has a `$FID` element with other
+#' than `NA` (i.e., a numeric value, optionally carrying the `bit64::integer64`
+#' class attribute and assumed to be a whole number), then the format
+#' driver may use that as the feature id of the new feature, but not
+#' necessarily. The FID of the last feature written to the layer may be
+#' obtained with the method `$getLastWriteFID()` (see below).
 #' Returns logical `TRUE` upon successful completion, or `FALSE` if creating
 #' the feature did not succeed. To create a feature, but set it if it already
 #' exists see the `$upsertFeature()` method.
+#'
+#' \code{$batchCreateFeature(feature_set)}\cr
+#' Batch version of `$createFeature()`. Creates and writes a batch of new
+#' features within the layer from data frame input given in the `feature_set`
+#' argument. Column names in the data frame must match field names of the
+#' layer and have compatible data types (see specifications above for the
+#' `$fetch()` method). Returns a logical vector of length equal to the number
+#' of input features (rows of the data frame), with `TRUE` indicating success
+#' for the feature at that row index, or `FALSE` if feature creation failed.
+#' It is recommended to use transactions for batch creation of features in a
+#' layer (see `$startTransaction()` below). This will generally have large
+#' performance benefit with data sources that provide efficient transaction
+#' support (e.g., RDBMS-based sources such as GeoPackage and PostGIS). Also,
+#' the vector returned by `$batchCreateFeature()` can be checked, and the
+#' transaction optionally committed or rolled back based on results of the
+#' operation across the full set of input features.
 #'
 #' \code{$upsertFeature(feature)}\cr
 #' Rewrites/replaces an existing feature or creates a new feature within the
@@ -585,12 +603,12 @@
 #' formats. This is the case if a FID has not been assigned yet, and generally
 #' does not indicate an error (e.g., formats that do not store a persistent FID
 #' and assign FIDs upon a sequential read operation). The returned FID is a
-#' numeric scalar carrying the `bit64::integer64` class attribute.
+#' numeric value carrying the `bit64::integer64` class attribute.
 #'
 #' \code{$deleteFeature(fid)}\cr
 #' Deletes a feature from the layer. The feature with the indicated feature ID
 #' is deleted from the layer if supported by the format driver. The value of
-#' `fid` must be a numeric scalar, optionally carrying the `bit64::integer64`
+#' `fid` must be a numeric value, optionally carrying the `bit64::integer64`
 #' class attribute (should be a whole number, will be truncated).
 #' The `DeleteFeature` element in the list returned by `$testCapability()` can
 #' be checked to establish if this layer has delete feature capability. Returns

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -120,6 +120,7 @@ lyr$releaseArrowStream()
 
 lyr$setFeature(feature)
 lyr$createFeature(feature)
+lyr$batchCreateFeature(feature_set)
 lyr$upsertFeature(feature)
 lyr$getLastWriteFID()
 lyr$deleteFeature(fid)
@@ -236,7 +237,7 @@ not required to call \code{$close()} explicitly in this case.
 No return value, called for side effects.
 
 \code{$isOpen()}\cr
-Returns a \code{logical} scalar indicating whether the vector dataset is open.
+Returns a \code{logical} value indicating whether the vector dataset is open.
 
 \code{$getDsn()}\cr
 Returns a character string containing the \code{dsn} associated with this
@@ -447,7 +448,7 @@ the \code{FastSetNextByIndex} element in the list returned by the
 
 \code{$getFeature(fid)}\cr
 Returns a feature by its identifier. The value of \code{fid} must be a numeric
-scalar, optionally carrying the \code{bit64::integer64} class attribute.
+value, optionally carrying the \code{bit64::integer64} class attribute.
 Success or failure of this operation is unaffected by any spatial or
 attribute filters that may be in effect.
 The \code{RandomRead} element in the list returned by \verb{$testCapability()} can
@@ -574,16 +575,33 @@ feature, but create it if it doesn't exist see the \verb{$upsertFeature()} metho
 
 \code{$createFeature(feature)}\cr
 Creates and writes a new feature within the layer. The \code{feature} argument is
-a named list of fields and their values.
+a named list of fields and their values (might be one row of a data frame).
 The passed feature is written to the layer as a new feature, rather than
-overwriting an existing one. If the feature has a \verb{$FID} element other than
-\code{NA}, then the vector format driver may use that as the feature id of the
-new feature, but not necessarily. The FID of the last feature written
-to the layer may be obtained with the method \verb{$getLastWriteFID()} (see
-below).
+overwriting an existing one. If the feature has a \verb{$FID} element with other
+than \code{NA} (i.e., a numeric value, optionally carrying the \code{bit64::integer64}
+class attribute and assumed to be a whole number), then the format
+driver may use that as the feature id of the new feature, but not
+necessarily. The FID of the last feature written to the layer may be
+obtained with the method \verb{$getLastWriteFID()} (see below).
 Returns logical \code{TRUE} upon successful completion, or \code{FALSE} if creating
 the feature did not succeed. To create a feature, but set it if it already
 exists see the \verb{$upsertFeature()} method.
+
+\code{$batchCreateFeature(feature_set)}\cr
+Batch version of \verb{$createFeature()}. Creates and writes a batch of new
+features within the layer from data frame input given in the \code{feature_set}
+argument. Column names in the data frame must match field names of the
+layer and have compatible data types (see specifications above for the
+\verb{$fetch()} method). Returns a logical vector of length equal to the number
+of input features (rows of the data frame), with \code{TRUE} indicating success
+for the feature at that row index, or \code{FALSE} if feature creation failed.
+It is recommended to use transactions for batch creation of features in a
+layer (see \verb{$startTransaction()} below). This will generally have large
+performance benefit with data sources that provide efficient transaction
+support (e.g., RDBMS-based sources such as GeoPackage and PostGIS). Also,
+the vector returned by \verb{$batchCreateFeature()} can be checked, and the
+transaction optionally committed or rolled back based on results of the
+operation across the full set of input features.
 
 \code{$upsertFeature(feature)}\cr
 Rewrites/replaces an existing feature or creates a new feature within the
@@ -606,12 +624,12 @@ Note that OGRNullFID (\code{-1}) may be returned after writing a feature in some
 formats. This is the case if a FID has not been assigned yet, and generally
 does not indicate an error (e.g., formats that do not store a persistent FID
 and assign FIDs upon a sequential read operation). The returned FID is a
-numeric scalar carrying the \code{bit64::integer64} class attribute.
+numeric value carrying the \code{bit64::integer64} class attribute.
 
 \code{$deleteFeature(fid)}\cr
 Deletes a feature from the layer. The feature with the indicated feature ID
 is deleted from the layer if supported by the format driver. The value of
-\code{fid} must be a numeric scalar, optionally carrying the \code{bit64::integer64}
+\code{fid} must be a numeric value, optionally carrying the \code{bit64::integer64}
 class attribute (should be a whole number, will be truncated).
 The \code{DeleteFeature} element in the list returned by \verb{$testCapability()} can
 be checked to establish if this layer has delete feature capability. Returns

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -589,33 +589,39 @@ exists see the \verb{$upsertFeature()} method.
 
 \code{$batchCreateFeature(feature_set)}\cr
 Batch version of \verb{$createFeature()}. Creates and writes a batch of new
-features within the layer from data frame input given in the \code{feature_set}
-argument. Column names in the data frame must match field names of the
-layer and have compatible data types (see specifications above for the
-\verb{$fetch()} method). Returns a logical vector of length equal to the number
-of input features (rows of the data frame), with \code{TRUE} indicating success
-for the feature at that row index, or \code{FALSE} if feature creation failed.
-It is recommended to use transactions for batch creation of features in a
-layer (see \verb{$startTransaction()} below). This will generally have large
+features within the layer from input passed as a data frame in the
+\code{feature_set} argument. Column names in the data frame must match field
+names of the layer and have compatible data types. The specifications
+listed above under the \verb{$fetch()} method generally apply to input data
+types for writing, but integers may be passed as 'numeric', and
+the 'integer64' class attribute is not strictly required on 'numeric'
+input if it is not needed for the data being passed to an OFTInteger64
+field.
+Returns a logical vector of length equal to the number of input features
+(rows of the data frame), with \code{TRUE} indicating success for the feature at
+that row index, or \code{FALSE} if writing the feature failed.
+It is recommended to use transactions when batch writing features to a
+layer (see \verb{$startTransaction()} below). This will generally give large
 performance benefit with data sources that provide efficient transaction
-support (e.g., RDBMS-based sources such as GeoPackage and PostGIS). Also,
-the vector returned by \verb{$batchCreateFeature()} can be checked, and the
-transaction optionally committed or rolled back based on results of the
+support (e.g., RDBMS-based sources such as GeoPackage and PostGIS). In
+addition, the return value of \verb{$batchCreateFeature()} can be checked, and
+the transaction optionally committed or rolled back based on results of the
 operation across the full set of input features.
 
 \code{$upsertFeature(feature)}\cr
 Rewrites/replaces an existing feature or creates a new feature within the
 layer. This method will write a feature to the layer, based on the feature
 id within the input feature. The \code{feature} argument is a named list of
-fields and their values, potentially including a \verb{$FID} element referencing
-an existing feature to rewrite. If the feature id doesn't exist a new
-feature will be written. Otherwise, the existing feature will be rewritten.
+fields and their values (might be one row of a data frame), potentially
+including a \verb{$FID} element referencing an existing feature to rewrite. If
+the feature id doesn't exist a new feature will be written. Otherwise, the
+existing feature will be rewritten.
 The \code{UpsertFeature} element in the list returned by \verb{$testCapability()} can
 be checked to determine if this layer supports upsert writing. See
 \verb{$setFeature()} above for a description of how omitted fields in the passed
 \code{feature} are processed.
-Returns logical \code{TRUE} upon successful completion, or \code{FALSE} if upserting
-the feature did not succeed. Requires GDAL >= 3.6.
+Returns logical \code{TRUE} upon successful completion, or \code{FALSE} if upsert did
+not succeed. Requires GDAL >= 3.6.
 
 \code{$getLastWriteFID()}\cr
 Returns the FID of the last feature written (either newly created or updated

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -8,6 +8,7 @@
 #ifndef SRC_GDALVECTOR_H_
 #define SRC_GDALVECTOR_H_
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -27,6 +28,8 @@
     typedef void *OGRFeatureH;
 #endif
 
+// value for marking FID when used along with regular attribute field indexes
+const int FID_MARKER = -999;
 
 class GDALVector {
  public:
@@ -99,9 +102,10 @@ class GDALVector {
     SEXP getArrowStream();
     void releaseArrowStream();
 
-    bool setFeature(const Rcpp::RObject &feature);
-    bool createFeature(const Rcpp::RObject &feature);
-    bool upsertFeature(const Rcpp::RObject &feature);
+    bool setFeature(const Rcpp::List &feature);
+    bool createFeature(const Rcpp::List &feature);
+    Rcpp::LogicalVector batchCreateFeature(const Rcpp::DataFrame &feature_set);
+    bool upsertFeature(const Rcpp::List &feature);
     SEXP getLastWriteFID() const;
     bool deleteFeature(const Rcpp::RObject &fid);
     bool syncToDisk() const;
@@ -152,7 +156,7 @@ class GDALVector {
 
     void close();
 
-    void OGRFeatureFromList_dumpReadble(const Rcpp::RObject &feat) const;
+    void OGRFeatureFromList_dumpReadble(const Rcpp::List &feat) const;
 
     void show() const;
 
@@ -173,7 +177,13 @@ class GDALVector {
                               const Rcpp::CharacterVector &geom_col_srs,
                               const std::string &geom_format) const;
 
-    OGRFeatureH OGRFeatureFromList_(const Rcpp::RObject &feature) const;
+    std::vector<std::map<R_xlen_t, int>> validateFeatInput_(
+            const Rcpp::List &feature) const;
+
+    OGRFeatureH OGRFeatureFromList_(
+            const Rcpp::List &feature, R_xlen_t row_idx,
+            const std::map<R_xlen_t, int> &map_flds,
+            const std::map<R_xlen_t, int> &map_geom_flds) const;
 
 #if __has_include("ogr_recordbatch.h")
     int arrow_get_schema(struct ArrowSchema* out);


### PR DESCRIPTION
Also refactors the internal class method `GDALVector::OGRFeatureFromList_()`, separating out much of the initial input validation into `GDALVector::validateFeatInput_()`.

>`$batchCreateFeature(feature_set)`
Batch version of `$createFeature()`. Creates and writes a batch of new
features within the layer from input passed as a data frame in the
`feature_set` argument. Column names in the data frame must match field
names of the layer and have compatible data types. The specifications
listed above under the `$fetch()` method generally apply to input data
types for writing, but integers may be passed as 'numeric', and
the 'integer64' class attribute is not strictly required on 'numeric'
input if it is not needed for the data being passed to an OFTInteger64
field.
Returns a logical vector of length equal to the number of input features
(rows of the data frame), with `TRUE` indicating success for the feature at
that row index, or `FALSE` if writing the feature failed.
It is recommended to use transactions when batch writing features to a
layer (see `$startTransaction()` below). This will generally give large
performance benefit with data sources that provide efficient transaction
support (e.g., RDBMS-based sources such as GeoPackage and PostGIS). In
addition, the return value of `$batchCreateFeature()` can be checked, and
the transaction optionally committed or rolled back based on results of the
operation across the full set of input features.