### PR TITLE
configure: remove configuration of PROJ include directory and libs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install macOS system dependencies
         if: runner.os == 'macOS'
-        run: brew install gdal proj
+        run: brew install gdal
 
       - uses: r-lib/actions/setup-r-dependencies@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Suggests:
     scales,
     testthat (>= 3.0.0)
 NeedsCompilation: yes
-SystemRequirements: C++17, GDAL (>= 3.1.0, built against GEOS), PROJ, libxml2
+SystemRequirements: C++17, GDAL (>= 3.1.0, built against GEOS)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/README.Rmd
+++ b/README.Rmd
@@ -116,8 +116,10 @@ remotes::install_github("USDAForestService/gdalraster")
 GDAL can be installed with Homebrew:
 
 ```
-brew install pkg-config gdal
+brew install gdal
 ```
+
+then
 
 ```{r, eval=FALSE}
 # Install the development version from GitHub

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,14 +74,14 @@ CRAN provides pre-compiled binary packages for Windows and macOS. These do not r
 
 #### Linux
 
-GDAL >= 3.1.0 built with GEOS is required, but a more recent GDAL version is recommended (e.g., >= 3.6.4). GDAL as of version 3.9 requires PROJ >= 6.3.1, but a more recent version of PROJ is also recommended. PROJ requires sqlite3, and libxml2 is required for the imported R package **xml2**.
+GDAL >= 3.1.0 built with GEOS is required, but a more recent version is recommended.
 
-On Ubuntu, recent versions of geospatial libraries can be installed from the [ubuntugis-unstable PPA](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable) with the following commands:
+On Ubuntu, recent versions of geospatial libraries can be installed from the [ubuntugis-unstable PPA](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable) with the following commands. Note that libxml2 is required for the R package **xml2** which is a dependency, so we go ahead and install it here as well:
 
 ```
 sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
 sudo apt update
-sudo apt install libgdal-dev libgeos-dev libproj-dev libsqlite3-dev libxml2-dev
+sudo apt install libgdal-dev libgeos-dev libxml2-dev
 ```
 
 The versions in ubuntugis-unstable generally work well and are more up-to-date, but less recent versions in the [ubuntugis-stable PPA](https://launchpad.net/~ubuntugis/+archive/ubuntu/ppa) could be used instead.
@@ -102,7 +102,7 @@ remotes::install_github("USDAForestService/gdalraster")
 
 #### Windows
 
-[RTools](https://cran.r-project.org/bin/windows/Rtools/) is needed to install from source on Windows. RTools since version 4.2 includes GDAL, PROJ and all other dependent libraries that are needed to compile **gdalraster**. Note that CRAN releases periodic revisions to RTools that often include updates to the libraries as new versions become available. [Release 6459](https://cran.r-project.org/bin/windows/Rtools/rtools44/rtools.html) of RTools 4.4 contains GDAL 3.10.1, GEOS 3.13.0 and PROJ 9.5.1.
+[RTools](https://cran.r-project.org/bin/windows/Rtools/) is needed to install from source on Windows. RTools since version 4.2 includes GDAL and all other dependent libraries that are needed to compile **gdalraster**. Note that CRAN releases periodic revisions to RTools that often include updates to the libraries as new versions become available. [Release 6459](https://cran.r-project.org/bin/windows/Rtools/rtools44/rtools.html) of RTools 4.4 contains GDAL 3.10.1, GEOS 3.13.0 and PROJ 9.5.1.
 
 With RTools installed:
 
@@ -113,20 +113,18 @@ remotes::install_github("USDAForestService/gdalraster")
 
 #### macOS
 
-GDAL and PROJ can be installed with Homebrew:
+GDAL can be installed with Homebrew:
 
 ```
-brew install pkg-config gdal proj
+brew install pkg-config gdal
 ```
-
-Then `configure.args` may be needed:
 
 ```{r, eval=FALSE}
 # Install the development version from GitHub
