### PR TITLE
Add inline `// cppcheck-suppress unknownMacro` on calls to `RCPP_EXPOSED_CLASS()`

### DIFF
--- a/src/cmb_table.h
+++ b/src/cmb_table.h
@@ -66,6 +66,7 @@ class CmbTable {
     std::unordered_map<cmbKey, cmbData, cmbHasher> m_cmb_map {};
 };
 
+// cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(CmbTable)
 
 #endif  // SRC_CMB_TABLE_H_

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -229,6 +229,7 @@ class GDALRaster {
     GDALAccess m_eAccess {GA_ReadOnly};
 };
 
+// cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(GDALRaster)
 
 Rcpp::CharacterVector gdal_version();

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -219,6 +219,7 @@ class GDALVector {
 #endif
 };
 
+// cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(GDALVector)
 
 #endif  // SRC_GDALVECTOR_H_

--- a/src/running_stats.h
+++ b/src/running_stats.h
@@ -36,6 +36,7 @@ class RunningStats {
     double m_M2;
 };
 
+// cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(RunningStats)
 
 #endif  // SRC_RUNNING_STATS_H_

--- a/src/vsifile.h
+++ b/src/vsifile.h
@@ -67,6 +67,7 @@ class VSIFile {
     VSILFILE *m_fp;
 };
 
+// cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(VSIFile)
 
 #endif  // SRC_VSIFILE_H_


### PR DESCRIPTION
Adds inline `// cppcheck-suppress unknownMacro` comment lines above calls to `RCPP_EXPOSED_CLASS()` to avoid triggering `error: There is an unknown macro here somewhere. Configuration is required.`

Requires using the `--inline-suppr` command-line argument. Something like the following tends to give useful information from cppcheck on the gdalraster src directory:
```
cppcheck -I /usr/share/R/include -I /usr/include/gdal -i src/RcppExports.cpp --enable=style --error-exitcode=1 --inline-suppr src
```
