### PR TITLE
Add `GDALRaster::get_block_indexing()`: helper method to get indexing values for the block layout

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -518,6 +518,13 @@ inv_geotransform <- function(gt) {
     .Call(`_gdalraster_get_pixel_line_ds`, xy, ds)
 }
 
+#' Returns bbox geospatial x,y coordinates (xmin, ymin, xmax, ymax) from
+#' inpouts of geotransform vector and the grid pixel/line extent
+#' @noRd
+.bbox_grid_to_geo <- function(gt, grid_xmin, grid_xmax, grid_ymin, grid_ymax) {
+    .Call(`_gdalraster_bbox_grid_to_geo_`, gt, grid_xmin, grid_xmax, grid_ymin, grid_ymax)
+}
+
 #' Flip raster data vertically
 #' @noRd
 .flip_vertical <- function(v, xsize, ysize, nbands) {

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -85,6 +85,7 @@
 #' ds$dim()
 #' ds$apply_geotransform(col_row)
 #' ds$get_pixel_line(xy)
+#' ds$get_block_indexing(band)
 #'
 #' ds$getDescription(band)
 #' ds$setDescription(band, desc)
@@ -328,6 +329,20 @@
 #' See the stand-alone function of the same name ([get_pixel_line()]) for more
 #' info and examples.
 #'
+#' \code{$get_block_indexing(band)}\cr
+#' Helper method returning a numeric matrix with named columns: `xblockoff`,
+#' `yblockoff`, `xoff`, `yoff`, `xsize`, `ysize`, `xmin`, `xmax`, `ymin`,
+#' `ymax`. For the meanings of these names, refer to the following class
+#' methods below: `$getBlockSize()`, `$getActualBlockSize` and `$read()`.
+#' All offsets are zero-based. The columns `xmin`, `xmax`, `ymin` and
+#' `ymax` give the extent of each block in geospatial coordinates.
+#' This method provides indexing values for the block layout of the given
+#' `band` number. The returned matrix has number of rows equal to the number
+#' of blocks comprising the band, with blocks ordered left to right, top
+#' to bottom. The `xoff`/`yoff` values are pixel offsets to the start of a
+#' block. The `xsize`/`ysize` values give the actual block sizes accounting
+#' for potentially incomplete blocks along the right and bottom edges.
+#'
 #' \code{$getDescription(band)}\cr
 #' Returns a string containing the description for \code{band}. An empty
 #' string is returned if no description is set for the band.
@@ -356,7 +371,7 @@
 #' Returns an integer vector of length two (xvalid, yvalid) containing the
 #' actual block size for a given block offset in \code{band}. Handles partial
 #' blocks at the edges of the raster and returns the true number of pixels.
-#' `xblockoff` is an integer scalar, the horizontal block offset for which to
+#' `xblockoff` is an integer value, the horizontal block offset for which to
 #' calculate the number of valid pixels, with zero indicating the left most
 #' block, 1 the next block, etc. `yblockoff` is likewise the vertical block
 #' offset, with zero indicating the top most block, 1 the next block, etc.

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -115,6 +115,7 @@ ds$res()
 ds$dim()
 ds$apply_geotransform(col_row)
 ds$get_pixel_line(xy)
+ds$get_block_indexing(band)
 
 ds$getDescription(band)
 ds$setDescription(band, desc)
@@ -363,6 +364,20 @@ coerced to numeric matrix). Returns an integer matrix of raster pixel/line.
 See the stand-alone function of the same name (\code{\link[=get_pixel_line]{get_pixel_line()}}) for more
 info and examples.
 
+\code{$get_block_indexing(band)}\cr
+Helper method returning a numeric matrix with named columns: \code{xblockoff},
+\code{yblockoff}, \code{xoff}, \code{yoff}, \code{xsize}, \code{ysize}, \code{xmin}, \code{xmax}, \code{ymin},
+\code{ymax}. For the meanings of these names, refer to the following class
+methods below: \verb{$getBlockSize()}, \verb{$getActualBlockSize} and \verb{$read()}.
+All offsets are zero-based. The columns \code{xmin}, \code{xmax}, \code{ymin} and
+\code{ymax} give the extent of each block in geospatial coordinates.
+This method provides indexing values for the block layout of the given
+\code{band} number. The returned matrix has number of rows equal to the number
+of blocks comprising the band, with blocks ordered left to right, top
+to bottom. The \code{xoff}/\code{yoff} values are pixel offsets to the start of a
+block. The \code{xsize}/\code{ysize} values give the actual block sizes accounting
+for potentially incomplete blocks along the right and bottom edges.
+
 \code{$getDescription(band)}\cr
 Returns a string containing the description for \code{band}. An empty
 string is returned if no description is set for the band.