-remotes::install_github("USDAForestService/gdalraster", configure.args = "--with-proj-lib=$(brew --prefix)/lib/")
+remotes::install_github("USDAForestService/gdalraster")
 ```
 
-Caution seems warranted on macOS with regard to mixing a source installation with installation of binaries from CRAN.
+Caution is warranted on macOS with regard to mixing a source installation with installation of binaries from CRAN. Consider installing the development version from R-universe instead.
 
 ### From R-universe
 

--- a/README.md
+++ b/README.md
@@ -112,20 +112,19 @@ do not require any separate installation of external libraries for GDAL.
 
 #### Linux
 
-GDAL \>= 3.1.0 built with GEOS is required, but a more recent GDAL
-version is recommended (e.g., \>= 3.6.4). GDAL as of version 3.9
-requires PROJ \>= 6.3.1, but a more recent version of PROJ is also
-recommended. PROJ requires sqlite3, and libxml2 is required for the
-imported R package **xml2**.
+GDAL \>= 3.1.0 built with GEOS is required, but a more recent version is
+recommended.
 
 On Ubuntu, recent versions of geospatial libraries can be installed from
 the [ubuntugis-unstable
 PPA](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable)
-with the following commands:
+with the following commands. Note that libxml2 is required for the R
+package **xml2** which is a dependency, so we go ahead and install it
+here as well:
 
     sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
     sudo apt update
-    sudo apt install libgdal-dev libgeos-dev libproj-dev libsqlite3-dev libxml2-dev
+    sudo apt install libgdal-dev libgeos-dev libxml2-dev
 
 The versions in ubuntugis-unstable generally work well and are more
 up-to-date, but less recent versions in the [ubuntugis-stable
@@ -152,8 +151,8 @@ remotes::install_github("USDAForestService/gdalraster")
 #### Windows
 
 [RTools](https://cran.r-project.org/bin/windows/Rtools/) is needed to
-install from source on Windows. RTools since version 4.2 includes GDAL,
-PROJ and all other dependent libraries that are needed to compile
+install from source on Windows. RTools since version 4.2 includes GDAL
+and all other dependent libraries that are needed to compile
 **gdalraster**. Note that CRAN releases periodic revisions to RTools
 that often include updates to the libraries as new versions become
 available. [Release
@@ -169,19 +168,18 @@ remotes::install_github("USDAForestService/gdalraster")
 
 #### macOS
 
-GDAL and PROJ can be installed with Homebrew:
+GDAL can be installed with Homebrew:
 
-    brew install pkg-config gdal proj
-
-Then `configure.args` may be needed:
+    brew install pkg-config gdal
 
 ``` r
 # Install the development version from GitHub
-remotes::install_github("USDAForestService/gdalraster", configure.args = "--with-proj-lib=$(brew --prefix)/lib/")
+remotes::install_github("USDAForestService/gdalraster")
 ```
 
-Caution seems warranted on macOS with regard to mixing a source
-installation with installation of binaries from CRAN.
+Caution is warranted on macOS with regard to mixing a source
+installation with installation of binaries from CRAN. Consider
+installing the development version from R-universe instead.
 
 ### From R-universe
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ remotes::install_github("USDAForestService/gdalraster")
 
 GDAL can be installed with Homebrew:
 
-    brew install pkg-config gdal
+    brew install gdal
+
+then
 
 ``` r
 # Install the development version from GitHub

--- a/configure
+++ b/configure
@@ -649,8 +649,6 @@ ac_includes_default="\
 ac_header_cxx_list=
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
-PROJ_LIBS
-PROJ_CPPFLAGS
 OBJEXT
 EXEEXT
 ac_ct_CXX
@@ -707,8 +705,6 @@ enable_option_checking
 with_gdal_config
 with_data_copy
 with_proj_data
-with_proj_include
-with_proj_lib
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1341,9 +1337,6 @@ Optional Packages:
   --with-data-copy=yes/no local copy of data directories in package, default
                           no
   --with-proj-data=DIR    location of PROJ data directory
-  --with-proj-include=DIR location of proj header files
-  --with-proj-lib=LIB_PATH
-                          the location of proj libraries
 
 Some influential environment variables:
   CXX         C++ compiler command
@@ -2922,11 +2915,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -2968,11 +2961,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -3256,61 +3249,9 @@ printf "%s\n" "$as_me:   GDAL: ${GDAL_DATADIR}" >&6;}
   fi
 fi
 
-#
-# PROJ include dir
-#
+PKG_CPPFLAGS="${INPKG_CPPFLAGS} ${GDAL_CPPFLAGS}"
 
