### PR TITLE
`get_cache_used()`: change return value to R numeric carrying the integer64 class attribute and add argument `units`

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -249,18 +249,22 @@ set_config_option <- function(key, value) {
 #' Get the size of memory in use by the GDAL block cache
 #'
 #' `get_cache_used()` returns the amount of memory currently in use for
-#' GDAL block caching. This a wrapper for `GDALGetCacheUsed64()` with return
-#' value as MB.
+#' GDAL block caching. Wrapper of `GDALGetCacheUsed64()` with return
+#' value in MB by default.
 #'
-#' @returns Integer. Amount of cache memory in use in MB.
+#' @param units Character string specifying units for the return value. One of
+#' `"MB"` (the default), `"GB"`, `"KB"` or `"bytes"` (values of `"byte"`,
+#' `"B"` and empty string `""` are also recognized to mean bytes).
+#' @returns Numeric value carrying the `integer64` class attribute. Amount of
+#' cache memory in use in the requested units.
 #'
 #' @seealso
 #' [GDAL Block Cache](https://usdaforestservice.github.io/gdalraster/articles/gdal-block-cache.html)
 #'
 #' @examples
 #' get_cache_used()
-get_cache_used <- function() {
-    .Call(`_gdalraster_get_cache_used`)
+get_cache_used <- function(units = "MB") {
+    .Call(`_gdalraster_get_cache_used`, units)
 }
 
 #' @noRd

--- a/man/get_cache_used.Rd
+++ b/man/get_cache_used.Rd
@@ -4,15 +4,21 @@
 \alias{get_cache_used}
 \title{Get the size of memory in use by the GDAL block cache}
 \usage{
-get_cache_used()
+get_cache_used(units = "MB")
+}
+\arguments{
+\item{units}{Character string specifying units for the return value. One of
+\code{"MB"} (the default), \code{"GB"}, \code{"KB"} or \code{"bytes"} (values of \code{"byte"},
+\code{"B"} and empty string \code{""} are also recognized to mean bytes).}
 }
 \value{
-Integer. Amount of cache memory in use in MB.
+Numeric value carrying the \code{integer64} class attribute. Amount of
+cache memory in use in the requested units.
 }
 \description{
 \code{get_cache_used()} returns the amount of memory currently in use for
-GDAL block caching. This a wrapper for \code{GDALGetCacheUsed64()} with return
-value as MB.
+GDAL block caching. Wrapper of \code{GDALGetCacheUsed64()} with return
+value in MB by default.
 }
 \examples{
 get_cache_used()

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -172,12 +172,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // get_cache_used
-int get_cache_used();
-RcppExport SEXP _gdalraster_get_cache_used() {
+Rcpp::NumericVector get_cache_used(std::string units);
+RcppExport SEXP _gdalraster_get_cache_used(SEXP unitsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    rcpp_result_gen = Rcpp::wrap(get_cache_used());
+    Rcpp::traits::input_parameter< std::string >::type units(unitsSEXP);
+    rcpp_result_gen = Rcpp::wrap(get_cache_used(units));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2038,7 +2039,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_gdal_formats", (DL_FUNC) &_gdalraster_gdal_formats, 1},
     {"_gdalraster_get_config_option", (DL_FUNC) &_gdalraster_get_config_option, 1},
     {"_gdalraster_set_config_option", (DL_FUNC) &_gdalraster_set_config_option, 2},
-    {"_gdalraster_get_cache_used", (DL_FUNC) &_gdalraster_get_cache_used, 0},
+    {"_gdalraster_get_cache_used", (DL_FUNC) &_gdalraster_get_cache_used, 1},
     {"_gdalraster_dump_open_datasets", (DL_FUNC) &_gdalraster_dump_open_datasets, 1},
     {"_gdalraster_push_error_handler", (DL_FUNC) &_gdalraster_push_error_handler, 1},
     {"_gdalraster_pop_error_handler", (DL_FUNC) &_gdalraster_pop_error_handler, 0},

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -225,10 +225,14 @@ void set_config_option(const std::string &key, const std::string &value) {
 //' Get the size of memory in use by the GDAL block cache
 //'
 //' `get_cache_used()` returns the amount of memory currently in use for
-//' GDAL block caching. This a wrapper for `GDALGetCacheUsed64()` with return
-//' value as MB.
+//' GDAL block caching. Wrapper of `GDALGetCacheUsed64()` with return
+//' value in MB by default.
 //'
-//' @returns Integer. Amount of cache memory in use in MB.
+//' @param units Character string specifying units for the return value. One of
+//' `"MB"` (the default), `"GB"`, `"KB"` or `"bytes"` (values of `"byte"`,
+//' `"B"` and empty string `""` are also recognized to mean bytes).
+//' @returns Numeric value carrying the `integer64` class attribute. Amount of
+//' cache memory in use in the requested units.
 //'
 //' @seealso
 //' [GDAL Block Cache](https://usdaforestservice.github.io/gdalraster/articles/gdal-block-cache.html)
@@ -236,9 +240,29 @@ void set_config_option(const std::string &key, const std::string &value) {
 //' @examples
 //' get_cache_used()
 // [[Rcpp::export]]
-int get_cache_used() {
-    GIntBig nCacheUsed = GDALGetCacheUsed64();
-    return static_cast<int>(nCacheUsed / (1000 * 1000));
+Rcpp::NumericVector get_cache_used(std::string units = "MB") {
+    int64_t nCacheUsed = static_cast<int64_t>(GDALGetCacheUsed64());
+    std::vector<int64_t> ret = {-1};
+
+    if (EQUAL(units.c_str(), "MB")) {
+        ret[0] = nCacheUsed / (1000 * 1000);
+    }
+    else if (EQUAL(units.c_str(), "GB")) {
+        ret[0] = nCacheUsed / (1000 * 1000 * 1000);
+    }
+    else if (EQUAL(units.c_str(), "KB")) {
+        ret[0] = nCacheUsed / (1000);
+    }
+    else if (EQUAL(units.c_str(), "") || EQUAL(units.c_str(), "B") ||
+             EQUAL(units.c_str(), "bytes") || EQUAL(units.c_str(), "byte")) {
+
+        ret[0] = nCacheUsed;
+    }
+    else {
+        Rcpp::stop("invalid value for 'units'");
+    }
+
+    return Rcpp::wrap(ret);
 }
 
 

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -238,7 +238,7 @@ int gdal_version_num();
 Rcpp::DataFrame gdal_formats(const std::string &fmt);
 std::string get_config_option(const std::string &key);
 void set_config_option(const std::string &key, const std::string &value);
-int get_cache_used();
+Rcpp::NumericVector get_cache_used(std::string units);
 int dump_open_datasets(const std::string &outfile);
 int get_num_cpus();
 Rcpp::NumericVector get_usable_physical_ram();

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -29,8 +29,8 @@ test_that("get/set_config_option work", {
     set_config_option("GDAL_CACHEMAX", co)
 })
 
-test_that("get_cache_used returns integer", {
-    expect_type(get_cache_used(), "integer")
+test_that("get_cache_used returns integer64", {
+    expect_s3_class(get_cache_used(), "integer64")
 })
 
 test_that("get_num_cpus returns integer", {


### PR DESCRIPTION
Previously this function returned an integer value in MB. This PR adds the argument `units` with default of MB, adding the option to return in bytes, KB or GB. The return value is now int64 (R numeric type carrying the integer64 class attribute).

> Get the size of memory in use by the GDAL block cache
>
> `get_cache_used()` returns the amount of memory currently in use for
> GDAL block caching. Wrapper of `GDALGetCacheUsed64()` with return
> value in MB by default.
> 
> @param units Character string specifying units for the return value. One of
> `"MB"` (the default), `"GB"`, `"KB"` or `"bytes"` (values of `"byte"`,
> `"B"` and empty string `""` are also recognized to mean bytes).
> @returns Numeric value carrying the `integer64` class attribute. Amount of
> cache memory in use in the requested units.