### PR TITLE
Geom API: support one-to-many input (this-to-others) in binary predicate functions and in g_distance()

### DIFF
--- a/man/g_binary_pred.Rd
+++ b/man/g_binary_pred.Rd
@@ -34,7 +34,9 @@ character vector containing one or more WKT strings.}
 
 \item{other_geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings. Must contain the same
-number of geometries as \code{this_geom}.}
+number of geometries as \code{this_geom}, unless \code{this_geom} contains a single
+geometry in which case pairwise tests will be performed for one-to-many if
+\code{other_geom} contains multiple geometries (i.e., "this-to-others").}
 
 \item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 }
@@ -77,6 +79,10 @@ a spatial way."
 \note{
 \code{this_geom} and \code{other_geom} are assumed to be in the same coordinate
 reference system.
+
+If \code{this_geom}is a single geometry and \code{other_geom} is a list or vector of
+multiple geometries, then \code{this_geom} will be tested against each geometry
+in \code{other_geom} (otherwise no recycling is done).
 
 Geometry validity is not checked. In case you are unsure of the validity
 of the input geometries, call \code{g_is_valid()} before, otherwise the result

--- a/man/g_measures.Rd
+++ b/man/g_measures.Rd
@@ -30,7 +30,9 @@ character vector containing one or more WKT strings.}
 
 \item{other_geom}{Either a raw vector of WKB or list of raw vectors, or a
 character vector containing one or more WKT strings. Must contain the same
-number of geometries as \code{geom}.}
+number of geometries as \code{geom}, unless \code{geom} contains a single
+geometry in which case pairwise distances will be computed for one-to-many
+if \code{other_geom} contains multiple geometries (i.e., "this-to-others").}
 
 \item{srs}{Character string specifying the spatial reference system
 for \code{geom}. May be in WKT format or any of the formats supported by
@@ -102,9 +104,12 @@ type, no SRS attached, etc.)
 Requires GDAL >= 3.10.
 }
 \note{
-For \code{g_distance()}, \code{geom} and \code{other_geom} must contain the same number of
-geometries (i.e., operates pair-wise on the inputs with no recycling), and
-are assumed to be in the same coordinate reference system.
+For \code{g_distance()}, \code{geom} and \code{other_geom} must be in the same coordinate
+reference system. If \code{geom} is a single geometry and \code{other_geom} is a list
+or vector of multiple geometries, then distances will be calculated between
+\code{geom} and each geometry in \code{other_geom}. Otherwise, no recycling is done
+and \code{length(geom)} must equal \code{length(other_geom)} to calculate distance
+between each corresponding pair of input geometries.
 
 Geometry validity is not checked. In case you are unsure of the validity
 of the input geometries, call \code{g_is_valid()} before, otherwise the result

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -80,6 +80,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_true(g_intersects(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_intersects(wkb_list_1, wkb_list_2), expected_value)
+    # one-to-many
+    expect_equal(g_intersects(pt, wkt_vec_1), expected_value)
 
     # WKT
     expect_false(g_equals(bb, bnd))
@@ -92,6 +94,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_false(g_equals(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_equals(wkb_list_1, wkb_list_2), expected_value)
+    # one-to-many
+    expect_equal(g_equals(pt, wkt_vec_1), expected_value)
 
     # WKT
     expect_false(g_disjoint(bb, bnd))
@@ -104,6 +108,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_false(g_disjoint(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_disjoint(wkb_list_1, wkb_list_2), expected_value)
+    # one-to-many
+    expect_equal(g_disjoint(pt, wkt_vec_1), expected_value)
 
     # WKT
     expect_false(g_touches(bb, bnd))
@@ -116,6 +122,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_false(g_touches(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_touches(wkb_list_1, wkb_list_2), expected_value)
+    # one-to-many
+    expect_equal(g_touches(pt, wkt_vec_1), expected_value)
 
     # WKT
     expect_true(g_contains(bb, bnd))
@@ -128,18 +136,22 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_true(g_contains(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_contains(wkb_list_1, wkb_list_2), expected_value)
+    # one-to-many
+    expect_equal(g_contains(bnd, wkt_vec_2), c(FALSE, FALSE))
 
     # WKT
     expect_false(g_within(bb, bnd))
     expect_error(g_within("invalid WKT", bnd))
     expect_error(g_within(bb, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(FALSE, FALSE)
-    expect_equal(g_within(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(TRUE, FALSE)
+    expect_equal(g_within(wkt_vec_2, wkt_vec_1), expected_value)
     # WKB
     expect_false(g_within(bb_wkb, pt_wkb))
     # list of WKB
-    expect_equal(g_within(wkb_list_1, wkb_list_2), expected_value)
+    expect_equal(g_within(wkb_list_2, wkb_list_1), expected_value)
+    # one-to-many
+    expect_equal(g_within(pt, wkt_vec_1), expected_value)
 
     # WKT
     expect_true(g_crosses(line, bnd))
@@ -153,6 +165,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_false(g_crosses(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_crosses(wkb_list_1, wkb_list_2), expected_value)
+    # one-to-many
+    expect_equal(g_crosses(pt, wkt_vec_1), expected_value)
 
     # WKT
     expect_false(g_overlaps(bb, bnd))
@@ -165,6 +179,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_false(g_overlaps(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_overlaps(wkb_list_1, wkb_list_2), expected_value)
+    # one-to-many
+    expect_equal(g_overlaps(pt, wkt_vec_1), expected_value)
 
     # buffer
     expect_equal(round(bbox_from_wkt(g_buffer(bnd, 100, as_wkb = FALSE))),
@@ -210,6 +226,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     # list of WKB
     res <- g_distance(wkb_list_1, wkb_list_2)
     expect_equal(res[2], 215.0365, tolerance = 1e-4)
+    # one-to-many
+    expect_equal(g_distance(pt, wkt_vec_1), c(0, 215.0365), tolerance = 1e-4)
 
     # length
     expect_equal(g_length(line), 3822.927, tolerance = 1e-2)


### PR DESCRIPTION
binary predicates:

> If `this_geom`is a single geometry and `other_geom` is a list or vector of multiple geometries, then `this_geom` will be tested against each geometry in `other_geom` (otherwise no recycling is done).

`g_distance()`:

>If `geom` is a single geometry and `other_geom` is a list or vector of multiple geometries, then distances will be calculated between `geom` and each geometry in `other_geom`. Otherwise, no recycling is done and `length(geom)` must equal `length(other_geom)` to calculate distance between each corresponding pair of input geometries.