-
-# Check whether --with-proj-include was given.
-if test ${with_proj_include+y}
-then :
-  withval=$with_proj_include; proj_include_path=$withval
-fi
-
-if test  -n "$proj_include_path"  ; then
-   PROJ_CPPFLAGS="-I${proj_include_path}"
-
-else
-  if test "${proj_config_ok}" = yes; then
-    PROJ_INCLUDE_PATH=`${PROJ_CONFIG} --cflags`
-    PROJ_CPPFLAGS="${PROJ_INCLUDE_PATH}"
-
-  fi
-fi
-
-#
-# PROJ libs
-#
-
-
-# Check whether --with-proj-lib was given.
-if test ${with_proj_lib+y}
-then :
-  withval=$with_proj_lib; proj_lib_path=$withval
-fi
-
-if test  -n "$proj_lib_path"  ; then
-    PROJ_LIBS="-L${proj_lib_path} ${INPKG_LIBS} -lproj"
-
-else
-  if test "${proj_config_ok}" = yes; then
-    if test `uname` = "Darwin"; then
-      PROJ_LIB_PATH=`${PROJ_CONFIG} --libs --static`
-    else
-      PROJ_LIB_PATH=`${PROJ_CONFIG} --libs`
-    fi
-    PROJ_LIBS="${PROJ_LIB_PATH}"
-    proj_version=`${PROJ_CONFIG} --modversion`
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: PROJ: ${proj_version}" >&5
-printf "%s\n" "$as_me: PROJ: ${proj_version}" >&6;}
-  else
-    PROJ_LIBS="-lproj"
-  fi
-fi
-
-PKG_CPPFLAGS="${INPKG_CPPFLAGS} ${PROJ_CPPFLAGS} ${GDAL_CPPFLAGS}"
-
-PKG_LIBS="${INPKG_LIBS} ${GDAL_LIBS} ${PROJ_LIBS}"
+PKG_LIBS="${INPKG_LIBS} ${GDAL_LIBS}"
 
 if test "${NEED_DEPS}" = yes; then
    PKG_LIBS="${PKG_LIBS} ${GDAL_DEP_LIBS}"
@@ -3318,7 +3259,7 @@ if test "${NEED_DEPS}" = yes; then
 fi
 
 CPPFLAGS="${INCPPFLAGS} ${PKG_CPPFLAGS}"
-LIBS="${LIBS} ${PROJ_LIBS}"
+LIBS="${LIBS}"
 
 #
 # test whether PROJ is available to gdal:
@@ -3339,33 +3280,6 @@ int main(int argc, char *argv[]) {
   return(ct == NULL); // signals PROJ is not available via GDAL
 }
 _EOCONF
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking GDAL: checking whether PROJ is available for linking:" >&5
-printf %s "checking GDAL: checking whether PROJ is available for linking:... " >&6; }
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-`cat gdal_proj.cpp`
-_ACEOF
-if ac_fn_cxx_try_link "$LINENO"
-then :
-  gdal_has_proj=yes
-else $as_nop
-  gdal_has_proj=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-if test "${gdal_has_proj}" = no; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-  rm -f gdal_proj.cpp
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Install failure: compilation and/or linkage problems." >&5
-printf "%s\n" "$as_me: Install failure: compilation and/or linkage problems." >&6;}
-  as_fn_error $? "cannot link projection code" "$LINENO" 5
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking GDAL: checking whether PROJ is available at runtime:" >&5
 printf %s "checking GDAL: checking whether PROJ is available at runtime:... " >&6; }
@@ -3400,7 +3314,6 @@ else
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 fi
-
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Package CPP flags: ${PKG_CPPFLAGS}" >&5
 printf "%s\n" "$as_me: Package CPP flags: ${PKG_CPPFLAGS}" >&6;}

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@
 # 2024-03-12: restore proj_include_path and proj_lib_path
 # 2024-03-17: rework GEOS test, include <ogr_api.h> in initial gdal_test.cpp
 # 2025-02-26: fix test for GDAL >= 3.1.0
+# 2025-04-25: drop PROJ include directory and libs since we require GDAL >= 3.1
 
 AC_INIT([gdalraster],[1.12.0.9000],[chris.toney@usda.gov])
 AC_LANG(C++)
@@ -281,54 +282,14 @@ AC_MSG_NOTICE([Copy data for:])
   fi
 fi
 
