### PR TITLE
`ogr_proc()`: rename argument `return_lyr_obj` to `return_obj`

### DIFF
--- a/R/ogr_proc.R
+++ b/R/ogr_proc.R
@@ -124,22 +124,22 @@
 #' @param mode_opt Optional character vector of `"NAME=VALUE"` pairs that
 #' specify processing options. Available options depend on the value of `mode`
 #' (see Details).
-#' @param overwrite Logical scalar. `TRUE` to overwrite the output layer if it
+#' @param overwrite Logical value. `TRUE` to overwrite the output layer if it
 #' already exists. Defaults to `FALSE`.
-#' @param quiet Logical scalar. If `TRUE`, a progress bar will not be
+#' @param quiet Logical value. If `TRUE`, a progress bar will not be
 #' displayed. Defaults to `FALSE`.
-#' @param return_lyr_obj Logical scalar. If `TRUE` (the default), an object of
+#' @param return_obj Logical value. If `TRUE` (the default), an object of
 #' class [`GDALVector`][GDALVector] opened on the output layer will be returned,
-#' otherwise returns a logical value.
+#' otherwise the function returns a logical value.
 #'
 #' @returns Upon successful completion, an object of class
 #' [`GDALVector`][GDALVector] is returned by default (if
-#' `return_lyr_obj = TRUE`), or logical `TRUE` is returned (invisibly) if
-#' `return_lyr_obj = FALSE`.
+#' `return_obj = TRUE`), or logical `TRUE` is returned (invisibly) if
+#' `return_obj = FALSE`.
 #' Logical `FALSE` is returned (invisibly) if an error occurs during processing.
 #'
 #' @note
-#' The first geometry field is always used.
+#' The first geometry field on a layer is always used.
 #'
 #' For best performance use the minimum amount of features in the method layer
 #' and copy into a memory layer.
@@ -161,9 +161,8 @@
 #' lyr1$getFeatureCount()
 #'
 #' # second layer for the 1988 North Fork fire perimeter
-#' sql <- paste0("SELECT incid_name, ig_year, geom ",
-#'               "FROM mtbs_perims ",
-#'               "WHERE incid_name = 'NORTH FORK'")
+#' sql <- "SELECT incid_name, ig_year, geom FROM mtbs_perims
+#'         WHERE incid_name = 'NORTH FORK'"
 #' lyr2 <- new(GDALVector, dsn, sql)
 #' lyr2$getFeatureCount()
 #'
@@ -182,7 +181,6 @@
 #'                     mode_opt = opt)
 #'
 #' # the output layer has attributes of both the input and method layers
-#' lyr_out$returnGeomAs <- "TYPE_NAME"
 #' d <- lyr_out$fetch(-1)
 #' print(d)
 #'
@@ -204,7 +202,7 @@ ogr_proc <- function(mode,
                      mode_opt = NULL,
                      overwrite = FALSE,
                      quiet = FALSE,
-                     return_lyr_obj = TRUE) {
+                     return_obj = TRUE) {
 
     if (is(input_lyr, "Rcpp_GDALVector")) {
         if (!input_lyr$isOpen()) {
@@ -344,7 +342,7 @@ ogr_proc <- function(mode,
         stop("invalid 'mode'", call. = FALSE)
     }
 
-    if (ret && return_lyr_obj) {
+    if (ret && return_obj) {
         out_lyr$open(read_only = TRUE)
         return(out_lyr)
     } else {

--- a/man/ogr_proc.Rd
+++ b/man/ogr_proc.Rd
@@ -17,7 +17,7 @@ ogr_proc(
   mode_opt = NULL,
   overwrite = FALSE,
   quiet = FALSE,
-  return_lyr_obj = TRUE
+  return_obj = TRUE
 )
 }
 \arguments{
@@ -59,21 +59,21 @@ for \code{out_layer} (\code{"NAME=VALUE"} pairs).}
 specify processing options. Available options depend on the value of \code{mode}
 (see Details).}
 
-\item{overwrite}{Logical scalar. \code{TRUE} to overwrite the output layer if it
+\item{overwrite}{Logical value. \code{TRUE} to overwrite the output layer if it
 already exists. Defaults to \code{FALSE}.}
 
-\item{quiet}{Logical scalar. If \code{TRUE}, a progress bar will not be
+\item{quiet}{Logical value. If \code{TRUE}, a progress bar will not be
 displayed. Defaults to \code{FALSE}.}
 
-\item{return_lyr_obj}{Logical scalar. If \code{TRUE} (the default), an object of
+\item{return_obj}{Logical value. If \code{TRUE} (the default), an object of
 class \code{\link{GDALVector}} opened on the output layer will be returned,
-otherwise returns a logical value.}
+otherwise the function returns a logical value.}
 }
 \value{
 Upon successful completion, an object of class
 \code{\link{GDALVector}} is returned by default (if
-\code{return_lyr_obj = TRUE}), or logical \code{TRUE} is returned (invisibly) if
-\code{return_lyr_obj = FALSE}.
+\code{return_obj = TRUE}), or logical \code{TRUE} is returned (invisibly) if
+\code{return_obj = FALSE}.
 Logical \code{FALSE} is returned (invisibly) if an error occurs during processing.
 }
 \description{
@@ -174,7 +174,7 @@ on-the-fly reprojection is done. When an output layer is created it will have
 the SRS of \code{input_lyr}.
 }
 \note{
-The first geometry field is always used.
+The first geometry field on a layer is always used.
 
 For best performance use the minimum amount of features in the method layer
 and copy into a memory layer.
@@ -189,9 +189,8 @@ lyr1$setAttributeFilter("ig_year >= 2000")
 lyr1$getFeatureCount()
 
 # second layer for the 1988 North Fork fire perimeter
-sql <- paste0("SELECT incid_name, ig_year, geom ",
-              "FROM mtbs_perims ",
-              "WHERE incid_name = 'NORTH FORK'")
+sql <- "SELECT incid_name, ig_year, geom FROM mtbs_perims
+        WHERE incid_name = 'NORTH FORK'"
 lyr2 <- new(GDALVector, dsn, sql)
 lyr2$getFeatureCount()
 
@@ -210,7 +209,6 @@ lyr_out <- ogr_proc(mode = "Intersection",
                     mode_opt = opt)
 
 # the output layer has attributes of both the input and method layers
-lyr_out$returnGeomAs <- "TYPE_NAME"
 d <- lyr_out$fetch(-1)
 print(d)
 


### PR DESCRIPTION
To be consistent with other functions that optionally return a `GDALVector` or `GDALRaster` object.

`ogr_proc()` is not in a release version yet so not designated as a breaking change.