### PR TITLE
Add g_delaunay_triangulation(): return a Delaunay triangulation of the vertices of the input geometry

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2368,6 +2368,11 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_delaunay_triangulation <- function(geom, tolerance = 0.0, only_edges = FALSE, as_iso = FALSE, byte_order = "LSB", quiet = FALSE) {
+    .Call(`_gdalraster_g_delaunay_triangulation`, geom, tolerance, only_edges, as_iso, byte_order, quiet)
+}
+
+#' @noRd
 .g_simplify <- function(geom, tolerance, preserve_topology = TRUE, as_iso = FALSE, byte_order = "LSB", quiet = FALSE) {
     .Call(`_gdalraster_g_simplify`, geom, tolerance, preserve_topology, as_iso, byte_order, quiet)
 }

--- a/R/geom.R
+++ b/R/geom.R
@@ -2291,7 +2291,8 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
 #' `OGR_G_ConvexHull()` in the GDAL API.
 #'
 #' `g_delaunay_triangulation()` returns a Delaunay triangulation of the
-#' vertices of the input geometry. Requires GEOS >= 3.4.
+#' vertices of the input geometry. Wrapper of `OGR_G_DelaunayTriangulation()`
+#' in the GDAL API. Requires GEOS >= 3.4.
 #'
 #' `g_simplify()` computes a simplified geometry. By default, it simplifies
 #' the input geometries while preserving topology (see Note). Wrapper of

--- a/man/g_unary_op.Rd
+++ b/man/g_unary_op.Rd
@@ -5,6 +5,7 @@
 \alias{g_buffer}
 \alias{g_boundary}
 \alias{g_convex_hull}
