### PR TITLE
Add the writable field `GDALVector::transactionsForce`, defaulted to `FALSE`

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -67,6 +67,7 @@
 #' lyr$quiet
 #' lyr$returnGeomAs
 #' lyr$wkbByteOrder
+#' lyr$transactionsForce
 #'
 #' ## Methods
 #' lyr$open(read_only)
@@ -116,7 +117,7 @@
 #' lyr$deleteFeature(fid)
 #' lyr$syncToDisk()
 #'
-#' lyr$startTransaction(force)
+#' lyr$startTransaction()
 #' lyr$commitTransaction()
 #' lyr$rollbackTransaction()
 #'
@@ -208,6 +209,14 @@
 #' Character string specifying the byte order for WKB geometries.
 #' Must be either `LSB` (Least Significant Byte first, the default) or
 #' `MSB` (Most Significant Byte first).
+#'
+#' \code{$transactionsForce}\cr
+#' A logical value, `FALSE` by default. Affects the behavior of attempted
+#' transactions on the layer (see the `$startTransaction()` method below).
+#' By default, only "efficient" transactions will be attempted. Some drivers
+#' may offer an emulation of transactions, but sometimes with significant
+#' overhead, in which case the user must explicitly allow for such an
+#' emulation by first setting `$transactionsForce <- TRUE`.
 #'
 #' ## Methods
 #'
@@ -630,14 +639,14 @@
 #' which will ensure all data is correctly flushed. Returns logical `TRUE` if
 #' no error occurs (even if nothing is done) or `FALSE` on error.
 #'
-#' \code{$startTransaction(force)}\cr
-#' Creates a transaction if supported by the vector data source. The `force`
-#' argument is a logical value. If `force = FALSE`, only "efficient"
-#' transactions will be attempted. Some drivers may offer an emulation of
-#' transactions, but sometimes with significant overhead, in which case the
-#' user must explicitly allow for such an emulation by setting `force =TRUE`.
-#' The function `ogr_ds_test_cap()` can be used to determine whether a vector
-#' data source supports efficient or emulated transactions.
+#' \code{$startTransaction()}\cr
+#' Creates a transaction if supported by the vector data source. By default,
+#' only "efficient" transactions will be attempted. See the writable field
+#' `$transactionsForce` above, which must be set to `TRUE` to allow for
+#' emulated transactions. These are supported by some drivers but with
+#' potentially significant overhead. The function `ogr_ds_test_cap()` can be
+#' used to determine whether a vector data source supports efficient or
+#' emulated transactions.
 #'
 #' All changes done after the start of the transaction are definitely applied
 #' in the data source if `$commitTransaction()` is called. They can be canceled

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -77,6 +77,7 @@ lyr$promoteToMulti
 lyr$quiet
 lyr$returnGeomAs
 lyr$wkbByteOrder
+lyr$transactionsForce
 
 ## Methods
 lyr$open(read_only)
@@ -126,7 +127,7 @@ lyr$getLastWriteFID()
 lyr$deleteFeature(fid)
 lyr$syncToDisk()
 
-lyr$startTransaction(force)
+lyr$startTransaction()
 lyr$commitTransaction()
 lyr$rollbackTransaction()
 
@@ -224,6 +225,14 @@ returned.
 Character string specifying the byte order for WKB geometries.
 Must be either \code{LSB} (Least Significant Byte first, the default) or
 \code{MSB} (Most Significant Byte first).
