### PR TITLE
`plot_raster()`: ensure `out_xsize` / `out_ysize` are whole numbers in the internal call to `read_ds()`

### DIFF
--- a/R/display.R
+++ b/R/display.R
@@ -340,12 +340,12 @@ plot_raster <- function(data, xsize=NULL, ysize=NULL, nbands=NULL,
         if (is.null(xsize))
             xsize <- out_xsize <- dm[1]
         else
-            out_xsize <- xsize
+            out_xsize <- trunc(xsize)
 
         if (is.null(ysize))
             ysize <- out_ysize <- dm[2]
         else
-            out_ysize <- ysize
+            out_ysize <- trunc(ysize)
 
         if ((out_xsize*out_ysize) > max_pixels)
             stop("'xsize * ysize' exceeds 'max_pixels'", call.=FALSE)


### PR DESCRIPTION
Avoids possible:
```r
#> Warning in r[i_begin:i_end] <- ds$read(b, xoff, yoff, xsize, ysize, out_xsize,
#> : number of items to replace is not a multiple of replacement length
```

in case the input dimensions for reading the raster were calculated, e.g., given to `plot_raster()` as something like `xsize = dm[1] / 2`, and we get a fractional value. Coerce to whole number by truncation.