### PR TITLE
`g_envelope()`: fix order of xy coordinates in the returned envelope vector(s) and add argument `as_3d`

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2308,8 +2308,8 @@ has_geos <- function() {
 }
 
 #' @noRd
-.g_envelope <- function(geom, quiet = FALSE) {
-    .Call(`_gdalraster_g_envelope`, geom, quiet)
+.g_envelope <- function(geom, as_3d = FALSE, quiet = FALSE) {
+    .Call(`_gdalraster_g_envelope`, geom, as_3d, quiet)
 }
 
 #' @noRd

--- a/man/g_envelope.Rd
+++ b/man/g_envelope.Rd
@@ -2,23 +2,29 @@
 % Please edit documentation in R/geom.R
 \name{g_envelope}
 \alias{g_envelope}
-\title{Obtain the bounding envelope for input geometries}
+\title{Obtain the 2D or 3D bounding envelope for input geometries}
 \usage{
-g_envelope(geom, quiet = FALSE)
+g_envelope(geom, as_3d = FALSE, quiet = FALSE)
 }
 \arguments{
 \item{geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings.}
 
+\item{as_3d}{Logical value. \code{TRUE} to return the 3D bounding envelope.
+The 2D envelope is returned by default (\code{as_3d = FALSE}).}
+
 \item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
 \value{
-Either a numeric vector of length 4 containing the envelope
-\verb{(xmin, xmax, ymin, ymax)}, or a four-column numeric matrix with number of
-rows equal to the number of input geometries and column names
-\verb{("xmin", "xmax", "ymin", "ymax")}.
+Either a numeric vector of length \code{4} containing the 2D envelope
+\verb{(xmin, xmax, ymin, ymax)} or of length \code{6} containing the 3D envelope
+\verb{(xmin, xmax, ymin, ymax, zmin, zmax)}, or a four-column or six-column
+numeric matrix with number of rows equal to the number of input geometries
+and column names \verb{("xmin", "xmax", "ymin", "ymax")}, or
+\verb{("xmin", "xmax", "ymin", "ymax", "zmin", "zmax")} for the 3D case.
 }
 \description{
 \code{g_envelope()} computes and returns the bounding envelope(s) for the input
-geometries. Wrapper of \code{OGR_G_GetEnvelope()} in GDAL OGRGeometry.
+geometries. Wrapper of \code{OGR_G_GetEnvelope()} / \code{OGR_G_GetEnvelope3D()} in
+the GDAL Geometry API.
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1204,14 +1204,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_envelope
-Rcpp::NumericVector g_envelope(const Rcpp::RawVector& geom, bool quiet);
-RcppExport SEXP _gdalraster_g_envelope(SEXP geomSEXP, SEXP quietSEXP) {
+Rcpp::NumericVector g_envelope(const Rcpp::RawVector& geom, bool as_3d, bool quiet);
+RcppExport SEXP _gdalraster_g_envelope(SEXP geomSEXP, SEXP as_3dSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_3d(as_3dSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
-    rcpp_result_gen = Rcpp::wrap(g_envelope(geom, quiet));
+    rcpp_result_gen = Rcpp::wrap(g_envelope(geom, as_3d, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2157,7 +2158,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_is_measured", (DL_FUNC) &_gdalraster_g_is_measured, 2},
     {"_gdalraster_g_name", (DL_FUNC) &_gdalraster_g_name, 2},
     {"_gdalraster_g_summary", (DL_FUNC) &_gdalraster_g_summary, 2},
-    {"_gdalraster_g_envelope", (DL_FUNC) &_gdalraster_g_envelope, 2},
+    {"_gdalraster_g_envelope", (DL_FUNC) &_gdalraster_g_envelope, 3},
     {"_gdalraster_g_intersects", (DL_FUNC) &_gdalraster_g_intersects, 3},
     {"_gdalraster_g_equals", (DL_FUNC) &_gdalraster_g_equals, 3},
     {"_gdalraster_g_disjoint", (DL_FUNC) &_gdalraster_g_disjoint, 3},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -55,7 +55,7 @@ Rcpp::LogicalVector g_is_3D(const Rcpp::RawVector &geom, bool quiet);
 Rcpp::LogicalVector g_is_measured(const Rcpp::RawVector &geom, bool quiet);
 SEXP g_name(const Rcpp::RawVector &geom, bool quiet);
 SEXP g_summary(const Rcpp::RawVector &geom, bool quiet);
-Rcpp::NumericVector g_envelope(const Rcpp::RawVector &geom,
+Rcpp::NumericVector g_envelope(const Rcpp::RawVector &geom, bool as_3d,
                                bool quiet);
 
 Rcpp::LogicalVector g_intersects(const Rcpp::RawVector &this_geom,

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -540,7 +540,7 @@ test_that("geometry properties are correct", {
     res <- bbox_to_wkt(bb) |> g_envelope()
     expect_equal(names(res), c("xmin", "xmax", "ymin", "ymax"))
     names(res) <- NULL
-    expect_equal(res, bb)
+    expect_equal(res, c(bb[1], bb[3], bb[2], bb[4]))
 
     # input as vector of WKT / list of WKB
     wkt_vec <- c(g1, g2, g3)
@@ -569,24 +569,34 @@ test_that("geometry properties are correct", {
     expect_true(g_is_measured(pt3))
 
     # g_envelope
-    bb1_2 <- c(0, 0, 10, 10)
-    bb3 <- c(0, 0, 0, 0)
-    bb_mat <- rbind(bb1_2, bb1_2, bb3)
-    colnames(bb_mat) <- c("xmin", "xmax", "ymin", "ymax")
-    dimnames(bb_mat) <- NULL
-    names(bb1_2) <- c("xmin", "xmax", "ymin", "ymax")
-    names(bb3) <- c("xmin", "xmax", "ymin", "ymax")
-    expect_equal(g_envelope(g1), bb1_2)
-    expect_equal(g_envelope(g2), bb1_2)  # same as g1 but g2 is invalid geom
-    expect_equal(g_envelope(g3), bb3)
+    env1_2 <- c(0, 10, 0, 10)
+    env3 <- c(0, 0, 0, 0)
+    env_mat <- rbind(env1_2, env1_2, env3)
+    colnames(env_mat) <- c("xmin", "xmax", "ymin", "ymax")
+    dimnames(env_mat) <- NULL
+    names(env1_2) <- c("xmin", "xmax", "ymin", "ymax")
+    names(env3) <- c("xmin", "xmax", "ymin", "ymax")
+    expect_equal(g_envelope(g1), env1_2)
+    expect_equal(g_envelope(g2), env1_2)  # same as g1 but g2 is invalid geom
+    expect_equal(g_envelope(g3), env3)
     wkt_vec <- c(g1, g2, g3)
     res <- g_envelope(wkt_vec)
     dimnames(res) <- NULL
-    expect_equal(res, bb_mat)
+    expect_equal(res, env_mat)
     wkb_list <- g_wk2wk(wkt_vec)
     res <- g_envelope(wkb_list)
     dimnames(res) <- NULL
-    expect_equal(res, bb_mat)
+    expect_equal(res, env_mat)
+    # 3D envelope
+    wkt_3d <- "MULTIPOLYGON(((1 2 3,-1 2 3,-1 -2 3,-1 2 3,1 2 3),(0.1 0.2 0.3,-0.1 0.2 0.3,-0.1 -0.2 0.3,-0.1 0.2 0.3,0.1 0.2 0.3)),((10 20 -30,-10 20 -30,-10 -20 -30,-10 20 -30,10 20 -30)))"
+    env3d <- c(-10, 10, -20, 20, -30, 3.0)
+    names(env3d) <- c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax")
+    res <- g_envelope(wkt_3d, as_3d = TRUE)
+    expect_equal(res, env3d)
+    # as_3d = TRUE on 2D geom
+    res <- g_envelope(g1, as_3d = TRUE)
+    names(res) <- NULL
+    expect_equal(res, c(0, 10, 0, 10, 0, 0))
 
 
     skip_if(gdal_version_num() < 3070000 )


### PR DESCRIPTION
The return order of xy coordinates is changed to `(xmin, xmax, ymin, ymax)`, as was documented and originally intended. This is a breaking change but is intended to match the return of `Geometry.GetEnvelope3D()` in the `osgeo.ogr` Python bindings. Fizes #725.

Also adds argument `as_3d`, optionally get the 3D envelope, wrapper of `OGR_G_GetEnvelope3D()` in the GDAL Geometry API returning `(xmin, xmax, ymin, ymax, zmin, zmax)`.