### PR TITLE
inspectDataset() and warp(): wrap checks of raster dataset open in quiet error handler

### DIFF
--- a/R/gdal_helpers.R
+++ b/R/gdal_helpers.R
@@ -695,7 +695,9 @@ inspectDataset <- function(filename, ...) {
     out$supports_raster <- fmt_info$raster
     out$contains_raster <- FALSE
     if (out$supports_raster) {
+        push_error_handler("quiet")
         ds <- try(new(GDALRaster, filename_in), silent = TRUE)
+        pop_error_handler()
         if (is(ds, "Rcpp_GDALRaster"))
             out$contains_raster <- TRUE
     }

--- a/R/gdal_util.R
+++ b/R/gdal_util.R
@@ -314,7 +314,9 @@ warp <- function(src_files,
         stop("'dst_filename' must be a character string or GDALRaster object",
              call. = FALSE)
     } else {
+        push_error_handler("quiet")
         ds <- try(new(GDALRaster, dst_filename), silent = TRUE)
+        pop_error_handler()
         if (is(ds, "Rcpp_GDALRaster") && t_srs == "") {
             t_srs <- ds$getProjection()
             ds$close()


### PR DESCRIPTION
Doing checks of the form:
```r
ds <- try(new(GDALRaster, filename_in), silent = TRUE)
if (is(ds, "Rcpp_GDALRaster"))
    # ...
```

are now wrapped with
```r
push_error_handler("quiet")
ds <- try(new(GDALRaster, filename_in), silent = TRUE)
pop_error_handler()
if (is(ds, "Rcpp_GDALRaster"))
        # ...
```

to suppress unnecessary error message from GDAL when `filename_in` does not already exists or is not a raster dataset.