### PR TITLE
Doc: update descriptions for the C++ exposed classes and emphasize lack of named argument support

### DIFF
--- a/R/cmb_table.R
+++ b/R/cmb_table.R
@@ -10,15 +10,19 @@
 #' and the count of occurrences of each unique integer combination as the
 #' value. A unique ID is assigned to each unique combination of input values.
 #'
+#' `CmbTable` is a C++ class exposed directly to R (via `RCPP_EXPOSED_CLASS`).
+#' Methods of the class are accessed using the `$` operator. **Note that all
+#' arguments to class methods are required and must be given in the
+#' order documented.** Naming the arguments is optional but may be preferred
+#' for readability.
+#'
 #' @param keyLen The number of integer values comprising each combination.
 #' @param varNames Optional character vector of names for the variables in the
 #' combination.
 #' @returns An object of class `CmbTable`. Contains a hash table having a
-#' vector of `keyLen` integers as the key and the count of occurrences of
-#' each unique integer combination as the value, along with methods that
-#' operate on the table as described in Details.
-#' `CmbTable` is a C++ class exposed directly to R (via `RCPP_EXPOSED_CLASS`).
-#' Methods of the class are accessed in R using the `$` operator.
+#' vector of `keyLen` integers as the key, and the count of occurrences of each
+#' unique integer combination as the value. Class methods that operate on the
+#' hash table are described in Details.
 #'
 #' @section Usage (see Details):
 #' \preformatted{

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -11,6 +11,12 @@
 #' `GDALRasterBand` objects. See \url{https://gdal.org/en/stable/api/index.html} for
 #' details of the GDAL Raster API.
 #'
+#' `GDALRaster` is a C++ class exposed directly to R (via `RCPP_EXPOSED_CLASS`).
+#' Fields and methods of the class are accessed using the `$` operator. **Note
+#' that all arguments to class methods are required and must be given in the
+#' order documented.** Naming the arguments is optional but may be preferred
+#' for readability.
+#'
 #' @param filename Character string containing the file name of a raster
 #' dataset to open, as full path or relative to the current working directory.
 #' In some cases, `filename` may not refer to a local file system, but instead
@@ -24,11 +30,12 @@
 #' specifying dataset open options.
 #' @param shared Logical. `FALSE` to open the dataset without using shared
 #' mode. Default is `TRUE` (see Note).
-#' @returns An object of class `GDALRaster` which contains a pointer to the
-#' opened dataset, and methods that operate on the dataset as described in
-#' Details. `GDALRaster` is a C++ class exposed directly to R (via
-#' `RCPP_EXPOSED_CLASS`). Fields and methods of the class are accessed using
-#' the `$` operator. The read/write fields can be used for per-object settings.
+#' @returns An object of class `GDALRaster`, which contains a pointer to the
+#' opened dataset.
+#' Class methods that operate on the dataset are described in Details, along
+#' with a set of writable fields for per-object settings. Values may be
+#' assigned to the class fields as needed during the lifetime of the object
+#' (i.e., by regular `<-` or `=` assignment).
 #'
 #' @section Usage (see Details):
 #' \preformatted{
@@ -37,12 +44,12 @@
 #' ds <- new(GDALRaster, filename)
 #' # for update access:
 #' ds <- new(GDALRaster, filename, read_only = FALSE)
-#' # to use dataset open options:
+#' # to specify dataset open options:
 #' ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
-#' # to open without shared mode:
+#' # to open without using shared mode:
 #' new(GDALRaster, filename, read_only, open_options, shared = FALSE)
 #'
-#' ## Read/write fields
+#' ## Read/write fields (per-object settings)
 #' ds$infoOptions
 #' ds$quiet
 #' ds$readByteAsRaw

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -9,12 +9,19 @@
 #' `GDALVector` provides an interface for accessing a vector layer in a GDAL
 #' dataset and calling methods on the underlying `OGRLayer` object.
 #' An object of class `GDALVector` persists an open connection to the dataset,