@@ -391,7 +406,7 @@ incomplete.
 Returns an integer vector of length two (xvalid, yvalid) containing the
 actual block size for a given block offset in \code{band}. Handles partial
 blocks at the edges of the raster and returns the true number of pixels.
-\code{xblockoff} is an integer scalar, the horizontal block offset for which to
+\code{xblockoff} is an integer value, the horizontal block offset for which to
 calculate the number of valid pixels, with zero indicating the left most
 block, 1 the next block, etc. \code{yblockoff} is likewise the vertical block
 offset, with zero indicating the top most block, 1 the next block, etc.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -376,6 +376,21 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// bbox_grid_to_geo_
+std::vector<double> bbox_grid_to_geo_(const std::vector<double>& gt, double grid_xmin, double grid_xmax, double grid_ymin, double grid_ymax);
+RcppExport SEXP _gdalraster_bbox_grid_to_geo_(SEXP gtSEXP, SEXP grid_xminSEXP, SEXP grid_xmaxSEXP, SEXP grid_yminSEXP, SEXP grid_ymaxSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::vector<double>& >::type gt(gtSEXP);
+    Rcpp::traits::input_parameter< double >::type grid_xmin(grid_xminSEXP);
+    Rcpp::traits::input_parameter< double >::type grid_xmax(grid_xmaxSEXP);
+    Rcpp::traits::input_parameter< double >::type grid_ymin(grid_yminSEXP);
+    Rcpp::traits::input_parameter< double >::type grid_ymax(grid_ymaxSEXP);
+    rcpp_result_gen = Rcpp::wrap(bbox_grid_to_geo_(gt, grid_xmin, grid_xmax, grid_ymin, grid_ymax));
+    return rcpp_result_gen;
+END_RCPP
+}
 // flip_vertical
 Rcpp::NumericVector flip_vertical(const Rcpp::NumericVector& v, int xsize, int ysize, int nbands);
 RcppExport SEXP _gdalraster_flip_vertical(SEXP vSEXP, SEXP xsizeSEXP, SEXP ysizeSEXP, SEXP nbandsSEXP) {
@@ -1983,6 +1998,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_inv_geotransform", (DL_FUNC) &_gdalraster_inv_geotransform, 1},
     {"_gdalraster_get_pixel_line_gt", (DL_FUNC) &_gdalraster_get_pixel_line_gt, 2},
     {"_gdalraster_get_pixel_line_ds", (DL_FUNC) &_gdalraster_get_pixel_line_ds, 2},
+    {"_gdalraster_bbox_grid_to_geo_", (DL_FUNC) &_gdalraster_bbox_grid_to_geo_, 5},
     {"_gdalraster_flip_vertical", (DL_FUNC) &_gdalraster_flip_vertical, 4},
     {"_gdalraster_buildVRT", (DL_FUNC) &_gdalraster_buildVRT, 4},
     {"_gdalraster_combine", (DL_FUNC) &_gdalraster_combine, 8},

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -868,6 +868,44 @@ Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
 }
 
 
+//' Returns bbox geospatial x,y coordinates (xmin, ymin, xmax, ymax) from
+//' inpouts of geotransform vector and the grid pixel/line extent
+//' @noRd
+// [[Rcpp::export(name = ".bbox_grid_to_geo")]]
+std::vector<double> bbox_grid_to_geo_(const std::vector<double> &gt,
+                                      double grid_xmin, double grid_xmax,
+                                      double grid_ymin, double grid_ymax) {
+
+    // {ul, ll, ur, lr}
+    Rcpp::NumericVector corners_x = {NA_REAL, NA_REAL, NA_REAL, NA_REAL};
+    Rcpp::NumericVector corners_y = {NA_REAL, NA_REAL, NA_REAL, NA_REAL};
+
+    // ul
+    corners_x[0] = gt[0] + gt[1] * grid_xmin + gt[2] * grid_ymax;
+    corners_y[0] = gt[3] + gt[4] * grid_xmin + gt[5] * grid_ymax;
+
+    // ll
+    corners_x[1] = gt[0] + gt[1] * grid_xmin + gt[2] * grid_ymin;
+    corners_y[1] = gt[3] + gt[4] * grid_xmin + gt[5] * grid_ymin;
+
+    // ur
+    corners_x[2] = gt[0] + gt[1] * grid_xmax + gt[2] * grid_ymax;
+    corners_y[2] = gt[3] + gt[4] * grid_xmax + gt[5] * grid_ymax;
+
+    // lr
+    corners_x[3] = gt[0] + gt[1] * grid_xmax + gt[2] * grid_ymin;
+    corners_y[3] = gt[3] + gt[4] * grid_xmax + gt[5] * grid_ymin;
+
+    double xmin = Rcpp::min(corners_x);
+    double xmax = Rcpp::max(corners_x);
+    double ymin = Rcpp::min(corners_y);
+    double ymax = Rcpp::max(corners_y);
+
+    std::vector<double> ret = {xmin, ymin, xmax, ymax};
+    return ret;
+}
+
+
 //' Flip raster data vertically
 //' @noRd
 // [[Rcpp::export(name = ".flip_vertical")]]

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -141,6 +141,7 @@ class GDALRaster {
                                       int krnl_dim,
                                       const std::string &xy_srs) const;
 
