### PR TITLE
Geom API: add `g_geodesic_area()` and `g_geodesic_length()`

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2310,6 +2310,16 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_geodesic_area <- function(geom, srs, traditional_gis_order, quiet) {
+    .Call(`_gdalraster_g_geodesic_area`, geom, srs, traditional_gis_order, quiet)
+}
+
+#' @noRd
+.g_geodesic_length <- function(geom, srs, traditional_gis_order, quiet) {
+    .Call(`_gdalraster_g_geodesic_length`, geom, srs, traditional_gis_order, quiet)
+}
+
+#' @noRd
 .g_centroid <- function(geom, quiet = FALSE) {
     .Call(`_gdalraster_g_centroid`, geom, quiet)
 }

--- a/man/g_measures.Rd
+++ b/man/g_measures.Rd
@@ -6,6 +6,8 @@
 \alias{g_centroid}
 \alias{g_distance}
 \alias{g_length}
+\alias{g_geodesic_area}
+\alias{g_geodesic_length}
 \title{Compute measurements for WKB/WKT geometries}
 \usage{
 g_area(geom, quiet = FALSE)
@@ -15,6 +17,10 @@ g_centroid(geom, quiet = FALSE)
 g_distance(geom, other_geom, quiet = FALSE)
 
 g_length(geom, quiet = FALSE)
+
+g_geodesic_area(geom, srs, traditional_gis_order = TRUE, quiet = FALSE)
+
+g_geodesic_length(geom, srs, traditional_gis_order = TRUE, quiet = FALSE)
 }
 \arguments{
 \item{geom}{Either a raw vector of WKB or list of raw vectors, or a
@@ -25,6 +31,16 @@ character vector containing one or more WKT strings.}
 \item{other_geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings. Must contain the same
 number of geometries as \code{geom}.}
+
+\item{srs}{Character string specifying the spatial reference system
+for \code{geom}. May be in WKT format or any of the formats supported by
+\code{\link[=srs_to_wkt]{srs_to_wkt()}}.}
+
+\item{traditional_gis_order}{Logical value, \code{TRUE} to use traditional GIS
+order of axis mapping (the default) or \code{FALSE} to use authority compliant
+axis order. By default, input \code{geom} vertices are assumed to
+be in longitude/latitude order if \code{srs} is a geographic coordinate system.
+This can be overridden by setting \code{traditional_gis_order = FALSE}.}
 }
 \description{
 These functions compute measurements for geometries. The input
@@ -60,6 +76,30 @@ occurs.
 Undefined for all other geometry types (returns zero). Returns a numeric
 vector, having length equal to the number of input geometries, containing
 computed length or '0' if undefined.
+
+\code{g_geodesic_area()} computes geometry area, considered as a surface on the
+underlying ellipsoid of the SRS attached to the geometry. The returned area
+will always be in square meters, and assumes that polygon edges describe
+geodesic lines on the ellipsoid. If the geometry SRS is not a geographic
+one, geometries are reprojected to the underlying geographic SRS.
+By default, input geometry vertices are assumed to be in longitude/latitude
+order if using a geographic coordinate system. This can be overridden with
+the \code{traditional_gis_order} argument.
+Returns the area in square meters, or \code{NA} in case of error (unsupported
+geometry type, no SRS attached, etc.)
+Requires GDAL >= 3.9.
+
+\code{g_geodesic_length()} computes the length of the curve, considered as a
+geodesic line on the underlying ellipsoid of the SRS attached to the
+geometry. The returned length will always be in meters. If the geometry SRS
+is not a geographic one, geometries are reprojected to the underlying
+geographic SRS.
+By default, input geometry vertices are assumed to be in longitude/latitude
+order if using a geographic coordinate system. This can be overridden with
+the \code{traditional_gis_order} argument.
+Returns the length in meters, or \code{NA} in case of error (unsupported geometry
+type, no SRS attached, etc.)
+Requires GDAL >= 3.10.
 }
 \note{
 For \code{g_distance()}, \code{geom} and \code{other_geom} must contain the same number of

--- a/man/g_transform.Rd
+++ b/man/g_transform.Rd
@@ -21,7 +21,7 @@ g_transform(
 character vector containing one or more WKT strings.}
 
 \item{srs_from}{Character string specifying the spatial reference system
-for \code{pts}. May be in WKT format or any of the formats supported by
+for \code{geom}. May be in WKT format or any of the formats supported by
 \code{\link[=srs_to_wkt]{srs_to_wkt()}}.}
 
 \item{srs_to}{Character string specifying the output spatial reference

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1396,6 +1396,34 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// g_geodesic_area
+double g_geodesic_area(const Rcpp::RawVector& geom, const std::string& srs, bool traditional_gis_order, bool quiet);
+RcppExport SEXP _gdalraster_g_geodesic_area(SEXP geomSEXP, SEXP srsSEXP, SEXP traditional_gis_orderSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    Rcpp::traits::input_parameter< bool >::type traditional_gis_order(traditional_gis_orderSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_geodesic_area(geom, srs, traditional_gis_order, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
+// g_geodesic_length
+double g_geodesic_length(const Rcpp::RawVector& geom, const std::string& srs, bool traditional_gis_order, bool quiet);
+RcppExport SEXP _gdalraster_g_geodesic_length(SEXP geomSEXP, SEXP srsSEXP, SEXP traditional_gis_orderSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    Rcpp::traits::input_parameter< bool >::type traditional_gis_order(traditional_gis_orderSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_geodesic_length(geom, srs, traditional_gis_order, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
 // g_centroid
 Rcpp::NumericVector g_centroid(const Rcpp::RawVector& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_centroid(SEXP geomSEXP, SEXP quietSEXP) {
@@ -2075,6 +2103,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_distance", (DL_FUNC) &_gdalraster_g_distance, 3},
     {"_gdalraster_g_length", (DL_FUNC) &_gdalraster_g_length, 2},
     {"_gdalraster_g_area", (DL_FUNC) &_gdalraster_g_area, 2},
+    {"_gdalraster_g_geodesic_area", (DL_FUNC) &_gdalraster_g_geodesic_area, 4},
+    {"_gdalraster_g_geodesic_length", (DL_FUNC) &_gdalraster_g_geodesic_length, 4},
     {"_gdalraster_g_centroid", (DL_FUNC) &_gdalraster_g_centroid, 2},
     {"_gdalraster_g_transform", (DL_FUNC) &_gdalraster_g_transform, 8},
     {"_gdalraster_bbox_from_wkt", (DL_FUNC) &_gdalraster_bbox_from_wkt, 3},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -116,6 +116,10 @@ double g_distance(const Rcpp::RawVector &this_geom,
 
 double g_length(const Rcpp::RawVector &geom, bool quiet);
 double g_area(const Rcpp::RawVector &geom, bool quiet);
+double g_geodesic_area(const Rcpp::RawVector &geom, const std::string &srs,
+                       bool traditional_gis_order, bool quiet);
+double g_geodesic_length(const Rcpp::RawVector &geom, const std::string &srs,
+                         bool traditional_gis_order, bool quiet);
 Rcpp::NumericVector g_centroid(const Rcpp::RawVector &geom, bool quiet);
 
 SEXP g_transform(const Rcpp::RawVector &geom, const std::string &srs_from,

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -690,6 +690,61 @@ test_that("geometry measures are correct", {
     expect_equal(res, c(325621.1, 5103477.0))
 })
 
+test_that("geodesic measures are correct", {
+    skip_if(.gdal_version_num() < 3090000)
+
+    ## geodesic area
+    # lon/lat order (traditional_gis_order = TRUE by default)
+    g <- "POLYGON((2 49,3 49,3 48,2 49))"
+    a <- g_geodesic_area(g, "EPSG:4326")
+    expect_equal(a, 4068384291.8911743, tolerance = 1e4)
+
+    g <- "POLYGON((2 89,3 89,3 88,2 89))"
+    a <- g_geodesic_area(g, "EPSG:4326")
+    expect_equal(a, 108860488.12023926, tolerance = 1e4)
+
+    # lat/lon order
+    g <- "POLYGON((49 2,49 3,48 3,49 2))"
+    a <- g_geodesic_area(g, "EPSG:4326", traditional_gis_order = FALSE)
+    expect_equal(a, 4068384291.8911743, tolerance = 1e4)
+
+    # projected srs
+    g <- "POLYGON((2 49,3 49,3 48,2 49))"
+    g2 <- g_transform(g, "EPSG:4326", "EPSG:32631")
+    a <- g_geodesic_area(g2, "EPSG:32631")
+    expect_equal(a, 4068384291.8911743, tolerance = 1e4)
+    # For comparison: cartesian area in UTM
+    a <- g_area(g2)
+    expect_equal(a, 4065070548.465351, tolerance = 1e4)
+
+
+    skip_if(.gdal_version_num() < 3100000)
+
+    ## geodesic length
+    # lon/lat order (traditional_gis_order = TRUE by default)
+    g <- "LINESTRING(2 49,3 49)"
+    l <- g_geodesic_length(g, "EPSG:4326")
+    expect_equal(l, 73171.26435678436, tolerance = 1e4)
+
+    g <- "POLYGON((2 49,3 49,3 48,2 49))"
+    l <- g_geodesic_length(g, "EPSG:4326")
+    expect_equal(l, 317885.78639964823, tolerance = 1e4)
+
+    # lat/lon order
+    g <- "LINESTRING(49 3,48 3)"
+    l <- g_geodesic_length(g, "EPSG:4326", traditional_gis_order = FALSE)
+    expect_equal(l, 111200.0367623785, tolerance = 1e4)
+
+    # projected srs
+    g <- "POLYGON((2 49,3 49,3 48,2 49))"
+    g2 <- g_transform(g, "EPSG:4326", "EPSG:32631")
+    l <- g_geodesic_length(g2, "EPSG:32631")
+    expect_equal(l, 317885.78639964823, tolerance = 1e4)
+    # For comparison: cartesian length in UTM
+    l <- g_length(g2)
+    expect_equal(l, 317763.15996565996, tolerance = 1e4)
+})
+
 test_that("make_valid works", {
     # test only with recent GDAL and GEOS
     # these tests could give different results if used across a range of older


### PR DESCRIPTION
`g_geodesic_area()` computes geometry area, considered as a surface on the
underlying ellipsoid of the SRS attached to the geometry. The returned area
will always be in square meters, and assumes that polygon edges describe
geodesic lines on the ellipsoid. If the geometry SRS is not a geographic
one, geometries are reprojected to the underlying geographic SRS.
By default, input geometry vertices are assumed to be in longitude/latitude
order if using a geographic coordinate system. This can be overridden with
the `traditional_gis_order` argument. Returns the area in square meters, or
`NA` in case of error (unsupported geometry type, no SRS attached, etc.)
Requires GDAL >= 3.9.

`g_geodesic_length()` computes the length of the curve, considered as a
geodesic line on the underlying ellipsoid of the SRS attached to the
geometry. The returned length will always be in meters. If the geometry SRS
is not a geographic one, geometries are reprojected to the underlying
geographic SRS. By default, input geometry vertices are assumed to be in
longitude/latitude order if using a geographic coordinate system. This can be
overridden with the `traditional_gis_order` argument. Returns the length in
meters, or `NA` in case of error (unsupported geometry type, no SRS
attached, etc.)
Requires GDAL >= 3.10.