### PR TITLE
Add g_boundary(): compute the boundary of a geometry

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2353,6 +2353,11 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_boundary <- function(geom, as_iso, byte_order, quiet) {
+    .Call(`_gdalraster_g_boundary`, geom, as_iso, byte_order, quiet)
+}
+
+#' @noRd
 .g_buffer <- function(geom, dist, quad_segs = 30L, as_iso = FALSE, byte_order = "LSB", quiet = FALSE) {
     .Call(`_gdalraster_g_buffer`, geom, dist, quad_segs, as_iso, byte_order, quiet)
 }

--- a/man/g_unary_op.Rd
+++ b/man/g_unary_op.Rd
@@ -3,6 +3,7 @@
 \name{g_unary_op}
 \alias{g_unary_op}
 \alias{g_buffer}
+\alias{g_boundary}
 \alias{g_convex_hull}
 \alias{g_simplify}
 \title{Unary operations on WKB or WKT geometries}
@@ -11,6 +12,14 @@ g_buffer(
   geom,
   dist,
   quad_segs = 30L,
+  as_wkb = TRUE,
+  as_iso = FALSE,
+  byte_order = "LSB",
+  quiet = FALSE
+)
+
+g_boundary(
+  geom,
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB",
@@ -83,10 +92,13 @@ WKB raw vectors, or a character vector containing one or more WKT strings.
 \details{
 These functions use the GEOS library via GDAL headers.
 
+\code{g_boundary()} computes the boundary of a geometry. Wrapper of
+\code{OGR_G_Boundary()} in the GDAL Geometry API.
+
 \code{g_buffer()} builds a new geometry containing the buffer region around
 the geometry on which it is invoked. The buffer is a polygon containing
 the region within the buffer distance of the original geometry.
-Wrapper of \code{OGR_G_Buffer()}in the GDAL Geometry API.
+Wrapper of \code{OGR_G_Buffer()} in the GDAL API.
 
 \code{g_convex_hull()} computes a convex hull, the smallest convex geometry that
 contains all the points in the input geometry. Wrapper of
@@ -100,6 +112,15 @@ the input geometries while preserving topology (see Note). Wrapper of
 Definitions of these operations are given in the GEOS documentation
 (\url{https://libgeos.org/doxygen/}, GEOS 3.14.0dev), some of which is
 copied here.
+
+\code{g_boundary()} computes the "boundary" as defined by the DE9IM
+(\url{https://en.wikipedia.org/wiki/DE-9IM}):
+\itemize{
+\item the boundary of a Polygon is the set of linear rings dividing the
+exterior from the interior
+\item the boundary of a LineString is the two end points
+\item the boundary of a Point/MultiPoint is defined as empty
+}
 
 \code{g_buffer()} always returns a polygonal result. The negative or
 zero-distance buffer of lines and points is always an empty Polygon.
@@ -131,11 +152,15 @@ N.B., \code{preserve_topology = TRUE} does not preserve boundaries shared betwee
 polygons.
 }
 \examples{
-g_buffer("POINT (0 0)", dist = 10, as_wkb = FALSE)
+g1 <- "POLYGON((0 0,1 1,1 0,0 0))"
+g_boundary(g1, as_wkb = FALSE)
 
-g1 <- "GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))"
-g_convex_hull(g1, as_wkb = FALSE)
+g2 <- "POINT (0 0)"
+g_buffer(g2, dist = 10, as_wkb = FALSE)
 
-g2 <- "LINESTRING(0 0,1 1,10 0)"
-g_simplify(g2, tolerance = 5, as_wkb = FALSE)
+g3 <- "GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))"
+g_convex_hull(g3, as_wkb = FALSE)
+
+g4 <- "LINESTRING(0 0,1 1,10 0)"
+g_simplify(g4, tolerance = 5, as_wkb = FALSE)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1320,6 +1320,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// g_boundary
+SEXP g_boundary(const Rcpp::RawVector& geom, bool as_iso, const std::string& byte_order, bool quiet);
+RcppExport SEXP _gdalraster_g_boundary(SEXP geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_boundary(geom, as_iso, byte_order, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
 // g_buffer
 SEXP g_buffer(const Rcpp::RawVector& geom, double dist, int quad_segs, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_buffer(SEXP geomSEXP, SEXP distSEXP, SEXP quad_segsSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
@@ -2181,6 +2195,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_within", (DL_FUNC) &_gdalraster_g_within, 3},
     {"_gdalraster_g_crosses", (DL_FUNC) &_gdalraster_g_crosses, 3},
     {"_gdalraster_g_overlaps", (DL_FUNC) &_gdalraster_g_overlaps, 3},
+    {"_gdalraster_g_boundary", (DL_FUNC) &_gdalraster_g_boundary, 4},
     {"_gdalraster_g_buffer", (DL_FUNC) &_gdalraster_g_buffer, 6},
     {"_gdalraster_g_convex_hull", (DL_FUNC) &_gdalraster_g_convex_hull, 4},
     {"_gdalraster_g_simplify", (DL_FUNC) &_gdalraster_g_simplify, 6},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -90,6 +90,9 @@ Rcpp::LogicalVector g_overlaps(const Rcpp::RawVector &this_geom,
                                const Rcpp::RawVector &other_geom,
                                bool quiet);
 
+SEXP g_boundary(const Rcpp::RawVector &geom, bool as_iso,
+                const std::string &byte_order, bool quiet);
+
 SEXP g_buffer(const Rcpp::RawVector &geom, double dist, int quad_segs,
               bool as_iso, const std::string &byte_order, bool quiet);
 

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -685,6 +685,31 @@ test_that("unary ops return correct values", {
     bb <- bbox_from_wkt(g_buffer(pt, dist = 10, as_wkb = FALSE))
     expect_equal(bb, c(-10, -10,  10,  10))
 
+    # g_boundary
+    g1 <- "POINT(1 1)"
+    expect_equal(g_boundary(g1, as_wkb = FALSE), "GEOMETRYCOLLECTION EMPTY")
+    g2 <- "MULTIPOINT((0 0),(1 1))"
+    expect_equal(g_boundary(g2, as_wkb = FALSE), "GEOMETRYCOLLECTION EMPTY")
+    g3 <- "LINESTRING(0 0, 1 1, 2 2, 3 2, 4 2)"
+    g_bnd <- g_boundary(g3)
+    expect_equal(g_name(g_bnd), "MULTIPOINT")
+    expect_equal(nrow(g_coords(g_bnd)), 2)
+    g4 <- "POLYGON((0 0,1 1,1 0,0 0))"
+    g_bnd <- g_boundary(g4)
+    expect_equal(g_name(g_bnd), "LINESTRING")
+    expect_true(nrow(g_coords(g_bnd)) > 1)
+    # vector/list input
+    # character vector of wkt input
+    g_bnd <- g_boundary(c(g1, g2, g3, g4))
+    expected_names <- c("GEOMETRYCOLLECTION", "GEOMETRYCOLLECTION",
+                        "MULTIPOINT", "LINESTRING")
+    expect_equal(g_name(g_bnd), expected_names)
+    # list of wkb input
+    g_bnd <- g_boundary(g_wk2wk(c(g1, g2, g3, g4)))
+    expected_names <- c("GEOMETRYCOLLECTION", "GEOMETRYCOLLECTION",
+                        "MULTIPOINT", "LINESTRING")
+    expect_equal(g_name(g_bnd), expected_names)
+
     # g_convex_hull
     g1 <- "GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))"
     g_conv_hull <- g_convex_hull(g1, as_wkb = FALSE)


### PR DESCRIPTION
Wrapper of `OGR_G_Boundary()` in the GDAL Geometry API.