### PR TITLE
inspectDataset(): handle case of separate raster and vector drivers identified when specific flag was not given

### DIFF
--- a/man/inspectDataset.Rd
+++ b/man/inspectDataset.Rd
@@ -43,6 +43,10 @@ The return value is a list with named elements.
 Subdataset names are the character strings that can be used to
 instantiate \code{GDALRaster} objects.
 See https://gdal.org/en/stable/en/latest/user/raster_data_model.html#subdatasets-domain.
+
+PostgreSQL / PostGISRaster are handled as a special case. If additional
+arguments \code{raster} or \code{vector} are not given for \code{identifyDriver()}, then
+\code{raster = FALSE} is assumed.
 }
 \examples{
 f <- system.file("extdata/ynp_features.zip", package = "gdalraster")

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -2906,7 +2906,7 @@ SEXP identifyDriver(const Rcpp::CharacterVector &filename,
     std::string filename_in;
     filename_in = Rcpp::as<std::string>(check_gdal_filename(filename));
 
-    unsigned int nIdentifyFlags = GDAL_OF_ALL;
+    unsigned int nIdentifyFlags = GDAL_OF_RASTER | GDAL_OF_VECTOR;
     if (!raster && !vector)
         return R_NilValue;
     else if (!raster)

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -434,10 +434,14 @@ test_that("identifyDriver works", {
     expect_equal(identifyDriver(src), "GPKG")
     expect_equal(identifyDriver(src, raster = FALSE), "GPKG")
     expect_equal(identifyDriver(src, vector = FALSE), "GPKG")
-    expect_equal(identifyDriver(src), "GPKG")
     expect_equal(identifyDriver(src, allowed_drivers = c("GPKG", "GTiff")), "GPKG")
     expect_true(is.null(identifyDriver(src, allowed_drivers = c("GTiff", "GeoJSON"))))
     expect_equal(identifyDriver(src, file_list = "ynp_fires_1984_2022.gpkg"), "GPKG")
+
+    # PostGISRaster vs. PostgreSQL
+    dsn <- "PG:dbname='testdb', host='127.0.0.1' port='5444' user='user' password='pwd'"
+    expect_equal(identifyDriver(dsn), "PostGISRaster")
+    expect_equal(identifyDriver(dsn, raster = FALSE), "PostgreSQL")
 })
 
 test_that("flip_vertical works", {

--- a/tests/testthat/test-gdal_helpers.R
+++ b/tests/testthat/test-gdal_helpers.R
@@ -103,4 +103,29 @@ test_that("inspectDataset works", {
     expect_false(dsinfo$supports_vector)
     expect_false(dsinfo$contains_vector)
     expect_vector(dsinfo$layer_names, ptype = character(), size = 0)
+
+    # PostGISRaster / PostgreSQL
+    dsn <- "PG:dbname='testdb', host='127.0.0.1' port='5444' user='user'
+            password='pwd'"
+    dsinfo <- inspectDataset(dsn)
+    expect_equal(dsinfo$format, "PostgreSQL")
+    expect_false(dsinfo$supports_raster)
+    expect_false(dsinfo$contains_raster)
+    expect_false(dsinfo$supports_subdatasets)
+    expect_false(dsinfo$contains_subdatasets)
+    expect_true(dsinfo$supports_vector)
+    expect_false(dsinfo$contains_vector)
+    expect_vector(dsinfo$layer_names, ptype = character(), size = 0)
+
+    dsn <- "PG:dbname='testdb', host='127.0.0.1' port='5444' table='raster_tbl'
+            column='raster_col' user='user' password='pwd'"
+    dsinfo <- inspectDataset(dsn, vector = FALSE)
+    expect_equal(dsinfo$format, "PostGISRaster")
+    expect_true(dsinfo$supports_raster)
+    expect_false(dsinfo$contains_raster)
+    expect_true(dsinfo$supports_subdatasets)
+    expect_false(dsinfo$contains_subdatasets)
+    expect_false(dsinfo$supports_vector)
+    expect_false(dsinfo$contains_vector)
+    expect_vector(dsinfo$layer_names, ptype = character(), size = 0)
 })


### PR DESCRIPTION
e.g., GPKG supports raster and vector so there is no ambiguity when identifying the driver for a .gpkg file. But a DSN that is a connection string for a PostgreSQL database would imply either "PostgreSQL" vector driver or "PostGISRaster" raster driver, if the specific `raster` or `vector` arguments are not given. This PR adds code to handle that case. PostgreSQL is treated as a special case and vector is assumed if not specified. In other cases, an error is raised indicating that additional arguments for `identifyDriver()` are needed.