### PR TITLE
g_transform(): add argument traditional_gis_order

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2310,12 +2310,12 @@ has_geos <- function() {
 }
 
 #' @noRd
-.g_geodesic_area <- function(geom, srs, traditional_gis_order, quiet) {
+.g_geodesic_area <- function(geom, srs, traditional_gis_order = TRUE, quiet = FALSE) {
     .Call(`_gdalraster_g_geodesic_area`, geom, srs, traditional_gis_order, quiet)
 }
 
 #' @noRd
-.g_geodesic_length <- function(geom, srs, traditional_gis_order, quiet) {
+.g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE, quiet = FALSE) {
     .Call(`_gdalraster_g_geodesic_length`, geom, srs, traditional_gis_order, quiet)
 }
 
@@ -2325,8 +2325,8 @@ has_geos <- function() {
 }
 
 #' @noRd
-.g_transform <- function(geom, srs_from, srs_to, wrap_date_line = FALSE, date_line_offset = 10L, as_iso = FALSE, byte_order = "LSB", quiet = FALSE) {
-    .Call(`_gdalraster_g_transform`, geom, srs_from, srs_to, wrap_date_line, date_line_offset, as_iso, byte_order, quiet)
+.g_transform <- function(geom, srs_from, srs_to, wrap_date_line = FALSE, date_line_offset = 10L, traditional_gis_order = TRUE, as_iso = FALSE, byte_order = "LSB", quiet = FALSE) {
+    .Call(`_gdalraster_g_transform`, geom, srs_from, srs_to, wrap_date_line, date_line_offset, traditional_gis_order, as_iso, byte_order, quiet)
 }
 
 #' Get the bounding box of a geometry specified in OGC WKT format

--- a/R/geom.R
+++ b/R/geom.R
@@ -131,7 +131,8 @@ bbox_union <- function(x, as_wkt = FALSE) {
     while (i <= n) {
         if (is.character(x)) {
             ds <- new(GDALRaster, x[i], read_only=TRUE)
-            this_bbox <- g_union(this_bbox, bbox_to_wkt(ds$bbox()), as_wkb = FALSE)
+            this_bbox <- g_union(this_bbox, bbox_to_wkt(ds$bbox()),
+                                 as_wkb = FALSE)
             ds$close()
         } else {
             this_bbox <- g_union(this_bbox, bbox_to_wkt(x[[i]]), as_wkb = FALSE)
@@ -227,7 +228,7 @@ bbox_transform <- function(bbox, srs_from, srs_to,
 #' @param geom Either a raw vector of WKB or list of raw vectors to convert
 #' to WKT, or a character vector containing one or more WKT strings to
 #' convert to WKB.
-#' @param as_iso Logical scalar. `TRUE` to export as ISO WKB/WKT (ISO 13249
+#' @param as_iso Logical value, `TRUE` to export as ISO WKB/WKT (ISO 13249
 #' SQL/MM Part 3), or `FALSE` (the default) to export as "Extended WKB/WKT"
 #' (see Note).
 #' @param byte_order Character string specifying the byte order when converting
@@ -271,7 +272,7 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -329,9 +330,9 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
 #' (x, y, z, m), so the input must have two, three or four columns.
 #' Data frame input will be coerced to numeric matrix. Rings for polygon
 #' geometries should be closed.
-#' @param as_wkb Logical, `TRUE` to return the output geometry in WKB
+#' @param as_wkb Logical value, `TRUE` to return the output geometry in WKB
 #' format (the default), or `FALSE` to return a WKT string.
-#' @param as_iso Logical, `TRUE` to export as ISO WKB/WKT (ISO 13249
+#' @param as_iso Logical value, `TRUE` to export as ISO WKB/WKT (ISO 13249
 #' SQL/MM Part 3), or `FALSE` (the default) to export as "Extended WKB/WKT".
 #' @param byte_order Character string specifying the byte order when output is
 #' WKB. One of `"LSB"` (the default) or `"MSB"` (uncommon).
@@ -402,12 +403,12 @@ g_create <- function(geom_type, pts = NULL, as_wkb = TRUE, as_iso = FALSE,
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical value", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical value", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -458,12 +459,12 @@ g_add_geom <- function(sub_geom, container, as_wkb = TRUE, as_iso = FALSE,
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -512,7 +513,7 @@ g_add_geom <- function(sub_geom, container, as_wkb = TRUE, as_iso = FALSE,
 #'
 #' @param geom Either a raw vector of WKB or list of raw vectors, or a
 #' character vector containing one or more WKT strings.
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #'
 #' @examples
 #' g1 <- "POLYGON ((0 0, 10 10, 10 0, 0 0))"
@@ -557,7 +558,7 @@ g_is_empty <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(geom)) {
@@ -585,7 +586,7 @@ g_is_valid <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(geom)) {
@@ -613,7 +614,7 @@ g_is_3D <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(geom)) {
@@ -641,7 +642,7 @@ g_is_measured <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(geom)) {
@@ -669,7 +670,7 @@ g_name <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(geom)) {
@@ -697,7 +698,7 @@ g_summary <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(geom)) {
@@ -740,15 +741,15 @@ g_summary <- function(geom, quiet = FALSE) {
 #' character vector containing one or more WKT strings.
 #' @param method Character string. One of `"LINEWORK"` (the default) or
 #' `"STRUCTURE"` (requires GEOS >= 3.10 and GDAL >= 3.4). See Details.
-#' @param keep_collapsed Logical, applies only to the STRUCTURE method.
+#' @param keep_collapsed Logical value, applies only to the STRUCTURE method.
 #' Defaults to `FALSE`. See Details.
-#' @param as_wkb Logical, `TRUE` to return the output geometry in WKB
+#' @param as_wkb Logical value, `TRUE` to return the output geometry in WKB
 #' format (the default), or `FALSE` to return as WKT.
-#' @param as_iso Logical, `TRUE` to export as ISO WKB/WKT (ISO 13249
+#' @param as_iso Logical value, `TRUE` to export as ISO WKB/WKT (ISO 13249
 #' SQL/MM Part 3), or `FALSE` (the default) to export as "Extended WKB/WKT".
 #' @param byte_order Character string specifying the byte order when output is
 #' WKB. One of `"LSB"` (the default) or `"MSB"` (uncommon).
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
 #' geometries as WKB/WKT with length equal to `length(geom)`. `NA` is returned
@@ -791,17 +792,17 @@ g_make_valid <- function(geom, method = "LINEWORK", keep_collapsed = FALSE,
     if (is.null(keep_collapsed))
         keep_collapsed <- FALSE
     if (!is.logical(keep_collapsed) || length(keep_collapsed) > 1)
-        stop("'keep_collapsed' must be a logical scalar", call. = FALSE)
+        stop("'keep_collapsed' must be a single logical value", call. = FALSE)
     # as_wkb
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -814,7 +815,7 @@ g_make_valid <- function(geom, method = "LINEWORK", keep_collapsed = FALSE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
     if (is.raw(geom)) {
@@ -849,7 +850,7 @@ g_make_valid <- function(geom, method = "LINEWORK", keep_collapsed = FALSE,
 #'
 #' @param geom Either a raw vector of WKB or list of raw vectors, or a
 #' character vector containing one or more WKT strings.
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return Either a numeric vector of length 4 containing the envelope
 #' `(xmin, xmax, ymin, ymax)`, or a four-column numeric matrix with number of
 #' rows equal to the number of input geometries and column names
@@ -860,7 +861,7 @@ g_envelope <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
     if (is.raw(geom)) {
@@ -923,7 +924,7 @@ g_envelope <- function(geom, quiet = FALSE) {
 #' @param other_geom Either a raw vector of WKB or list of raw vectors, or a
 #' character vector containing one or more WKT strings. Must contain the same
 #' number of geometries as `this_geom`.
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return Logical vector with length equal to the number of input geometry
 #' pairs.
 #'
@@ -960,7 +961,7 @@ g_intersects <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1008,7 +1009,7 @@ g_disjoint <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1056,7 +1057,7 @@ g_touches <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1104,7 +1105,7 @@ g_contains <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1152,7 +1153,7 @@ g_within <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1200,7 +1201,7 @@ g_crosses <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1248,7 +1249,7 @@ g_overlaps <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1296,7 +1297,7 @@ g_equals <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1347,13 +1348,13 @@ g_equals <- function(this_geom, other_geom, quiet = FALSE) {
 #' @param other_geom Either a raw vector of WKB or list of raw vectors, or a
 #' character vector containing one or more WKT strings. Must contain the same
 #' number of geometries as `this_geom`.
-#' @param as_wkb Logical, `TRUE` to return the output geometry in WKB
+#' @param as_wkb Logical value, `TRUE` to return the output geometry in WKB
 #' format (the default), or `FALSE` to return as WKT.
-#' @param as_iso Logical, `TRUE` to export as ISO WKB/WKT (ISO 13249
+#' @param as_iso Logical value, `TRUE` to export as ISO WKB/WKT (ISO 13249
 #' SQL/MM Part 3), or `FALSE` (the default) to export as "Extended WKB/WKT".
 #' @param byte_order Character string specifying the byte order when output is
 #' WKB. One of `"LSB"` (the default) or `"MSB"` (uncommon).
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
 #' geometries as WKB/WKT with length equal to the number of input geometry
@@ -1418,12 +1419,12 @@ g_intersection <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -1436,7 +1437,7 @@ g_intersection <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1493,12 +1494,12 @@ g_union <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -1511,7 +1512,7 @@ g_union <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1568,12 +1569,12 @@ g_difference <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -1586,7 +1587,7 @@ g_difference <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1643,12 +1644,12 @@ g_sym_difference <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -1661,7 +1662,7 @@ g_sym_difference <- function(this_geom, other_geom, as_wkb = TRUE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
     if (is.raw(this_geom) && is.raw(other_geom)) {
@@ -1675,8 +1676,8 @@ g_sym_difference <- function(this_geom, other_geom, as_wkb = TRUE,
 
         wkb <- list()
         for (i in seq_along(this_geom)) {
-            wkb[[i]] <- .g_sym_difference(this_geom[[i]], other_geom[[i]], as_iso,
-                                          byte_order, quiet)
+            wkb[[i]] <- .g_sym_difference(this_geom[[i]], other_geom[[i]],
+                                          as_iso, byte_order, quiet)
         }
 
     } else {
@@ -1763,7 +1764,7 @@ g_sym_difference <- function(this_geom, other_geom, as_wkb = TRUE,
 #' axis order. By default, input `geom` vertices are assumed to
 #' be in longitude/latitude order if `srs` is a geographic coordinate system.
 #' This can be overridden by setting `traditional_gis_order = FALSE`.
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #'
 #' @note
 #' For `g_distance()`, `geom` and `other_geom` must contain the same number of
@@ -1800,7 +1801,7 @@ g_area <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
     if (is.raw(geom)) {
@@ -1827,7 +1828,7 @@ g_centroid <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
     if (is.raw(geom)) {
@@ -1874,7 +1875,7 @@ g_distance <- function(geom, other_geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- -1
     if (is.raw(geom) && is.raw(other_geom)) {
@@ -1904,7 +1905,7 @@ g_length <- function(geom, quiet = FALSE) {
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
     if (is.raw(geom)) {
@@ -1941,7 +1942,7 @@ g_geodesic_area <- function(geom, srs, traditional_gis_order = TRUE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- -1.0
     if (is.raw(geom)) {
@@ -1981,7 +1982,7 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- -1.0
     if (is.raw(geom)) {
@@ -2018,13 +2019,13 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
 #' curve (quadrant of a circle). Large values result in large numbers of
 #' vertices in the resulting buffer geometry while small numbers reduce the
 #' accuracy of the result.
-#' @param as_wkb Logical, `TRUE` to return the output geometry in WKB
+#' @param as_wkb Logical value, `TRUE` to return the output geometry in WKB
 #' format (the default), or `FALSE` to return as WKT.
-#' @param as_iso Logical, `TRUE` to export as ISO WKB/WKT (ISO 13249
+#' @param as_iso Logical value, `TRUE` to export as ISO WKB/WKT (ISO 13249
 #' SQL/MM Part 3), or `FALSE` (the default) to export as "Extended WKB/WKT".
 #' @param byte_order Character string specifying the byte order when output is
 #' WKB. One of `"LSB"` (the default) or `"MSB"` (uncommon).
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return
 #' A polygon as WKB raw vector or WKT string, or a list/character vector of
 #' polygons as WKB/WKT with length equal to the number of input geometries.
@@ -2042,12 +2043,12 @@ g_buffer <- function(geom, dist, quad_segs = 30L, as_wkb = TRUE,
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -2060,7 +2061,7 @@ g_buffer <- function(geom, dist, quad_segs = 30L, as_wkb = TRUE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
     if (is.raw(geom)) {
@@ -2102,18 +2103,22 @@ g_buffer <- function(geom, dist, quad_segs = 30L, as_wkb = TRUE,
 #' @param srs_to Character string specifying the output spatial reference
 #' system. May be in WKT format or any of the formats supported by
 #' [srs_to_wkt()].
-#' @param wrap_date_line Logical scalar. `TRUE` to correct geometries that
+#' @param wrap_date_line Logical value, `TRUE` to correct geometries that
 #' incorrectly go from a longitude on a side of the antimeridian to the other
 #' side. Defaults to `FALSE`.
-#' @param date_line_offset Integer scalar. Longitude gap in degree. Defaults
-#' to `10`.
-#' @param as_wkb Logical, `TRUE` to return the output geometry in WKB
+#' @param date_line_offset Integer longitude gap in degree. Defaults to `10L`.
+#' @param traditional_gis_order Logical value, `TRUE` to use traditional GIS
+#' order of axis mapping (the default) or `FALSE` to use authority compliant
+#' axis order. By default, input `geom` vertices are assumed to
+#' be in longitude/latitude order if `srs_from` is a geographic coordinate
+#' system. This can be overridden by setting `traditional_gis_order = FALSE`.
+#' @param as_wkb Logical value, `TRUE` to return the output geometry in WKB
 #' format (the default), or `FALSE` to return as WKT.
-#' @param as_iso Logical, `TRUE` to export as ISO WKB/WKT (ISO 13249
+#' @param as_iso Logical value, `TRUE` to export as ISO WKB/WKT (ISO 13249
 #' SQL/MM Part 3), or `FALSE` (the default) to export as "Extended WKB/WKT".
 #' @param byte_order Character string specifying the byte order when output is
 #' WKB. One of `"LSB"` (the default) or `"MSB"` (uncommon).
-#' @param quiet Logical, `TRUE` to suppress warnings. Defaults to `FALSE`.
+#' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
 #' geometries as WKB/WKT with length equal to the number of input geometries.
@@ -2149,23 +2154,42 @@ g_buffer <- function(geom, dist, quad_segs = 30L, as_wkb = TRUE,
 #' g_transform(geom, "WGS84", "WGS84", wrap_date_line = TRUE, as_wkb = FALSE)
 #' @export
 g_transform <- function(geom, srs_from, srs_to, wrap_date_line = FALSE,
-                        date_line_offset = 10L, as_wkb = TRUE,
-                        as_iso = FALSE, byte_order = "LSB", quiet = FALSE) {
-
+                        date_line_offset = 10L, traditional_gis_order = TRUE,
+                        as_wkb = TRUE, as_iso = FALSE, byte_order = "LSB",
+                        quiet = FALSE) {
+    # srs_from
     if (!(is.character(srs_from) && length(srs_from) == 1))
         stop("'srs_from' must be a character string", call. = FALSE)
+    # srs_to
     if (!(is.character(srs_to) && length(srs_to) == 1))
         stop("'srs_to' must be a character string", call. = FALSE)
+    # wrap_date_line
+    if (!(is.logical(wrap_date_line) &&
+          length(wrap_date_line) == 1)) {
+
+        stop("'wrap_date_line' must be a single logical value",
+             call. = FALSE)
+    }
+    # date_line_offset
+    if (!(is.numeric(date_line_offset) && length(date_line_offset) == 1))
+        stop("'date_line_offset' must be an integer value", call. = FALSE)
+    # traditional_gis_order
+    if (!(is.logical(traditional_gis_order) &&
+          length(traditional_gis_order) == 1)) {
+
+        stop("'traditional_gis_order' must be a single logical value",
+             call. = FALSE)
+    }
     # as_wkb
     if (is.null(as_wkb))
         as_wkb <- TRUE
     if (!is.logical(as_wkb) || length(as_wkb) > 1)
-        stop("'as_wkb' must be a logical scalar", call. = FALSE)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
     # as_iso
     if (is.null(as_iso))
         as_iso <- FALSE
     if (!is.logical(as_iso) || length(as_iso) > 1)
-        stop("'as_iso' must be a logical scalar", call. = FALSE)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
     # byte_order
     if (is.null(byte_order))
         byte_order <- "LSB"
@@ -2178,24 +2202,27 @@ g_transform <- function(geom, srs_from, srs_to, wrap_date_line = FALSE,
     if (is.null(quiet))
         quiet <- FALSE
     if (!is.logical(quiet) || length(quiet) > 1)
-        stop("'quiet' must be a logical scalar", call. = FALSE)
+        stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
     if (is.raw(geom)) {
         wkb <- .g_transform(geom, srs_from, srs_to, wrap_date_line,
-                            date_line_offset, as_iso, byte_order, quiet)
+                            date_line_offset, traditional_gis_order, as_iso,
+                            byte_order, quiet)
     } else if (is.list(geom) && is.raw(geom[[1]])) {
         wkb <- lapply(geom, .g_transform, srs_from, srs_to, wrap_date_line,
-                      date_line_offset, as_iso, byte_order, quiet)
+                      date_line_offset, traditional_gis_order, as_iso,
+                      byte_order, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
             wkb <- .g_transform(g_wk2wk(geom), srs_from, srs_to,
-                                wrap_date_line, date_line_offset, as_iso,
-                                byte_order, quiet)
+                                wrap_date_line, date_line_offset,
+                                traditional_gis_order, as_iso, byte_order,
+                                quiet)
         } else {
             wkb <- lapply(g_wk2wk(geom), .g_transform, srs_from, srs_to,
-                          wrap_date_line, date_line_offset, as_iso, byte_order,
-                          quiet)
+                          wrap_date_line, date_line_offset,
+                          traditional_gis_order, as_iso, byte_order, quiet)
         }
     } else {
         stop("'geom' must be a character vector, raw vector, or list",

--- a/man/g_binary_op.Rd
+++ b/man/g_binary_op.Rd
@@ -52,16 +52,16 @@ character vector containing one or more WKT strings.}
 character vector containing one or more WKT strings. Must contain the same
 number of geometries as \code{this_geom}.}
 
-\item{as_wkb}{Logical, \code{TRUE} to return the output geometry in WKB
+\item{as_wkb}{Logical value, \code{TRUE} to return the output geometry in WKB
 format (the default), or \code{FALSE} to return as WKT.}
 
-\item{as_iso}{Logical, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
+\item{as_iso}{Logical value, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
 SQL/MM Part 3), or \code{FALSE} (the default) to export as "Extended WKB/WKT".}
 
 \item{byte_order}{Character string specifying the byte order when output is
 WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \value{
 A geometry as WKB raw vector or WKT string, or a list/character vector of

--- a/man/g_binary_pred.Rd
+++ b/man/g_binary_pred.Rd
@@ -36,7 +36,7 @@ character vector containing one or more WKT strings.}
 character vector containing one or more WKT strings. Must contain the same
 number of geometries as \code{this_geom}.}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \value{
 Logical vector with length equal to the number of input geometry

--- a/man/g_buffer.Rd
+++ b/man/g_buffer.Rd
@@ -25,16 +25,16 @@ curve (quadrant of a circle). Large values result in large numbers of
 vertices in the resulting buffer geometry while small numbers reduce the
 accuracy of the result.}
 
-\item{as_wkb}{Logical, \code{TRUE} to return the output geometry in WKB
+\item{as_wkb}{Logical value, \code{TRUE} to return the output geometry in WKB
 format (the default), or \code{FALSE} to return as WKT.}
 
-\item{as_iso}{Logical, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
+\item{as_iso}{Logical value, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
 SQL/MM Part 3), or \code{FALSE} (the default) to export as "Extended WKB/WKT".}
 
 \item{byte_order}{Character string specifying the byte order when output is
 WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \value{
 A polygon as WKB raw vector or WKT string, or a list/character vector of

--- a/man/g_envelope.Rd
+++ b/man/g_envelope.Rd
@@ -10,7 +10,7 @@ g_envelope(geom, quiet = FALSE)
 \item{geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings.}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \value{
 Either a numeric vector of length 4 containing the envelope

--- a/man/g_factory.Rd
+++ b/man/g_factory.Rd
@@ -33,10 +33,10 @@ empty geometry. The points can be given as (x, y), (x, y, z) or
 Data frame input will be coerced to numeric matrix. Rings for polygon
 geometries should be closed.}
 
-\item{as_wkb}{Logical, \code{TRUE} to return the output geometry in WKB
+\item{as_wkb}{Logical value, \code{TRUE} to return the output geometry in WKB
 format (the default), or \code{FALSE} to return a WKT string.}
 
-\item{as_iso}{Logical, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
+\item{as_iso}{Logical value, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
 SQL/MM Part 3), or \code{FALSE} (the default) to export as "Extended WKB/WKT".}
 
 \item{byte_order}{Character string specifying the byte order when output is

--- a/man/g_make_valid.Rd
+++ b/man/g_make_valid.Rd
@@ -21,19 +21,19 @@ character vector containing one or more WKT strings.}
 \item{method}{Character string. One of \code{"LINEWORK"} (the default) or
 \code{"STRUCTURE"} (requires GEOS >= 3.10 and GDAL >= 3.4). See Details.}
 
-\item{keep_collapsed}{Logical, applies only to the STRUCTURE method.
+\item{keep_collapsed}{Logical value, applies only to the STRUCTURE method.
 Defaults to \code{FALSE}. See Details.}
 
-\item{as_wkb}{Logical, \code{TRUE} to return the output geometry in WKB
+\item{as_wkb}{Logical value, \code{TRUE} to return the output geometry in WKB
 format (the default), or \code{FALSE} to return as WKT.}
 
-\item{as_iso}{Logical, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
+\item{as_iso}{Logical value, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
 SQL/MM Part 3), or \code{FALSE} (the default) to export as "Extended WKB/WKT".}
 
 \item{byte_order}{Character string specifying the byte order when output is
 WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \value{
 A geometry as WKB raw vector or WKT string, or a list/character vector of

--- a/man/g_measures.Rd
+++ b/man/g_measures.Rd
@@ -26,7 +26,7 @@ g_geodesic_length(geom, srs, traditional_gis_order = TRUE, quiet = FALSE)
 \item{geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings.}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 
 \item{other_geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings. Must contain the same

--- a/man/g_query.Rd
+++ b/man/g_query.Rd
@@ -26,7 +26,7 @@ g_summary(geom, quiet = FALSE)
 \item{geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings.}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \description{
 These functions return information about WKB/WKT geometries. The input

--- a/man/g_transform.Rd
+++ b/man/g_transform.Rd
@@ -10,6 +10,7 @@ g_transform(
   srs_to,
   wrap_date_line = FALSE,
   date_line_offset = 10L,
+  traditional_gis_order = TRUE,
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB",
@@ -28,23 +29,28 @@ for \code{geom}. May be in WKT format or any of the formats supported by
 system. May be in WKT format or any of the formats supported by
 \code{\link[=srs_to_wkt]{srs_to_wkt()}}.}
 
-\item{wrap_date_line}{Logical scalar. \code{TRUE} to correct geometries that
+\item{wrap_date_line}{Logical value, \code{TRUE} to correct geometries that
 incorrectly go from a longitude on a side of the antimeridian to the other
 side. Defaults to \code{FALSE}.}
 
-\item{date_line_offset}{Integer scalar. Longitude gap in degree. Defaults
-to \code{10}.}
+\item{date_line_offset}{Integer longitude gap in degree. Defaults to \code{10L}.}
 
-\item{as_wkb}{Logical, \code{TRUE} to return the output geometry in WKB
+\item{traditional_gis_order}{Logical value, \code{TRUE} to use traditional GIS
+order of axis mapping (the default) or \code{FALSE} to use authority compliant
+axis order. By default, input \code{geom} vertices are assumed to
+be in longitude/latitude order if \code{srs_from} is a geographic coordinate
+system. This can be overridden by setting \code{traditional_gis_order = FALSE}.}
+
+\item{as_wkb}{Logical value, \code{TRUE} to return the output geometry in WKB
 format (the default), or \code{FALSE} to return as WKT.}
 
-\item{as_iso}{Logical, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
+\item{as_iso}{Logical value, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
 SQL/MM Part 3), or \code{FALSE} (the default) to export as "Extended WKB/WKT".}
 
 \item{byte_order}{Character string specifying the byte order when output is
 WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 
-\item{quiet}{Logical, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
+\item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \value{
 A geometry as WKB raw vector or WKT string, or a list/character vector of

--- a/man/g_wk2wk.Rd
+++ b/man/g_wk2wk.Rd
@@ -11,7 +11,7 @@ g_wk2wk(geom, as_iso = FALSE, byte_order = "LSB")
 to WKT, or a character vector containing one or more WKT strings to
 convert to WKB.}
 
-\item{as_iso}{Logical scalar. \code{TRUE} to export as ISO WKB/WKT (ISO 13249
+\item{as_iso}{Logical value, \code{TRUE} to export as ISO WKB/WKT (ISO 13249
 SQL/MM Part 3), or \code{FALSE} (the default) to export as "Extended WKB/WKT"
 (see Note).}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1437,8 +1437,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_transform
-SEXP g_transform(const Rcpp::RawVector& geom, const std::string& srs_from, const std::string& srs_to, bool wrap_date_line, int date_line_offset, bool as_iso, const std::string& byte_order, bool quiet);
-RcppExport SEXP _gdalraster_g_transform(SEXP geomSEXP, SEXP srs_fromSEXP, SEXP srs_toSEXP, SEXP wrap_date_lineSEXP, SEXP date_line_offsetSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
+SEXP g_transform(const Rcpp::RawVector& geom, const std::string& srs_from, const std::string& srs_to, bool wrap_date_line, int date_line_offset, bool traditional_gis_order, bool as_iso, const std::string& byte_order, bool quiet);
+RcppExport SEXP _gdalraster_g_transform(SEXP geomSEXP, SEXP srs_fromSEXP, SEXP srs_toSEXP, SEXP wrap_date_lineSEXP, SEXP date_line_offsetSEXP, SEXP traditional_gis_orderSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1447,10 +1447,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::string& >::type srs_to(srs_toSEXP);
     Rcpp::traits::input_parameter< bool >::type wrap_date_line(wrap_date_lineSEXP);
     Rcpp::traits::input_parameter< int >::type date_line_offset(date_line_offsetSEXP);
+    Rcpp::traits::input_parameter< bool >::type traditional_gis_order(traditional_gis_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
-    rcpp_result_gen = Rcpp::wrap(g_transform(geom, srs_from, srs_to, wrap_date_line, date_line_offset, as_iso, byte_order, quiet));
+    rcpp_result_gen = Rcpp::wrap(g_transform(geom, srs_from, srs_to, wrap_date_line, date_line_offset, traditional_gis_order, as_iso, byte_order, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2106,7 +2107,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_geodesic_area", (DL_FUNC) &_gdalraster_g_geodesic_area, 4},
     {"_gdalraster_g_geodesic_length", (DL_FUNC) &_gdalraster_g_geodesic_length, 4},
     {"_gdalraster_g_centroid", (DL_FUNC) &_gdalraster_g_centroid, 2},
-    {"_gdalraster_g_transform", (DL_FUNC) &_gdalraster_g_transform, 8},
+    {"_gdalraster_g_transform", (DL_FUNC) &_gdalraster_g_transform, 9},
     {"_gdalraster_bbox_from_wkt", (DL_FUNC) &_gdalraster_bbox_from_wkt, 3},
     {"_gdalraster_bbox_to_wkt", (DL_FUNC) &_gdalraster_bbox_to_wkt, 3},
     {"_gdalraster_ogr_ds_exists", (DL_FUNC) &_gdalraster_ogr_ds_exists, 2},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -124,7 +124,7 @@ Rcpp::NumericVector g_centroid(const Rcpp::RawVector &geom, bool quiet);
 
 SEXP g_transform(const Rcpp::RawVector &geom, const std::string &srs_from,
                  const std::string &srs_to, bool wrap_date_line,
-                 int date_line_offset, bool as_iso,
+                 int date_line_offset, bool traditional_gis_order, bool as_iso,
                  const std::string &byte_order, bool quiet);
 
 Rcpp::NumericVector bbox_from_wkt(const std::string &wkt,

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -691,6 +691,8 @@ test_that("geometry measures are correct", {
 })
 
 test_that("geodesic measures are correct", {
+    # tests based on gdal/autotest/ogr/ogr_geom.py
+    # https://github.com/OSGeo/gdal/blob/28e94e2f52893d4206830011d75efe1783f1b7c1/autotest/ogr/ogr_geom.py
     skip_if(.gdal_version_num() < 3090000)
 
     ## geodesic area
@@ -716,6 +718,12 @@ test_that("geodesic measures are correct", {
     # For comparison: cartesian area in UTM
     a <- g_area(g2)
     expect_equal(a, 4065070548.465351, tolerance = 1e4)
+    # start with lat/lon order
+    g <- "POLYGON((49 2,49 3,48 3,49 2))"
+    g2 <- g_transform(g, "EPSG:4326", "EPSG:32631",
+                      traditional_gis_order = FALSE)
+    a <- g_geodesic_area(g2, "EPSG:32631")
+    expect_equal(a, 4068384291.8911743, tolerance = 1e4)
 
 
     skip_if(.gdal_version_num() < 3100000)
@@ -743,6 +751,12 @@ test_that("geodesic measures are correct", {
     # For comparison: cartesian length in UTM
     l <- g_length(g2)
     expect_equal(l, 317763.15996565996, tolerance = 1e4)
+    # start with lat/lon order
+    g <- "POLYGON((49 2,49 3,48 3,49 2))"
+    g2 <- g_transform(g, "EPSG:4326", "EPSG:32631",
+                      traditional_gis_order = FALSE)
+    l <- g_geodesic_length(g2, "EPSG:32631")
+    expect_equal(l, 317885.78639964823, tolerance = 1e4)
 })
 
 test_that("make_valid works", {


### PR DESCRIPTION
To support authority compliant order for geometries using geographic coordinates.

@param `traditional_gis_order` Logical value, `TRUE` to use traditional GIS
order of axis mapping (the default) or `FALSE` to use authority compliant
axis order. By default, input `geom` vertices are assumed to
be in longitude/latitude order if `srs_from` is a geographic coordinate
system. This can be overridden by setting `traditional_gis_order = FALSE`.