-#' and exposes methods that retrieve layer information, set attribute and
-#' spatial filters, read feature data via traversal by traditional row-based
-#' cursor including a direct analog of `DBI::dbFetch()`, read via
-#' column-oriented Arrow Array stream, write new features in a layer,
-#' edit/overwrite existing features, upsert, and delete. Supports transactions
-#' providing the option to rollback uncommitted data modifications.
+#' and exposes methods to: retrieve layer information, set attribute and
+#' spatial filters, traverse and read feature data by traditional row-based
+#' cursor (including an analog of `DBI::dbFetch()`), read via column-oriented
+#' Arrow Array stream, write new features in a layer, edit/overwrite existing
+#' features, upsert, and delete features, and perform data manipulation within
+#' transactions.
+#'
+#' `GDALVector` is a C++ class exposed directly to R (via `RCPP_EXPOSED_CLASS`).
+#' Fields and methods of the class are accessed using the `$` operator. **Note
+#' that all arguments to class methods are required and must be given in the
+#' order documented.** Most `GDALVector` methods take zero or one argument, so
+#' this is usually not an issue. Class constructors are the main exception.
+#' Naming the arguments is optional but may be preferred for readability.
 #'
 #' @param dsn Character string containing the data source name (DSN), usually a
 #' filename or database connection string.
@@ -32,14 +39,12 @@
 #' be used, except for RDBMS drivers that will use their dedicated SQL engine,
 #' unless `"OGRSQL"` is explicitly passed as the dialect. The `"SQLITE"`
 #' dialect can also be used.
-#' @returns An object of class `GDALVector` which contains pointers to the
-#' opened layer and the dataset that owns it, and methods that operate on
-#' the layer as described in Details. `GDALVector` is a C++ class exposed
-#' directly to R (via `RCPP_EXPOSED_CLASS`). Fields and methods of the class
-#' are accessed using the `$` operator. Note that all arguments to exposed
-#' class methods are required (but do not have to be named). The read/write
-#' fields are per-object settings which can be changed as needed during the
-#' lifetime of the object.
+#' @returns An object of class `GDALVector`, which contains pointers to the
+#' opened layer and the GDAL dataset that owns it. Class methods that operate
+#' on the layer are described in Details, along with a set of writable fields
+#' for per-object settings. Values may be assigned to the class fields as
+#' needed during the lifetime of the object (i.e., by regular `<-` or `=`
+#' assignment).
 #'
 #' @section Usage (see Details):
 #' \preformatted{
@@ -537,7 +542,7 @@
 #' driver provides a specialized implementation (`FastGetArrowStream`), as
 #' opposed to the (slower) default implementation. Note however that
 #' specialized implementations may fallback to the default when attribute or
-#' spatlal filters are in use.
+#' spatial filters are in use.
 #' (See the GDAL documentation for
 #' [`OGR_L_GetArrowStream()`](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_GetArrowStream9OGRLayerHP16ArrowArrayStreamPPc).)
 #'

--- a/R/geom.R
+++ b/R/geom.R
@@ -308,7 +308,7 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
 #' `g_create()` creates a geometry object from the given point(s) and returns
 #' a raw vector of WKB (the default) or a character string of WKT. Currently
 #' supports creating Point, MultiPoint, LineString, Polygon, and
-#' GeomteryCollection.
+#' GeometryCollection.
 #' If multiple input points are given for creating Point type, then multiple
 #' geometries will be returned as a list of WKB raw vectors, or character
 #' vector of WKT strings (if `as_wkb = FALSE`). Otherwise, a single geometry

--- a/R/running_stats.R
+++ b/R/running_stats.R
@@ -13,17 +13,18 @@
 #' stored in memory, so this class can be used to compute statistics for very
 #' large data streams.
 #'
