### PR TITLE
`rasterize()`: support passing a `GDALRaster` object for in-place updating

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -869,8 +869,8 @@ ogrinfo <- function(dsn, layers = NULL, cl_arg = as.character( c("-so", "-nomd")
 #'
 #' Called from and documented in R/gdalraster_proc.R
 #' @noRd
-.rasterize <- function(src_dsn, dst_filename, cl_arg, quiet = FALSE) {
-    .Call(`_gdalraster_rasterize`, src_dsn, dst_filename, cl_arg, quiet)
+.rasterize <- function(src_dsn, dst_filename, dst_dataset, cl_arg, quiet = FALSE) {
+    .Call(`_gdalraster_rasterize`, src_dsn, dst_filename, dst_dataset, cl_arg, quiet)
 }
 
 #' Remove small raster polygons

--- a/man/rasterize.Rd
+++ b/man/rasterize.Rd
@@ -31,9 +31,12 @@ rasterize(
 \item{src_dsn}{Data source name for the input vector layer (filename or
 connection string).}
 
-\item{dstfile}{Filename of the output raster. Must support update mode
-access. This file will be created (or overwritten if it already exists -
-see Note).}
+\item{dstfile}{Either a character string giving the filename of the
+output raster dataset, or an object of class \code{GDALRaster} for the output.
+Must support update mode access. If given as a filename, this file will
+be created (or overwritten if it already exists - see Note).
+If given as a \code{GDALRaster} object for an existing dataset, then the affected
+pixels are updated in-place (object must be open with write access).}
 
 \item{band}{Numeric vector. The band(s) to burn values into (for existing
 \code{dstfile}). The default is to burn into band 1. Not used when creating a
@@ -113,11 +116,16 @@ This function is a wrapper for the \command{gdal_rasterize} command-line
 utility (\url{https://gdal.org/en/stable/programs/gdal_rasterize.html}).
 }
 \note{
-The function creates a new target raster when any of the \code{fmt}, \code{dstnodata},
-\code{init}, \code{co}, \code{te}, \code{tr}, \code{tap}, \code{ts}, or \code{dtName} arguments are used. The
-resolution or size must be specified using the \code{tr} or \code{ts} argument for all
-new rasters. The target raster will be overwritten if it already exists and
-any of these creation-related options are used.
+\code{rasterize()} creates a new target raster when \code{dstfile} is given as a
+filename (character string). In that case, some combination of the \code{fmt},
+\code{dstnodata}, \code{init}, \code{co}, \code{te}, \code{tr}, \code{tap}, \code{ts}, and \code{dtName} arguments
+will be used. The resolution or size must be specified using either the \code{tr}
+or \code{ts} argument for all new rasters. The target raster will be overwritten
+if it already exists and any of these creation-related options are used.
+
+To update an existing raster in-place, an object of class \code{GDALRaster} may
+be given for the \code{dstfile} argument. The \code{GDALRaster} object should be open
+for write access.
 }
 \examples{
 # MTBS fire perimeters for Yellowstone National Park 1984-2022

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -531,16 +531,17 @@ BEGIN_RCPP
 END_RCPP
 }
 // rasterize
-bool rasterize(const std::string& src_dsn, const std::string& dst_filename, const Rcpp::CharacterVector& cl_arg, bool quiet);
-RcppExport SEXP _gdalraster_rasterize(SEXP src_dsnSEXP, SEXP dst_filenameSEXP, SEXP cl_argSEXP, SEXP quietSEXP) {
+bool rasterize(const std::string& src_dsn, const std::string& dst_filename, Rcpp::List dst_dataset, const Rcpp::CharacterVector& cl_arg, bool quiet);
+RcppExport SEXP _gdalraster_rasterize(SEXP src_dsnSEXP, SEXP dst_filenameSEXP, SEXP dst_datasetSEXP, SEXP cl_argSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type src_dsn(src_dsnSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type dst_filename(dst_filenameSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type dst_dataset(dst_datasetSEXP);
     Rcpp::traits::input_parameter< const Rcpp::CharacterVector& >::type cl_arg(cl_argSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
-    rcpp_result_gen = Rcpp::wrap(rasterize(src_dsn, dst_filename, cl_arg, quiet));
+    rcpp_result_gen = Rcpp::wrap(rasterize(src_dsn, dst_filename, dst_dataset, cl_arg, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1980,7 +1981,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_ogr2ogr", (DL_FUNC) &_gdalraster_ogr2ogr, 5},
     {"_gdalraster_ogrinfo", (DL_FUNC) &_gdalraster_ogrinfo, 6},
     {"_gdalraster_polygonize", (DL_FUNC) &_gdalraster_polygonize, 9},
-    {"_gdalraster_rasterize", (DL_FUNC) &_gdalraster_rasterize, 4},
+    {"_gdalraster_rasterize", (DL_FUNC) &_gdalraster_rasterize, 5},
     {"_gdalraster_sieveFilter", (DL_FUNC) &_gdalraster_sieveFilter, 10},
     {"_gdalraster_translate", (DL_FUNC) &_gdalraster_translate, 4},
     {"_gdalraster_warp", (DL_FUNC) &_gdalraster_warp, 6},

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -377,7 +377,8 @@ bool polygonize(const Rcpp::CharacterVector &src_filename, int src_band,
                 int connectedness, bool quiet);
 
 bool rasterize(const std::string &src_dsn, const std::string &dst_filename,
-               const Rcpp::CharacterVector &cl_arg, bool quiet);
+               Rcpp::List dst_dataset, const Rcpp::CharacterVector &cl_arg,
+               bool quiet);
 
 bool sieveFilter(const Rcpp::CharacterVector &src_filename, int src_band,
                  const Rcpp::CharacterVector &dst_filename, int dst_band,


### PR DESCRIPTION
`rasterize()` previously supported only creation of a new raster dataset for the output. This PR adds support for passing an object of class `GDALRaster` for an existing dataset to be used as the output target, in which case the affected pixels are updated in-place.

>@param `dstfile` Either a character string giving the filename of the
output raster dataset, or an object of class `GDALRaster` for the output.
Must support update mode access. If given as a filename, this file will
be created (or overwritten if it already exists - see Note).
If given as a `GDALRaster` object for an existing dataset, then the affected
pixels are updated in-place (object must be open with write access).