### PR TITLE
Avoid clang-asan error from CPLString implicitly wrapped as an R character vector

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -533,7 +533,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // ogrinfo
-std::string ogrinfo(const Rcpp::CharacterVector& dsn, const Rcpp::Nullable<Rcpp::CharacterVector>& layers, const Rcpp::Nullable<Rcpp::CharacterVector>& cl_arg, const Rcpp::Nullable<Rcpp::CharacterVector>& open_options, bool read_only, bool cout);
+Rcpp::String ogrinfo(const Rcpp::CharacterVector& dsn, const Rcpp::Nullable<Rcpp::CharacterVector>& layers, const Rcpp::Nullable<Rcpp::CharacterVector>& cl_arg, const Rcpp::Nullable<Rcpp::CharacterVector>& open_options, bool read_only, bool cout);
 RcppExport SEXP _gdalraster_ogrinfo(SEXP dsnSEXP, SEXP layersSEXP, SEXP cl_argSEXP, SEXP open_optionsSEXP, SEXP read_onlySEXP, SEXP coutSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -1917,15 +1917,15 @@ bool ogr2ogr(const Rcpp::CharacterVector &src_dsn,
 //' args <- c("-dialect", "sqlite", "-sql", sql)
 //' ogrinfo(src_mem, cl_arg = args, read_only = FALSE)
 // [[Rcpp::export(invisible = true)]]
-std::string ogrinfo(const Rcpp::CharacterVector &dsn,
-                    const Rcpp::Nullable<Rcpp::CharacterVector> &layers =
+Rcpp::String ogrinfo(const Rcpp::CharacterVector &dsn,
+                     const Rcpp::Nullable<Rcpp::CharacterVector> &layers =
                             R_NilValue,
-                    const Rcpp::Nullable<Rcpp::CharacterVector> &cl_arg =
+                     const Rcpp::Nullable<Rcpp::CharacterVector> &cl_arg =
                             Rcpp::CharacterVector::create("-so", "-nomd"),
-                    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options =
+                     const Rcpp::Nullable<Rcpp::CharacterVector> &open_options =
                             R_NilValue,
-                    bool read_only = true,
-                    bool cout = true) {
+                     bool read_only = true,
+                     bool cout = true) {
 
 #if GDAL_VERSION_NUM < 3070000
     Rcpp::stop("ogrinfo() requires GDAL >= 3.7");
@@ -1982,23 +1982,23 @@ std::string ogrinfo(const Rcpp::CharacterVector &dsn,
         Rcpp::stop("ogrinfo() failed (could not create options struct)");
     }
 
-    CPLString info_out = "";
+    Rcpp::String info_out = "";
     char *pszInfo = GDALVectorInfo(src_ds, psOptions);
     if (pszInfo != nullptr)
         info_out = pszInfo;
 
-    CPLFree(pszInfo);
     GDALVectorInfoOptionsFree(psOptions);
     GDALReleaseDataset(src_ds);
 
     if (cout)
-        Rcpp::Rcout << info_out;
+        Rcpp::Rcout << info_out.get_cstring();
 
     if (as_json)
-        info_out.replaceAll('\n', ' ');
+        info_out.replace_all("\n", " ");
+
+    CPLFree(pszInfo);
 
     return info_out;
-
 #endif
 }
 

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -228,7 +228,7 @@ void GDALRaster::info() const {
     CPLFree(pszGDALInfoOutput);
 }
 
-std::string GDALRaster::infoAsJSON() const {
+Rcpp::String GDALRaster::infoAsJSON() const {
     checkAccess_(GA_ReadOnly);
 
     const Rcpp::CharacterVector argv = infoOptions;
@@ -253,14 +253,14 @@ std::string GDALRaster::infoAsJSON() const {
         Rcpp::stop("creation of GDALInfoOptions failed (check $infoOptions)");
 
     char *pszGDALInfoOutput = GDALInfo(m_hDataset, psOptions);
-    CPLString out = "";
+    Rcpp::String out = "";
     if (pszGDALInfoOutput != nullptr)
         out = pszGDALInfoOutput;
 
     GDALInfoOptionsFree(psOptions);
-    CPLFree(pszGDALInfoOutput);
 
-    out.replaceAll('\n', ' ');
+    out.replace_all("\n", " ");
+    CPLFree(pszGDALInfoOutput);
 
     return out;
 }

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -113,7 +113,7 @@ class GDALRaster {
     Rcpp::CharacterVector getFileList() const;
 
     void info() const;
-    std::string infoAsJSON() const;
+    Rcpp::String infoAsJSON() const;
 
     std::string getDriverShortName() const;
     std::string getDriverLongName() const;
@@ -372,12 +372,12 @@ bool ogr2ogr(const Rcpp::CharacterVector &src_dsn,
              const Rcpp::Nullable<Rcpp::CharacterVector> &cl_arg,
              const Rcpp::Nullable<Rcpp::CharacterVector> &open_options);
 
-std::string ogrinfo(const Rcpp::CharacterVector &dsn,
-                    const Rcpp::Nullable<Rcpp::CharacterVector> &layers,
-                    const Rcpp::Nullable<Rcpp::CharacterVector> &cl_arg,
-                    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options,
-                    bool read_only,
-                    bool cout);
+Rcpp::String ogrinfo(const Rcpp::CharacterVector &dsn,
+                     const Rcpp::Nullable<Rcpp::CharacterVector> &layers,
+                     const Rcpp::Nullable<Rcpp::CharacterVector> &cl_arg,
+                     const Rcpp::Nullable<Rcpp::CharacterVector> &open_options,
+                     bool read_only,
+                     bool cout);
 
 bool polygonize(const Rcpp::CharacterVector &src_filename, int src_band,
                 const Rcpp::CharacterVector &out_dsn,

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -241,12 +241,14 @@ void GDALVector::info() const {
         if (m_is_sql) {
             cl_arg.push_back("-sql");
             cl_arg.push_back(m_layer_name);
-            Rcpp::Rcout << ogrinfo(m_dsn, R_NilValue, cl_arg, m_open_options,
-                                   true, false);
+            Rcpp::String out = ogrinfo(m_dsn, R_NilValue, cl_arg,
+                                       m_open_options, true, false);
+            Rcpp::Rcout << out.get_cstring();
         }
         else {
-            Rcpp::Rcout << ogrinfo(m_dsn, Rcpp::wrap(m_layer_name), cl_arg,
-                                   m_open_options, true, false);
+            Rcpp::String out = ogrinfo(m_dsn, Rcpp::wrap(m_layer_name), cl_arg,
+                                       m_open_options, true, false);
+            Rcpp::Rcout << out.get_cstring();
         }
     }
     else {


### PR DESCRIPTION
Avoids clang-asan / clang-ubsan errors due to the changes in #714 (i.e., at dev version 2.0.0.9000, not in released version). This PR uses `Rcpp::String` instead of `CPLString` in `GDALRaster::infoAsJSON()` and `ogrinfo()` (no longer attempts implicit wrapping of a `CPLString` object as R character vector).

gcc-asan did not report errors, but:

clang-ubsan
```
UndefinedBehaviorSanitizer:DEADLYSIGNAL
==6352==ERROR: UndefinedBehaviorSanitizer: SEGV on unknown address 0x000000000c99 (pc 0x7f8e3e7422e0 bp 0x7ffd70bd8a70 sp 0x7ffd70bd8238 T6352)
==6352==The signal is caused by a READ memory access.
==6352==Hint: address points to the zero page.
...
```

clang-asan
```
   *** caught segfault ***
  address 0xc99, cause 'memory not mapped'
  
  Traceback:
   1: .External(list(name = "CppMethod__invoke_notvoid", address = <pointer: 0x503000024400>,     dll = list(name = "Rcpp", path = "/github/home/R/x86_64-pc-linux-gnu-library/4.6/Rcpp/libs/Rcpp.so",         dynamicLookup = TRUE, handle = <pointer: 0x51a0000b9480>,         info = <pointer: 0x508000000fa0>, forceSymbols = FALSE),     numParameters = -1L), <pointer: 0x511000153280>, <pointer: 0x503000047050>,     .pointer)
   2: ds$infoAsJSON()
...
```