+#' `RunningStats` is a C++ class exposed directly to R (via
+#' `RCPP_EXPOSED_CLASS`). Methods of the class are accessed using the `$`
+#' operator.
+#'
 #' @param na_rm Logical scalar. `TRUE` to remove `NA` from the input data (the
 #' default) or `FALSE` to retain `NA`.
 #' @returns An object of class `RunningStats`. A `RunningStats` object
 #' maintains the current minimum, maximum, mean, variance, sum and count of
 #' values that have been read from the stream. It can be updated repeatedly
 #' with new values (i.e., chunks of data read from the input stream), but its
-#' memory footprint is negligible. Class methods for updating with new values
-#' and retrieving current values of statistics are described in Details.
-#' `RunningStats` is a C++ class exposed directly to R (via
-#' `RCPP_EXPOSED_CLASS`). Methods of the class are accessed in R using the `$`
-#' operator.
+#' memory footprint is negligible. Class methods for updating with new values,
+#' and retrieving the current values of statistics, are described in Details.
 #'
 #' @note
 #' The intended use is computing summary statistics for specific subsets or

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -29,6 +29,9 @@ SEEK_END <- "SEEK_END"
 #' virtualization of disk I/O so that non-file data sources can be made to
 #' appear as files.
 #'
+#' `VSIFile` is a C++ class exposed directly to R (via `RCPP_EXPOSED_CLASS`).
+#' Methods of the class are accessed using the `$` operator.
+#'
 #' @param filename Character string containing the filename to open. It may be
 #' a file in a regular local filesystem, or a filename with a GDAL /vsiPREFIX/
 #' (see \url{https://gdal.org/en/stable/user/virtual_file_systems.html}).
@@ -46,9 +49,7 @@ SEEK_END <- "SEEK_END"
 #' filesystem-dependent options (GDAL >= 3.3, see Details).
 #' @returns An object of class `VSIFile` which contains a pointer to a
 #' `VSIVirtualHandle`, and methods that operate on the file as described in
-#' Details. `VSIFile` is a C++ class exposed directly to R (via
-#' `RCPP_EXPOSED_CLASS`). Methods of the class are accessed using the
-#' `$` operator.
+#' Details.
 #'
 #' @section Usage (see Details):
 #' \preformatted{