+
+\code{$transactionsForce}\cr
+A logical value, \code{FALSE} by default. Affects the behavior of attempted
+transactions on the layer (see the \verb{$startTransaction()} method below).
+By default, only "efficient" transactions will be attempted. Some drivers
+may offer an emulation of transactions, but sometimes with significant
+overhead, in which case the user must explicitly allow for such an
+emulation by first setting \verb{$transactionsForce <- TRUE}.
 }
 
 \subsection{Methods}{
@@ -651,14 +660,14 @@ In any event, you should always close any opened datasource with \verb{$close()}
 which will ensure all data is correctly flushed. Returns logical \code{TRUE} if
 no error occurs (even if nothing is done) or \code{FALSE} on error.
 
-\code{$startTransaction(force)}\cr
-Creates a transaction if supported by the vector data source. The \code{force}
-argument is a logical value. If \code{force = FALSE}, only "efficient"
-transactions will be attempted. Some drivers may offer an emulation of
-transactions, but sometimes with significant overhead, in which case the
-user must explicitly allow for such an emulation by setting \code{force =TRUE}.
-The function \code{ogr_ds_test_cap()} can be used to determine whether a vector
-data source supports efficient or emulated transactions.
+\code{$startTransaction()}\cr
+Creates a transaction if supported by the vector data source. By default,
+only "efficient" transactions will be attempted. See the writable field
+\verb{$transactionsForce} above, which must be set to \code{TRUE} to allow for
+emulated transactions. These are supported by some drivers but with
+potentially significant overhead. The function \code{ogr_ds_test_cap()} can be
+used to determine whether a vector data source supports efficient or
+emulated transactions.
 
 All changes done after the start of the transaction are definitely applied
 in the data source if \verb{$commitTransaction()} is called. They can be canceled

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -1925,8 +1925,10 @@ bool GDALVector::syncToDisk() const {
         return false;
 }
 
-bool GDALVector::startTransaction(bool force) {
+bool GDALVector::startTransaction() {
     checkAccess_(GA_ReadOnly);
+
+    bool force = this->transactionsForce;
 
     if (!force) {
         if (!GDALDatasetTestCapability(m_hDataset, ODsCTransactions)) {
@@ -1944,7 +1946,7 @@ bool GDALVector::startTransaction(bool force) {
 
              if (!quiet) {
                 Rcpp::Rcerr << "dataset does not have transaction capability"
-                        << std::endl;
+                    << std::endl;
              }
             return false;
         }
@@ -3809,6 +3811,7 @@ RCPP_MODULE(mod_GDALVector) {
     .field("quiet", &GDALVector::quiet)
     .field("returnGeomAs", &GDALVector::returnGeomAs)
     .field("wkbByteOrder", &GDALVector::wkbByteOrder)
+    .field("transactionsForce", &GDALVector::transactionsForce)
 
     // methods
     .const_method("getDsn", &GDALVector::getDsn,

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -58,6 +58,7 @@ class GDALVector {
     bool quiet {false};
     std::string returnGeomAs {"WKB"};
     std::string wkbByteOrder {"LSB"};
+    bool transactionsForce {false};
 
     // exposed methods
     void open(bool read_only);
@@ -110,7 +111,7 @@ class GDALVector {
     bool deleteFeature(const Rcpp::RObject &fid);
     bool syncToDisk() const;
 
-    bool startTransaction(bool force);
+    bool startTransaction();
     bool commitTransaction();
     bool rollbackTransaction();
 

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -371,11 +371,11 @@ test_that("delete feature works", {
     expect_false(lyr$commitTransaction())
     expect_false(lyr$rollbackTransaction())
 
-    expect_true(lyr$startTransaction(force = FALSE))
+    expect_true(lyr$startTransaction())
     lyr$deleteFeature(10)
     expect_true(lyr$commitTransaction())
     expect_equal(lyr$getFeatureCount(), num_feat - 1)
-    lyr$startTransaction(force = FALSE)
+    lyr$startTransaction()
     lyr$deleteFeature(11)
     expect_true(lyr$rollbackTransaction())
     expect_equal(lyr$getFeatureCount(), num_feat - 1)


### PR DESCRIPTION
 So that the `force` argument to `GDALVector::startTransaction()` can be removed, and the default of `FALSE` supports the typical use cases anyway. The user can now set, e.g., `lyr$transactionsForce <- TRUE`, on a per-object basis to enable emulated transactions to be attempted.

(A limitation of `RCPP_EXPOSED_CLASS` is that we cannot supply default argument values in class methods, so using writable fields on the object is generally a decent workaround for setting various options.)

>`$transactionsForce`
A logical value, `FALSE` by default. Affects the behavior of attempted
transactions on the layer (see the `$startTransaction()` method below).
By default, only "efficient" transactions will be attempted. Some drivers
may offer an emulation of transactions, but sometimes with significant
overhead, in which case the user must explicitly allow for such an
emulation by first setting `$transactionsForce <- TRUE`.