+    Rcpp::NumericMatrix get_block_indexing(int band) const;
     std::vector<int> getBlockSize(int band) const;
     std::vector<int> getActualBlockSize(int band, int xblockoff,
                                         int yblockoff) const;
@@ -315,6 +316,10 @@ Rcpp::IntegerMatrix get_pixel_line_gt(const Rcpp::RObject &xy,
 
 Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject &xy,
                                       const GDALRaster* const &ds);
+
+std::vector<double> bbox_grid_to_geo_(const std::vector<double> &gt,
+                                      double grid_xmin, double grid_xmax,
+                                      double grid_ymin, double grid_ymax);
 
 Rcpp::NumericVector flip_vertical(const Rcpp::NumericVector &v,
                                   int xsize, int ysize, int nbands);


### PR DESCRIPTION
`$get_block_indexing(band)`
Helper method returning a numeric matrix with named columns: `xblockoff`,
`yblockoff`, `xoff`, `yoff`, `xsize`, `ysize`, `xmin`, `xmax`, `ymin`,
`ymax`. For the meanings of these names, refer to the following class
methods below: `$getBlockSize()`, `$getActualBlockSize` and `$read()`.
All offsets are zero-based. The columns `xmin`, `xmax`, `ymin` and
`ymax` give the extent of each block in geospatial coordinates.
This method provides indexing values for the block layout of the given
`band` number. The returned matrix has number of rows equal to the number
of blocks comprising the band, with blocks ordered left to right, top
to bottom. The `xoff`/`yoff` values are pixel offsets to the start of a
block. The `xsize`/`ysize` values give the actual block sizes accounting
for potentially incomplete blocks along the right and bottom edges.

``` r
library(gdalraster)
#> GDAL 3.9.3 (released 2024-10-07), GEOS 3.12.2, PROJ 9.4.1

f <- tempfile(fileext = ".tif")
opt <- c("TILED=YES", "BLOCKXSIZE=128", "BLOCKYSIZE=128", "COMPRESS=LZW")
ds <- create(format = "GTiff", dst_filename = f, xsize = 671, ysize = 528,
             nbands = 1, dataType = "Byte", options = opt,
             return_obj = TRUE)

ds$setGeoTransform(c(0.0, 5.0, 0.0, 5.0, 0.0, -5.0))
#> [1] TRUE

blocks <- ds$get_block_indexing(band = 1)

head(blocks)
#>      xblockoff yblockoff xoff yoff xsize ysize xmin xmax ymin ymax
#> [1,]         0         0    0    0   128   128    0  640 -635    5
#> [2,]         1         0  128    0   128   128  640 1280 -635    5
#> [3,]         2         0  256    0   128   128 1280 1920 -635    5
#> [4,]         3         0  384    0   128   128 1920 2560 -635    5
#> [5,]         4         0  512    0   128   128 2560 3200 -635    5
#> [6,]         5         0  640    0    31   128 3200 3355 -635    5

tail(blocks)
#>       xblockoff yblockoff xoff yoff xsize ysize xmin xmax  ymin  ymax
#> [25,]         0         4    0  512   128    16    0  640 -2635 -2555
#> [26,]         1         4  128  512   128    16  640 1280 -2635 -2555
#> [27,]         2         4  256  512   128    16 1280 1920 -2635 -2555
#> [28,]         3         4  384  512   128    16 1920 2560 -2635 -2555
#> [29,]         4         4  512  512   128    16 2560 3200 -2635 -2555
#> [30,]         5         4  640  512    31    16 3200 3355 -2635 -2555

ds$close()
deleteDataset(f)
#> [1] TRUE
```
<sup>Created on 2025-03-25 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>