### PR TITLE
Doc: update GDALVector class description

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -9,17 +9,12 @@
 #' `GDALVector` provides an interface for accessing a vector layer in a GDAL
 #' dataset and calling methods on the underlying `OGRLayer` object.
 #' An object of class `GDALVector` persists an open connection to the dataset,
-#' and exposes methods for retrieving layer information, setting attribute and
-#' spatial filters, and reading/writing feature data.
-#' See \url{https://gdal.org/en/stable/api/index.html} for details of the GDAL
-#' Vector API.
-#'
-#' **Class `GDALVector` is currently under development**. An initial
-#' implementation supporting read access was added in gdalraster 1.11.1.9100.
-#' A working document with draft specifications is available at:\cr
-#' \url{https://usdaforestservice.github.io/gdalraster/articles/gdalvector-draft.html}\cr
-#' and discussion thread/status updates at:\cr
-#' \url{https://github.com/USDAForestService/gdalraster/issues/241}.
+#' and exposes methods that retrieve layer information, set attribute and
+#' spatial filters, read feature data via traversal by traditional row-based
+#' cursor including a direct analog of `DBI::dbFetch()`, read via
+#' column-oriented Arrow Array stream, write new features in a layer,
+#' edit/overwrite existing features, upsert, and delete. Supports transactions
+#' providing the option to rollback uncommitted data modifications.
 #'
 #' @param dsn Character string containing the data source name (DSN), usually a
 #' filename or database connection string.
@@ -721,7 +716,10 @@
 #' \url{https://gdal.org/en/stable/drivers/vector/index.html}
 #'
 #' GDAL-supported SQL dialects:\cr
-#' \url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html})
+#' \url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html}
+#'
+#' GDAL Vector API documentation:\cr
+#' \url{https://gdal.org/en/stable/api/index.html}
 #'
 #' @examples
 #' ## MTBS fire perimeters in Yellowstone National Park 1984-2022

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -43,17 +43,12 @@ lifetime of the object.
 \code{GDALVector} provides an interface for accessing a vector layer in a GDAL
 dataset and calling methods on the underlying \code{OGRLayer} object.
 An object of class \code{GDALVector} persists an open connection to the dataset,
-and exposes methods for retrieving layer information, setting attribute and
-spatial filters, and reading/writing feature data.
-See \url{https://gdal.org/en/stable/api/index.html} for details of the GDAL
-Vector API.
-
-\strong{Class \code{GDALVector} is currently under development}. An initial
-implementation supporting read access was added in gdalraster 1.11.1.9100.
-A working document with draft specifications is available at:\cr
-\url{https://usdaforestservice.github.io/gdalraster/articles/gdalvector-draft.html}\cr
-and discussion thread/status updates at:\cr
-\url{https://github.com/USDAForestService/gdalraster/issues/241}.
+and exposes methods that retrieve layer information, set attribute and
+spatial filters, read feature data via traversal by traditional row-based
+cursor including a direct analog of \code{DBI::dbFetch()}, read via
+column-oriented Arrow Array stream, write new features in a layer,
+edit/overwrite existing features, upsert, and delete. Supports transactions
+providing the option to rollback uncommitted data modifications.
 }
 \section{Usage (see Details)}{
 
@@ -986,5 +981,8 @@ GDAL vector format descriptions:\cr
 \url{https://gdal.org/en/stable/drivers/vector/index.html}
 
 GDAL-supported SQL dialects:\cr
-\url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html})
+\url{https://gdal.org/en/stable/user/ogr_sql_sqlite_dialect.html}
+
+GDAL Vector API documentation:\cr
+\url{https://gdal.org/en/stable/api/index.html}
 }


### PR DESCRIPTION
The full class documentation will undergo further editing, but this PR removes the note re: "currently under development... supporting read access", as it is now basically feature complete relative to the initial release target.

@title Class encapsulating a vector layer in a GDAL dataset

@description
`GDALVector` provides an interface for accessing a vector layer in a GDAL
dataset and calling methods on the underlying `OGRLayer` object.
An object of class `GDALVector` persists an open connection to the dataset,
and exposes methods that retrieve layer information, set attribute and
spatial filters, read feature data via traversal by traditional row-based
cursor including a direct analog of `DBI::dbFetch()`, read via
column-oriented Arrow Array stream, write new features in a layer,
edit/overwrite existing features, upsert, and delete. Supports transactions
providing the option to rollback uncommitted data modifications.