+\alias{g_delaunay_triangulation}
 \alias{g_simplify}
 \title{Unary operations on WKB or WKT geometries}
 \usage{
@@ -28,6 +29,16 @@ g_boundary(
 
 g_convex_hull(
   geom,
+  as_wkb = TRUE,
+  as_iso = FALSE,
+  byte_order = "LSB",
+  quiet = FALSE
+)
+
+g_delaunay_triangulation(
+  geom,
+  tolerance = 0,
+  only_edges = FALSE,
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB",
@@ -66,10 +77,16 @@ WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 
 \item{quiet}{Logical value, \code{TRUE} to suppress warnings. Defaults to \code{FALSE}.}
 
-\item{tolerance}{Numeric value of the simplification tolerance, as distance
-in units of the input \code{geom}. Simplification removes vertices which are
-within the tolerance distance of the simplified linework (as long as
-topology is preserved when \code{preserve_topology = TRUE}).}
+\item{tolerance}{Numeric value. For \code{g_simplify()}, the simplification
+tolerance as distance in units of the input \code{geom}. Simplification removes
+vertices which are within the tolerance distance of the simplified linework
+(as long as topology is preserved when \code{preserve_topology = TRUE}).
+For \code{g_delaunay_triangulation()}, an optional snapping tolerance to use for
+improved robustness.}
+
+\item{only_edges}{Logical value. If \code{TRUE}, \code{g_delaunay_triangulation()}
+will return a MULTILINESTRING, otherwise it will return a GEOMETRYCOLLECTION
+containing triangular POLYGONs (the default).}
 
 \item{preserve_topology}{Logical value, \code{TRUE} to simplify geometries while
 preserving topology (the default). Setting to \code{FALSE} simplifies geometries
@@ -103,6 +120,9 @@ Wrapper of \code{OGR_G_Buffer()} in the GDAL API.
 \code{g_convex_hull()} computes a convex hull, the smallest convex geometry that
 contains all the points in the input geometry. Wrapper of
 \code{OGR_G_ConvexHull()} in the GDAL API.
+
+\code{g_delaunay_triangulation()} returns a Delaunay triangulation of the
+vertices of the input geometry. Requires GEOS >= 3.4.
 
 \code{g_simplify()} computes a simplified geometry. By default, it simplifies
 the input geometries while preserving topology (see Note). Wrapper of
@@ -161,6 +181,9 @@ g_buffer(g2, dist = 10, as_wkb = FALSE)
 g3 <- "GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))"
 g_convex_hull(g3, as_wkb = FALSE)
 
-g4 <- "LINESTRING(0 0,1 1,10 0)"
-g_simplify(g4, tolerance = 5, as_wkb = FALSE)
+g4 <- "MULTIPOINT(0 0,0 1,1 1,1 0)"
+g_delaunay_triangulation(g4, as_wkb = FALSE)
+
+g5 <- "LINESTRING(0 0,1 1,10 0)"
+g_simplify(g5, tolerance = 5, as_wkb = FALSE)
 }

--- a/man/g_unary_op.Rd
+++ b/man/g_unary_op.Rd
@@ -122,7 +122,8 @@ contains all the points in the input geometry. Wrapper of
 \code{OGR_G_ConvexHull()} in the GDAL API.
 
 \code{g_delaunay_triangulation()} returns a Delaunay triangulation of the
-vertices of the input geometry. Requires GEOS >= 3.4.
+vertices of the input geometry. Wrapper of \code{OGR_G_DelaunayTriangulation()}
+in the GDAL API. Requires GEOS >= 3.4.
 
 \code{g_simplify()} computes a simplified geometry. By default, it simplifies
 the input geometries while preserving topology (see Note). Wrapper of

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1364,6 +1364,22 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// g_delaunay_triangulation
+SEXP g_delaunay_triangulation(const Rcpp::RawVector& geom, double tolerance, bool only_edges, bool as_iso, const std::string& byte_order, bool quiet);
+RcppExport SEXP _gdalraster_g_delaunay_triangulation(SEXP geomSEXP, SEXP toleranceSEXP, SEXP only_edgesSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< double >::type tolerance(toleranceSEXP);
+    Rcpp::traits::input_parameter< bool >::type only_edges(only_edgesSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_delaunay_triangulation(geom, tolerance, only_edges, as_iso, byte_order, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
 // g_simplify
 SEXP g_simplify(const Rcpp::RawVector& geom, double tolerance, bool preserve_topology, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_simplify(SEXP geomSEXP, SEXP toleranceSEXP, SEXP preserve_topologySEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
@@ -2198,6 +2214,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_boundary", (DL_FUNC) &_gdalraster_g_boundary, 4},
     {"_gdalraster_g_buffer", (DL_FUNC) &_gdalraster_g_buffer, 6},
     {"_gdalraster_g_convex_hull", (DL_FUNC) &_gdalraster_g_convex_hull, 4},
+    {"_gdalraster_g_delaunay_triangulation", (DL_FUNC) &_gdalraster_g_delaunay_triangulation, 6},
     {"_gdalraster_g_simplify", (DL_FUNC) &_gdalraster_g_simplify, 6},
     {"_gdalraster_g_intersection", (DL_FUNC) &_gdalraster_g_intersection, 5},
     {"_gdalraster_g_union", (DL_FUNC) &_gdalraster_g_union, 5},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -99,6 +99,10 @@ SEXP g_buffer(const Rcpp::RawVector &geom, double dist, int quad_segs,
 SEXP g_convex_hull(const Rcpp::RawVector &geom, bool as_iso,
                    const std::string &byte_order, bool quiet);
 
+SEXP g_delaunay_triangulation(const Rcpp::RawVector &geom, double tolerance,
+                              bool only_edges, bool as_iso,
+                              const std::string &byte_order, bool quiet);
+
 SEXP g_simplify(const Rcpp::RawVector &geom, double tolerance,
                 bool preserve_topology, bool as_iso,
                 const std::string &byte_order, bool quiet);

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -744,6 +744,24 @@ test_that("unary ops return correct values", {
     g_conv_hull <- g_convex_hull(g_wk2wk(c(g1, g1)), as_wkb = FALSE)
     expect_equal(g_conv_hull, rep(g_expect, 2))
 
+    # g_delaunay_triangulation
+    g1 <- "MULTIPOINT(0 0,0 1,1 1,1 0)"
+    g_dt <- g_delaunay_triangulation(g1, as_wkb = FALSE)
+    g_expect <- "GEOMETRYCOLLECTION (POLYGON ((0 1,0 0,1 0,0 1)),POLYGON ((0 1,1 0,1 1,0 1)))"
+    expect_equal(g_dt, g_expect)
+    # wkb input
+    g_dt <- g_delaunay_triangulation(g_wk2wk(g1), as_wkb = FALSE)
+    expect_equal(g_dt, g_expect)
+    # vector/list input
+    g_expect <- rep(g_expect, 2)
+    g2 <- "LINESTRING(0 0,1 1,10 0)"
+    # character vector of wkt input
+    g_dt <- g_delaunay_triangulation(c(g1, g1), as_wkb = FALSE)
+    expect_equal(g_dt, g_expect)
+    # list of wkb input
+    g_dt <- g_delaunay_triangulation(g_wk2wk(c(g1, g1)), as_wkb = FALSE)
+    expect_equal(g_dt, g_expect)
+
     # g_simplify
     g1 <- "LINESTRING(0 0,1 0,10 0)"
     g_simp <- g_simplify(g1, tolerance = 5, as_wkb = FALSE)


### PR DESCRIPTION
Wrapper of `OGR_G_DelaunayTriangulation()` in the GDAL Geometry API.