--- a/man/CmbTable-class.Rd
+++ b/man/CmbTable-class.Rd
@@ -14,16 +14,20 @@ combination.}
 }
 \value{
 An object of class \code{CmbTable}. Contains a hash table having a
-vector of \code{keyLen} integers as the key and the count of occurrences of
-each unique integer combination as the value, along with methods that
-operate on the table as described in Details.
-\code{CmbTable} is a C++ class exposed directly to R (via \code{RCPP_EXPOSED_CLASS}).
-Methods of the class are accessed in R using the \code{$} operator.
+vector of \code{keyLen} integers as the key, and the count of occurrences of each
+unique integer combination as the value. Class methods that operate on the
+hash table are described in Details.
 }
 \description{
 \code{CmbTable} implements a hash table having a vector of integers as the key,
 and the count of occurrences of each unique integer combination as the
 value. A unique ID is assigned to each unique combination of input values.
+
+\code{CmbTable} is a C++ class exposed directly to R (via \code{RCPP_EXPOSED_CLASS}).
+Methods of the class are accessed using the \code{$} operator. \strong{Note that all
+arguments to class methods are required and must be given in the
+order documented.} Naming the arguments is optional but may be preferred
+for readability.
 }
 \section{Usage (see Details)}{
 

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -25,17 +25,24 @@ specifying dataset open options.}
 mode. Default is \code{TRUE} (see Note).}
 }
 \value{
-An object of class \code{GDALRaster} which contains a pointer to the
-opened dataset, and methods that operate on the dataset as described in
-Details. \code{GDALRaster} is a C++ class exposed directly to R (via
-\code{RCPP_EXPOSED_CLASS}). Fields and methods of the class are accessed using
-the \code{$} operator. The read/write fields can be used for per-object settings.
+An object of class \code{GDALRaster}, which contains a pointer to the
+opened dataset.
+Class methods that operate on the dataset are described in Details, along
+with a set of writable fields for per-object settings. Values may be
+assigned to the class fields as needed during the lifetime of the object
+(i.e., by regular \verb{<-} or \code{=} assignment).
 }
 \description{
 \code{GDALRaster} provides an interface for accessing a raster dataset via GDAL
 and calling methods on the underlying \code{GDALDataset}, \code{GDALDriver} and
 \code{GDALRasterBand} objects. See \url{https://gdal.org/en/stable/api/index.html} for
 details of the GDAL Raster API.
+
+\code{GDALRaster} is a C++ class exposed directly to R (via \code{RCPP_EXPOSED_CLASS}).
+Fields and methods of the class are accessed using the \code{$} operator. \strong{Note
+that all arguments to class methods are required and must be given in the
+order documented.} Naming the arguments is optional but may be preferred
+for readability.
 }
 \note{
 If a dataset object is opened with update access (\code{read_only = FALSE}), it
@@ -67,12 +74,12 @@ override the default resampling to one of \code{BILINEAR}, \code{CUBIC},
 ds <- new(GDALRaster, filename)
 # for update access:
 ds <- new(GDALRaster, filename, read_only = FALSE)
-# to use dataset open options:
+# to specify dataset open options:
 ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
-# to open without shared mode:
+# to open without using shared mode:
 new(GDALRaster, filename, read_only, open_options, shared = FALSE)
 
-## Read/write fields
+## Read/write fields (per-object settings)
 ds$infoOptions
 ds$quiet
 ds$readByteAsRaw

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -30,25 +30,30 @@ unless \code{"OGRSQL"} is explicitly passed as the dialect. The \code{"SQLITE"}
 dialect can also be used.}
 }
 \value{
-An object of class \code{GDALVector} which contains pointers to the
-opened layer and the dataset that owns it, and methods that operate on
-the layer as described in Details. \code{GDALVector} is a C++ class exposed
-directly to R (via \code{RCPP_EXPOSED_CLASS}). Fields and methods of the class
-are accessed using the \code{$} operator. Note that all arguments to exposed
-class methods are required (but do not have to be named). The read/write
-fields are per-object settings which can be changed as needed during the
-lifetime of the object.
+An object of class \code{GDALVector}, which contains pointers to the
+opened layer and the GDAL dataset that owns it. Class methods that operate
+on the layer are described in Details, along with a set of writable fields
+for per-object settings. Values may be assigned to the class fields as
+needed during the lifetime of the object (i.e., by regular \verb{<-} or \code{=}
+assignment).
 }
 \description{
 \code{GDALVector} provides an interface for accessing a vector layer in a GDAL
 dataset and calling methods on the underlying \code{OGRLayer} object.
 An object of class \code{GDALVector} persists an open connection to the dataset,
-and exposes methods that retrieve layer information, set attribute and
-spatial filters, read feature data via traversal by traditional row-based
-cursor including a direct analog of \code{DBI::dbFetch()}, read via
-column-oriented Arrow Array stream, write new features in a layer,
-edit/overwrite existing features, upsert, and delete. Supports transactions
-providing the option to rollback uncommitted data modifications.
+and exposes methods to: retrieve layer information, set attribute and
+spatial filters, traverse and read feature data by traditional row-based
+cursor (including an analog of \code{DBI::dbFetch()}), read via column-oriented
+Arrow Array stream, write new features in a layer, edit/overwrite existing
+features, upsert, and delete features, and perform data manipulation within
+transactions.
+
+\code{GDALVector} is a C++ class exposed directly to R (via \code{RCPP_EXPOSED_CLASS}).
+Fields and methods of the class are accessed using the \code{$} operator. \strong{Note
+that all arguments to class methods are required and must be given in the
+order documented.} Most \code{GDALVector} methods take zero or one argument, so
+this is usually not an issue. Class constructors are the main exception.
+Naming the arguments is optional but may be preferred for readability.
 }
 \section{Usage (see Details)}{
 
@@ -558,7 +563,7 @@ See also the \verb{$testCapability()} method above to check whether the format
 driver provides a specialized implementation (\code{FastGetArrowStream}), as
 opposed to the (slower) default implementation. Note however that
 specialized implementations may fallback to the default when attribute or
-spatlal filters are in use.
+spatial filters are in use.
 (See the GDAL documentation for
 \href{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_GetArrowStream9OGRLayerHP16ArrowArrayStreamPPc}{\code{OGR_L_GetArrowStream()}}.)
 

--- a/man/RunningStats-class.Rd
+++ b/man/RunningStats-class.Rd
@@ -15,11 +15,8 @@ An object of class \code{RunningStats}. A \code{RunningStats} object
 maintains the current minimum, maximum, mean, variance, sum and count of
 values that have been read from the stream. It can be updated repeatedly
 with new values (i.e., chunks of data read from the input stream), but its
-memory footprint is negligible. Class methods for updating with new values
-and retrieving current values of statistics are described in Details.
-\code{RunningStats} is a C++ class exposed directly to R (via
-\code{RCPP_EXPOSED_CLASS}). Methods of the class are accessed in R using the \code{$}
-operator.
+memory footprint is negligible. Class methods for updating with new values,
+and retrieving the current values of statistics, are described in Details.
 }
 \description{
 \code{RunningStats} computes summary statistics on a data stream efficiently.
@@ -28,6 +25,10 @@ Mean and variance are calculated with Welford's online algorithm
 The min, max, sum and count are also tracked. The input data values are not
 stored in memory, so this class can be used to compute statistics for very
 large data streams.
+
+\code{RunningStats} is a C++ class exposed directly to R (via
+\code{RCPP_EXPOSED_CLASS}). Methods of the class are accessed using the \code{$}
+operator.
 }
 \note{
 The intended use is computing summary statistics for specific subsets or

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -28,9 +28,7 @@ filesystem-dependent options (GDAL >= 3.3, see Details).}
 \value{
 An object of class \code{VSIFile} which contains a pointer to a
 \code{VSIVirtualHandle}, and methods that operate on the file as described in
-Details. \code{VSIFile} is a C++ class exposed directly to R (via
-\code{RCPP_EXPOSED_CLASS}). Methods of the class are accessed using the
-\code{$} operator.
+Details.
 }
 \description{
 \code{VSIFile} provides bindings to the GDAL VSIVirtualHandle API. Encapsulates a
@@ -41,6 +39,9 @@ cloud storage services, Zip/GZip/7z/RAR, and in-memory files.
 It provides analogs of several Standard C file I/O functions, allowing
 virtualization of disk I/O so that non-file data sources can be made to
 appear as files.
+
+\code{VSIFile} is a C++ class exposed directly to R (via \code{RCPP_EXPOSED_CLASS}).
+Methods of the class are accessed using the \code{$} operator.
 }
 \note{
 File offsets are given as R \code{numeric} (i.e., \code{double} type), optionally

--- a/man/g_factory.Rd
+++ b/man/g_factory.Rd
@@ -63,7 +63,7 @@ These functions use the GEOS library via GDAL headers.
 \code{g_create()} creates a geometry object from the given point(s) and returns
 a raw vector of WKB (the default) or a character string of WKT. Currently
 supports creating Point, MultiPoint, LineString, Polygon, and
-GeomteryCollection.
+GeometryCollection.
 If multiple input points are given for creating Point type, then multiple
 geometries will be returned as a list of WKB raw vectors, or character
 vector of WKT strings (if \code{as_wkb = FALSE}). Otherwise, a single geometry


### PR DESCRIPTION
Restructures so that some information is moved up from the constructor return value section into the main class description section. Mainly to emphasize that named arguments are not supported in the C++ class methods, i.e., the Rcpp exposed classes are pretty close to C++ so document that behavior more emphatically, e.g.,

>`GDALRaster` is a C++ class exposed directly to R (via `RCPP_EXPOSED_CLASS`). Fields and methods of the class are accessed using the `$` operator. **Note that all arguments to class methods are required and must be given in the order documented.** Naming the arguments is optional but may be preferred for readability.

Partially addresses #648.