-#
-# PROJ include dir
-#
-
-AC_ARG_WITH([proj-include],
-    AS_HELP_STRING([--with-proj-include=DIR],[location of proj header files]),
-    [proj_include_path=$withval])
-if test [ -n "$proj_include_path" ] ; then
-   AC_SUBST([PROJ_CPPFLAGS],["-I${proj_include_path}"])
-else
-  if test "${proj_config_ok}" = yes; then
-    PROJ_INCLUDE_PATH=`${PROJ_CONFIG} --cflags`
-    AC_SUBST([PROJ_CPPFLAGS],["${PROJ_INCLUDE_PATH}"])
-  fi
-fi
-
-#
-# PROJ libs
-#
-
-AC_ARG_WITH([proj-lib],
-    AS_HELP_STRING([--with-proj-lib=LIB_PATH],[the location of proj libraries]),
-               [proj_lib_path=$withval])
-if test [ -n "$proj_lib_path" ] ; then
-    AC_SUBST([PROJ_LIBS], ["-L${proj_lib_path} ${INPKG_LIBS} -lproj"])
-else
-  if test "${proj_config_ok}" = yes; then
-    if test `uname` = "Darwin"; then
-      PROJ_LIB_PATH=`${PROJ_CONFIG} --libs --static`
-    else
-      PROJ_LIB_PATH=`${PROJ_CONFIG} --libs`
-    fi
-    PROJ_LIBS="${PROJ_LIB_PATH}"
-    proj_version=`${PROJ_CONFIG} --modversion`
-    AC_MSG_NOTICE([PROJ: ${proj_version}])
-  else
-    PROJ_LIBS="-lproj"
-  fi
-fi
-
-AC_SUBST([PKG_CPPFLAGS], ["${INPKG_CPPFLAGS} ${PROJ_CPPFLAGS} ${GDAL_CPPFLAGS}"])
-AC_SUBST([PKG_LIBS], ["${INPKG_LIBS} ${GDAL_LIBS} ${PROJ_LIBS}"])
+AC_SUBST([PKG_CPPFLAGS], ["${INPKG_CPPFLAGS} ${GDAL_CPPFLAGS}"])
+AC_SUBST([PKG_LIBS], ["${INPKG_LIBS} ${GDAL_LIBS}"])
 if test "${NEED_DEPS}" = yes; then
    AC_SUBST([PKG_LIBS], ["${PKG_LIBS} ${GDAL_DEP_LIBS}"])
 fi
 
 CPPFLAGS="${INCPPFLAGS} ${PKG_CPPFLAGS}"
-LIBS="${LIBS} ${PROJ_LIBS}"
+LIBS="${LIBS}"
 
 #
 # test whether PROJ is available to gdal:
@@ -350,21 +311,6 @@ int main(int argc, char *argv[]) {
 }
 _EOCONF]
 
-AC_MSG_CHECKING(GDAL: checking whether PROJ is available for linking:)
-AC_LINK_IFELSE(
-   [AC_LANG_SOURCE([`cat gdal_proj.cpp`])],
-   gdal_has_proj=yes,
-   gdal_has_proj=no
-)
-if test "${gdal_has_proj}" = no; then
-  AC_MSG_RESULT(no)
-  rm -f gdal_proj.cpp
-  AC_MSG_NOTICE([Install failure: compilation and/or linkage problems.])
-  AC_MSG_ERROR([cannot link projection code])
-else
-  AC_MSG_RESULT(yes)
-fi
-
 AC_MSG_CHECKING(GDAL: checking whether PROJ is available at runtime:)
 AC_RUN_IFELSE(
    [AC_LANG_SOURCE([`cat gdal_proj.cpp`])],
@@ -381,7 +327,6 @@ elif test "${gdal_has_proj}" = cross_compiling; then
 else
   AC_MSG_RESULT(yes)
 fi
-
 
 AC_MSG_NOTICE([Package CPP flags: ${PKG_CPPFLAGS}])
 AC_MSG_NOTICE([Package LIBS: ${PKG_LIBS}])

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,8 +1,3 @@
-PKG_CPPFLAGS = \
-	-DHAVE_PROJ_H
-
-TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
-
 ifeq (,$(shell pkg-config --version 2>/dev/null))
   LIBSHARPYUV = $(or $(and $(wildcard $(R_TOOLS_SOFT)/lib/libsharpyuv.a),-lsharpyuv),)
 


### PR DESCRIPTION
External PROJ is not needed since gdalraster now requires GDAL >= 3.1. PROJ has been a GDAL build requirement since 3.0, and gdalraster only uses PROJ via GDAL headers (i.e., we use GDAL's libinternalproj). This PR removes configuration of the PROJ include directory and libs in configure.ac. Optional local copies of the GDAL and PROJ data directories are still supported. PROJ availability to GDAL at runtime is also still tested in configure, but link testing is removed. The DESCRIPTION file removes PROJ as a separate dependency in the SystemRequirements list (and also removes libxml2 since it is  only an indirect system requirement for the imported package xml2). The README file is updated to remove references to external PROJ as a dependency.