### PR TITLE
Add more error messages from GDAL in a few places

### DIFF
--- a/inst/extdata/doctype.xml
+++ b/inst/extdata/doctype.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<!-- Copied from gdal/autotest/gcore/data/doctype.xml. -->
+<!-- Sample XML document to test reading complex DOCTYPE element. -->
+
+<!-- The XML document type declaration contains or points to markup
+     declarations that provide a grammar for a class of documents. -->
+
+<!DOCTYPE chapter [
+    <!ELEMENT chapter (title,para+)>
+    <!ELEMENT title (#PCDATA)>
+    <!ELEMENT para (#PCDATA)>
+]>
+
+<chapter><title>Chapter 1</title>
+  <para>More unexpert, I boast not: them let those</para>
+  <para>Contrive who need, or when they need, not now.</para>
+  <para>For while they sit contriving, shall the rest,</para>
+  <para>Millions that stand in Arms, and longing wait</para>
+</chapter>

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -186,6 +186,8 @@ void GDALRaster::open(bool read_only) {
     if (m_shared)
         nOpenFlags |= GDAL_OF_SHARED;
 
+    nOpenFlags |= GDAL_OF_VERBOSE_ERROR;
+
     m_hDataset = GDALOpenEx(m_fname.c_str(), nOpenFlags, nullptr,
                             dsoo.data(), nullptr);
 
@@ -410,8 +412,10 @@ bool GDALRaster::setProjection(const std::string &projection) {
     }
 
     if (GDALSetProjection(m_hDataset, projection.c_str()) == CE_Failure) {
-        if (!quiet)
+        if (!quiet) {
+            Rcpp::Rcerr << CPLGetLastErrorMsg() << std::endl;
             Rcpp::Rcerr << "set projection failed\n";
+        }
         return false;
     }
     else {
@@ -910,8 +914,10 @@ void GDALRaster::buildOverviews(const std::string &resampling,
                                     quiet ? nullptr : GDALTermProgressR,
                                     nullptr);
 
-    if (err == CE_Failure)
+    if (err == CE_Failure) {
+        Rcpp::Rcerr << CPLGetLastErrorMsg() << std::endl;
         Rcpp::stop("build overviews failed");
+    }
 }
 
 std::string GDALRaster::getDataTypeName(int band) const {
@@ -1633,8 +1639,10 @@ void GDALRaster::write(int band, int xoff, int yoff, int xsize, int ysize,
         Rcpp::stop("data must be a vector of 'numeric' or 'complex' or 'raw'");
     }
 
-    if (err == CE_Failure)
+    if (err == CE_Failure) {
+        Rcpp::Rcerr << CPLGetLastErrorMsg() << std::endl;
         Rcpp::stop("write to raster failed");
+    }
 }
 
 void GDALRaster::fillRaster(int band, double value, double ivalue) {

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -131,6 +131,8 @@ void GDALVector::open(bool read_only) {
     else
         nOpenFlags |= GDAL_OF_UPDATE;
 
+    nOpenFlags |= GDAL_OF_VERBOSE_ERROR;
+
     m_hDataset = GDALOpenEx(m_dsn.c_str(), nOpenFlags, nullptr,
                             dsoo.data(), nullptr);
     if (m_hDataset == nullptr)

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -1,4 +1,13 @@
 # Tests for src/gdalraster.cpp
+test_that("class constructors work as expected", {
+    # TODO
+    # ...
+
+    # not recognized as being in a supported file format
+    f <- system.file("extdata/doctype.xml", package="gdalraster")
+    expect_error(ds <- new(GDALRaster, f))
+})
+
 test_that("info() prints output to the console", {
     evt_file <- system.file("extdata/storml_evt.tif", package="gdalraster")
     ds <- new(GDALRaster, evt_file, TRUE)

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -53,6 +53,10 @@ test_that("class constructors work", {
 
     # default construstrctor with no arguments should not error
     expect_no_error(lyr <- new(GDALVector))
+
+    # not recognized as being in a supported file format
+    f <- system.file("extdata/doctype.xml", package="gdalraster")
+    expect_error(lyr <- new(GDALVector, f))
 })
 
 test_that("class basic interface works", {


### PR DESCRIPTION
Mainly adds the `GDAL_OF_VERBOSE_ERROR` open flag for `GDALOpenEx()` to give more informative feedback if a class constructor fails to open a dataset (in `GDALRaster` and `GDALVector`).

Adds the file inst/extdata/doctype.xml, copied from GDAL autotest, which is used there in some cases to test "not recognized as being in a supported file format".
