### PR TITLE
Doc: add missing option in `GDALVector::arrowStreamOptions`

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -210,6 +210,8 @@
 #' the GDAL API documentation for
 #' [OGR_L_GetArrowStream()](https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_GetArrowStream9OGRLayerHP16ArrowArrayStreamPPc).
 #' * INCLUDE_FID=YES/NO. Defaults to YES.
+#' * MAX_FEATURES_IN_BATCH=integer. Maximum number of features to retrieve in
+#' an ArrowArray batch. Defaults to 65536.
 #' * TIMEZONE=unknown/UTC/(+|:)HH:MM or any other value supported by
 #' Arrow (GDAL >= 3.8).
 #' * GEOMETRY_METADATA_ENCODING=OGC/GEOARROW (GDAL >= 3.8). The GDAL default is

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -227,6 +227,8 @@ the GDAL API documentation for
 \href{https://gdal.org/en/stable/api/vector_c_api.html#_CPPv420OGR_L_GetArrowStream9OGRLayerHP16ArrowArrayStreamPPc}{OGR_L_GetArrowStream()}.
 \itemize{
 \item INCLUDE_FID=YES/NO. Defaults to YES.
+\item MAX_FEATURES_IN_BATCH=integer. Maximum number of features to retrieve in
+an ArrowArray batch. Defaults to 65536.
 \item TIMEZONE=unknown/UTC/(+|:)HH:MM or any other value supported by
 Arrow (GDAL >= 3.8).
 \item GEOMETRY_METADATA_ENCODING=OGC/GEOARROW (GDAL >= 3.8). The GDAL default is


### PR DESCRIPTION
Add missing option in the list:
* MAX_FEATURES_IN_BATCH=integer. Maximum number of features to retrieve in an ArrowArray batch. Defaults to 65536.