### PR TITLE
Fix `GDALRaster::pixel_extract()` for points exactly on the right or bottom edges of the raster

### DIFF
--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -533,6 +533,27 @@ test_that("pixel extract internal class method returns correct data", {
 
     expect_equal(extr_nearest[1], 173)
 
+    # point exactly on right edge
+    # see https://github.com/OSGeo/gdal/pull/12087
+    bb <- ds$bbox()
+    extr_nearest <- ds$pixel_extract(xy = c(bb[3], (bb[2] + 200)),
+                                     bands = 1,
+                                     interp_method = "near",
+                                     krnl_dim = 1,
+                                     xy_srs = "")
+
+    expect_equal(extr_nearest[1], 132)
+
+    # exactly bottom right corner
+    bb <- ds$bbox()
+    extr_nearest <- ds$pixel_extract(xy = c(bb[3], bb[2]),
+                                     bands = 1,
+                                     interp_method = "near",
+                                     krnl_dim = 1,
+                                     xy_srs = "")
+
+    expect_equal(extr_nearest[1], 107)
+
     # as data frame
     geo_xy <- data.frame(geo_xy[1], geo_xy[2])
     extr_nearest <- ds$pixel_extract(xy = geo_xy,
@@ -568,7 +589,7 @@ test_that("pixel extract internal class method returns correct data", {
                                   interp_method = "invalid",
                                   krnl_dim = 1,
                                   xy_srs = ""))
-    # only  one band at a time supported for NxN kernel extract
+    # only one band at a time supported for NxN kernel extract
     expect_error(ds$pixel_extract(xy = geo_xy,
                                   bands = c(1, 2),
                                   interp_method = "near",

--- a/tests/testthat/test-gdalraster_proc.R
+++ b/tests/testthat/test-gdalraster_proc.R
@@ -491,6 +491,13 @@ test_that("pixel_extract wrapper returns correct data", {
     dim(extr_na) <- NULL
     expect_na <- c(expected_values, NA_real_)
     expect_equal(extr_na, expect_na)
+    # with NaN in the input
+    pts_nan <- rbind(pts, c(11, NaN, NaN))
+    extr_nan <- pixel_extract(ds, pts_na[-1])
+    colnames(extr_nan) <- NULL
+    dim(extr_nan) <- NULL
+    expect_nan <- c(expected_values, NA_real_)
+    expect_equal(extr_nan, expect_nan)
     ds$close()
 
     # interpolated values


### PR DESCRIPTION
Allow geospatial coordinates that are exactly on the right or bottom edges of the raster to be considered as inside when doing single-pixel extract (i.e., nearest neighbor).

Match behavior in https://github.com/OSGeo/gdal/pull/12087.
