### PR TITLE
Doc: update for transform_bounds() consistent with upstream documentation change

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2887,6 +2887,8 @@ srs_get_axis_mapping_strategy <- function(srs) {
 #' Reference System API. Requires GDAL >= 3.4.
 #'
 #' @details
+#' The following refer to the *output* values `xmin`, `ymin`, `xmax`, `ymax`:
+#'
 #' If the destination CRS is geographic, the first axis is longitude, and
 #' `xmax < xmin` then the bounds crossed the antimeridian. In this scenario
 #' there are two polygons, one on each side of the antimeridian. The first

--- a/R/geom.R
+++ b/R/geom.R
@@ -159,12 +159,18 @@ bbox_union <- function(x, as_wkt = FALSE) {
 #' transform_bounds(bbox, srs_from, srs_to)
 #' ```
 #'
+#' See Details for [transform_bounds()] for cases where the bounds crossed the
+#' antimeridian.
+#'
 #' With `use_transform_bounds = FALSE`, this function returns:
 #' ```
 #' bbox_to_wkt(bbox) |>
 #'   g_transform(srs_from, srs_to) |>
 #'   bbox_from_wkt()
 #' ```
+#'
+#' See the Note for [g_transform()] for cases where the bounds crossed the
+#' antimeridian.
 #'
 #' @param bbox Numeric vector of length four containing a bounding box
 #' (xmin, ymin, xmax, ymax) to transform.

--- a/man/bbox_transform.Rd
+++ b/man/bbox_transform.Rd
@@ -38,12 +38,18 @@ With \code{use_transform_bounds = TRUE} (the default) this function returns:
 transform_bounds(bbox, srs_from, srs_to)
 }\if{html}{\out{</div>}}
 
+See Details for \code{\link[=transform_bounds]{transform_bounds()}} for cases where the bounds crossed the
+antimeridian.
+
 With \code{use_transform_bounds = FALSE}, this function returns:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{bbox_to_wkt(bbox) |>
   g_transform(srs_from, srs_to) |>
   bbox_from_wkt()
 }\if{html}{\out{</div>}}
+
+See the Note for \code{\link[=g_transform]{g_transform()}} for cases where the bounds crossed the
+antimeridian.
 }
 \examples{
 bb <- c(-1405880.72, -1371213.76, 5405880.72, 5371213.76)

--- a/man/transform_bounds.Rd
+++ b/man/transform_bounds.Rd
@@ -43,6 +43,8 @@ the outermost bounds. Wrapper of \code{OCTTransformBounds()} in the GDAL Spatial
 Reference System API. Requires GDAL >= 3.4.
 }
 \details{
+The following refer to the \emph{output} values \code{xmin}, \code{ymin}, \code{xmax}, \code{ymax}:
+
 If the destination CRS is geographic, the first axis is longitude, and
 \code{xmax < xmin} then the bounds crossed the antimeridian. In this scenario
 there are two polygons, one on each side of the antimeridian. The first

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -403,6 +403,8 @@ Rcpp::NumericMatrix transform_xy(const Rcpp::RObject &pts,
 //' Reference System API. Requires GDAL >= 3.4.
 //'
 //' @details
+//' The following refer to the *output* values `xmin`, `ymin`, `xmax`, `ymax`:
+//'
 //' If the destination CRS is geographic, the first axis is longitude, and
 //' `xmax < xmin` then the bounds crossed the antimeridian. In this scenario
 //' there are two polygons, one on each side of the antimeridian. The first


### PR DESCRIPTION
Update to be consistent with the GDAL documentation change in https://github.com/OSGeo/gdal/commit/1a3f781304cd2856ec0438b2f773357907d7d893 clarifying that the output values, not input values, need to be checked in cases that cross the antimeridian.

https://lists.osgeo.org/pipermail/gdal-dev/2025-April/060416.html