### PR TITLE
Account for possible `convertToLinear` and/or `promoteToMulti` in the GIS attributes attached to vector read outputs

### DIFF
--- a/src/geom_api.cpp
+++ b/src/geom_api.cpp
@@ -1898,3 +1898,28 @@ Rcpp::String bbox_to_wkt(const Rcpp::NumericVector &bbox,
 
     return g_wkb2wkt(g_create("POLYGON", poly_xy));
 }
+
+// helper function for geom type conversions
+OGRwkbGeometryType getTargetGeomType(OGRwkbGeometryType geom_type,
+                                     bool convert_to_linear,
+                                     bool promote_to_multi) {
+
+    OGRwkbGeometryType out_type = geom_type;
+
+    if (convert_to_linear || (convert_to_linear && promote_to_multi)) {
+        out_type = OGR_GT_GetLinear(out_type);
+    }
+
+    if (promote_to_multi || (convert_to_linear && promote_to_multi)) {
+        if (out_type == wkbTriangle || out_type == wkbTIN ||
+            out_type == wkbPolyhedralSurface) {
+
+            out_type = wkbMultiPolygon;
+        }
+        else if (!OGR_GT_IsSubClassOf(out_type, wkbGeometryCollection)) {
+            out_type = OGR_GT_GetCollection(out_type);
+        }
+    }
+
+    return out_type;
+}

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -126,4 +126,8 @@ Rcpp::NumericVector bbox_from_wkt(const std::string &wkt,
 Rcpp::String bbox_to_wkt(const Rcpp::NumericVector &bbox,
                          double extend_x, double extend_y);
 
+OGRwkbGeometryType getTargetGeomType(OGRwkbGeometryType geom_type,
+                                     bool convert_to_linear,
+                                     bool promote_to_multi);
+
 #endif  // SRC_GEOM_API_H_

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -312,6 +312,9 @@ test_that("read methods work correctly", {
     expect_false("POLYGON" %in% d[, geom_fld])
     expected_geoms <- rep("MULTIPOLYGON", lyr$getFeatureCount())
     expect_equal(d[, geom_fld], expected_geoms)
+    expect_equal(attr(d, "gis")$geom_col_type, "MULTIPOLYGON")
+    rm(d)
+
     # returnGeomAs
     lyr$returnGeomAs <- "WKB"
     f <- lyr$getFeature(1)
@@ -354,9 +357,11 @@ test_that("read methods work correctly", {
     dsn <- file.path("/vsizip", dsn, "multisurface.gpkg")
     lyr <- new(GDALVector, dsn, "multisurface_test")
     g1 <- lyr$fetch(-1)
+    expect_equal(attr(g1, "gis")$geom_col_type, "MULTISURFACE")
     expect_equal(g_name(g1$geom), rep("MULTISURFACE", 5))
     lyr$convertToLinear <- TRUE
     g2 <- lyr$fetch(-1)
+    expect_equal(attr(g2, "gis")$geom_col_type, "MULTIPOLYGON")
     expect_equal(g_name(g2$geom), rep("MULTIPOLYGON", 5))
     diff <- g_difference(g1$geom, g2$geom)
     expect_true(all(g_is_empty(diff)))


### PR DESCRIPTION
closes #643 