### PR TITLE
Geom API: fix the handling of OGR NULL geometries

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -1,6 +1,16 @@
 # R interface for the GEOS functions defined in src/geom_api.h
 # Chris Toney <chris.toney at usda.gov>
 
+
+#' @noRd
+#' @export
+.is_raw_or_null <- function(x) {
+    if (is.raw(x) || is.null(x))
+        return(TRUE)
+    else
+        return(FALSE)
+}
+
 #' Get GEOS version
 #'
 #' @description
@@ -254,8 +264,8 @@ bbox_transform <- function(bbox, srs_from, srs_to,
 #' types, it is equivalent to ISO.
 #'
 #' When the return value is a list of WKB raw vectors, an element in the
-#' returned list will contain `NA` if the corresponding input string was `NA`
-#' or empty (`""`).
+#' returned list will contain `NULL` (and a warning emitted) if the
+#' corresponding input string was `NA` or empty (`""`).
 #'
 #' When input is a list of WKB raw vectors, a corresponding element in the
 #' returned character vector will be an empty string (`""`) if the input was
@@ -303,6 +313,8 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
     } else if (is.list(geom)) {
         return(.g_wkb_list2wkt(geom, as_iso))
     } else if (is.na(geom)) {
+        return(NULL)
+    } else if (is.null(geom)) {
         return(NA_character_)
     } else {
         stop("'geom' must be a character vector, raw vector, or list",
@@ -573,9 +585,9 @@ g_is_empty <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_is_empty(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_is_empty, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -601,9 +613,9 @@ g_is_valid <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_is_valid(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_is_valid, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -629,9 +641,9 @@ g_is_3D <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_is_3D(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_is_3D, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -657,9 +669,9 @@ g_is_measured <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_is_measured(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_is_measured, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -685,9 +697,9 @@ g_name <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_name(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_name, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -713,9 +725,9 @@ g_summary <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_summary(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_summary, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -763,7 +775,7 @@ g_summary <- function(geom, quiet = FALSE) {
 #' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
-#' geometries as WKB/WKT with length equal to `length(geom)`. `NA` is returned
+#' geometries as WKB/WKT with length equal to `length(geom)`. `NULL` is returned
 #' with a warning if WKB input cannot be converted into an OGR geometry object,
 #' or if an error occurs in the call to MakeValid() in the underlying OGR API.
 #'
@@ -771,7 +783,7 @@ g_summary <- function(geom, quiet = FALSE) {
 #' This function is built on the GEOS >= 3.8 library, check it for the
 #' definition of the geometry operation. If OGR is built without GEOS >= 3.8,
 #' this function will return a clone of the input geometry if it is valid, or
-#' `NA` if it is invalid.
+#' `NULL` (`as_wkb = TRUE`) / `NA` (`as_wkb = FALSE`) if it is invalid.
 #'
 #' @examples
 #' # requires GEOS >= 3.8, otherwise is only a validity test (see Note)
@@ -828,10 +840,10 @@ g_make_valid <- function(geom, method = "LINEWORK", keep_collapsed = FALSE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_make_valid(geom, method, keep_collapsed, as_iso,
                              byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_make_valid, method, keep_collapsed, as_iso,
                       byte_order, quiet)
     } else if (is.character(geom)) {
@@ -869,8 +881,9 @@ g_make_valid <- function(geom, method = "LINEWORK", keep_collapsed = FALSE,
 #' @param quiet Logical value, `TRUE` to suppress warnings. Defaults to `FALSE`.
 #' @return
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
-#' geometries as WKB/WKT with length equal to `length(geom)`. `NA` is returned
-#' with a warning if WKB input cannot be converted into an OGR geometry object.
+#' geometries as WKB/WKT with length equal to `length(geom)`.
+#' `NULL` (`as_wkb = TRUE`) / `NA` (`as_wkb = FALSE`) is returned with a
+#' warning if WKB input cannot be converted into an OGR geometry object.
 #'
 #' @examples
 #' g <- "GEOMETRYCOLLECTION(POINT(1 2),
@@ -907,9 +920,9 @@ g_swap_xy <- function(geom, as_wkb = TRUE, as_iso = FALSE, byte_order = "LSB",
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_swap_xy(geom, as_iso, byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_swap_xy, as_iso, byte_order, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -959,13 +972,13 @@ g_envelope <- function(geom, as_3d = FALSE, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_envelope(geom, as_3d, quiet)
         if (as_3d)
             names(ret) <- c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax")
         else
             names(ret) <- c("xmin", "xmax", "ymin", "ymax")
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- t(sapply(geom, .g_envelope, as_3d, quiet))
         if (as_3d)
             colnames(ret) <- c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax")
@@ -1055,8 +1068,8 @@ g_envelope <- function(geom, as_3d = FALSE, quiet = FALSE) {
 g_intersects <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1064,8 +1077,8 @@ g_intersects <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1083,12 +1096,12 @@ g_intersects <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_intersects(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1119,8 +1132,8 @@ g_intersects <- function(this_geom, other_geom, quiet = FALSE) {
 g_disjoint <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1128,8 +1141,8 @@ g_disjoint <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1147,12 +1160,12 @@ g_disjoint <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_disjoint(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1183,8 +1196,8 @@ g_disjoint <- function(this_geom, other_geom, quiet = FALSE) {
 g_touches <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1192,8 +1205,8 @@ g_touches <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1211,12 +1224,12 @@ g_touches <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_touches(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1247,8 +1260,8 @@ g_touches <- function(this_geom, other_geom, quiet = FALSE) {
 g_contains <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1256,8 +1269,8 @@ g_contains <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1275,12 +1288,12 @@ g_contains <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_contains(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1311,8 +1324,8 @@ g_contains <- function(this_geom, other_geom, quiet = FALSE) {
 g_within <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1320,8 +1333,8 @@ g_within <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1339,12 +1352,12 @@ g_within <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_within(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1375,8 +1388,8 @@ g_within <- function(this_geom, other_geom, quiet = FALSE) {
 g_crosses <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1384,8 +1397,8 @@ g_crosses <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1403,12 +1416,12 @@ g_crosses <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_crosses(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1439,8 +1452,8 @@ g_crosses <- function(this_geom, other_geom, quiet = FALSE) {
 g_overlaps <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1448,8 +1461,8 @@ g_overlaps <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1467,12 +1480,12 @@ g_overlaps <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_overlaps(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1503,8 +1516,8 @@ g_overlaps <- function(this_geom, other_geom, quiet = FALSE) {
 g_equals <- function(this_geom, other_geom, quiet = FALSE) {
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1512,8 +1525,8 @@ g_equals <- function(this_geom, other_geom, quiet = FALSE) {
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1531,12 +1544,12 @@ g_equals <- function(this_geom, other_geom, quiet = FALSE) {
 
     ret <- NULL
     one_to_many <- FALSE
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_equals(this_geom, other_geom, quiet)
-    } else if ((is.raw(this_geom) || is.list(this_geom)) &&
+    } else if ((.is_raw_or_null(this_geom) || is.list(this_geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(this_geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(this_geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(this_geom) &&
@@ -1600,9 +1613,9 @@ g_equals <- function(this_geom, other_geom, quiet = FALSE) {
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
 #' geometries as WKB/WKT with length equal to the number of input geometry
 #' pairs.
-#' `NA` is returned with a warning if WKB input cannot be converted
-#' into an OGR geometry object, or if an error occurs in the call to the
-#' underlying OGR API function.
+#' `NULL` (`as_wkb = TRUE`) / `NA` (`as_wkb = FALSE`) is returned with a
+#' warning if WKB input cannot be converted into an OGR geometry object, or if
+#' an error occurs in the call to the underlying OGR API function.
 #'
 #' @note
 #' `this_geom` and `other_geom` are assumed to be in the same coordinate
@@ -1640,8 +1653,8 @@ g_intersection <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1649,8 +1662,8 @@ g_intersection <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1681,7 +1694,7 @@ g_intersection <- function(this_geom, other_geom, as_wkb = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         wkb <- .g_intersection(this_geom, other_geom, as_iso,
                                byte_order, quiet)
     } else if (is.list(this_geom) && is.list(other_geom)) {
@@ -1715,8 +1728,8 @@ g_union <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1724,8 +1737,8 @@ g_union <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1756,7 +1769,7 @@ g_union <- function(this_geom, other_geom, as_wkb = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         wkb <- .g_union(this_geom, other_geom, as_iso,
                         byte_order, quiet)
     } else if (is.list(this_geom) && is.list(other_geom)) {
@@ -1790,8 +1803,8 @@ g_difference <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1799,8 +1812,8 @@ g_difference <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1831,7 +1844,7 @@ g_difference <- function(this_geom, other_geom, as_wkb = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         wkb <- .g_difference(this_geom, other_geom, as_iso,
                              byte_order, quiet)
     } else if (is.list(this_geom) && is.list(other_geom)) {
@@ -1865,8 +1878,8 @@ g_sym_difference <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(this_geom))
         this_geom <- g_wk2wk(this_geom)
-    if (!(is.raw(this_geom) || (is.list(this_geom) &&
-                                is.raw(this_geom[[1]])))) {
+    if (!(.is_raw_or_null(this_geom) || (is.list(this_geom) &&
+                                         .is_raw_or_null(this_geom[[1]])))) {
 
         stop("'this_geom' must be raw vector or character",
              call. = FALSE)
@@ -1874,8 +1887,8 @@ g_sym_difference <- function(this_geom, other_geom, as_wkb = TRUE,
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -1906,7 +1919,7 @@ g_sym_difference <- function(this_geom, other_geom, as_wkb = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(this_geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(this_geom) && .is_raw_or_null(other_geom)) {
         wkb <- .g_sym_difference(this_geom, other_geom, as_iso,
                                  byte_order, quiet)
     } else if (is.list(this_geom) && is.list(other_geom)) {
@@ -2050,9 +2063,9 @@ g_area <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_area(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_area, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -2077,10 +2090,10 @@ g_centroid <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_centroid(geom, quiet)
         names(ret) <- c("x", "y")
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- t(sapply(geom, .g_centroid, quiet))
         colnames(ret) <- c("x", "y")
     } else if (is.character(geom)) {
@@ -2104,15 +2117,17 @@ g_centroid <- function(geom, quiet = FALSE) {
 g_distance <- function(geom, other_geom, quiet = FALSE) {
     if (is.character(geom))
         geom <- g_wk2wk(geom)
-    if (!(is.raw(geom) || (is.list(geom) && is.raw(geom[[1]])))) {
+    if (!(.is_raw_or_null(geom) || (is.list(geom) &&
+                                    .is_raw_or_null(geom[[1]])))) {
+
         stop("'geom' must be raw vector or character",
              call. = FALSE)
     }
 
     if (is.character(other_geom))
         other_geom <- g_wk2wk(other_geom)
-    if (!(is.raw(other_geom) || (is.list(other_geom) &&
-                                 is.raw(other_geom[[1]])))) {
+    if (!(.is_raw_or_null(other_geom) || (is.list(other_geom) &&
+                                          .is_raw_or_null(other_geom[[1]])))) {
 
         stop("'other_geom' must be raw vector or character",
              call. = FALSE)
@@ -2130,12 +2145,12 @@ g_distance <- function(geom, other_geom, quiet = FALSE) {
 
     ret <- -1
     one_to_many <- FALSE
-    if (is.raw(geom) && is.raw(other_geom)) {
+    if (.is_raw_or_null(geom) && .is_raw_or_null(other_geom)) {
         ret <- .g_distance(geom, other_geom, quiet)
-    } else if ((is.raw(geom) || is.list(geom)) &&
+    } else if ((.is_raw_or_null(geom) || is.list(geom)) &&
                is.list(other_geom)) {
 
-        if (is.raw(geom) && is.list(other_geom)) {
+        if (.is_raw_or_null(geom) && is.list(other_geom)) {
             one_to_many <- TRUE
 
         } else if (is.list(geom) &&
@@ -2170,9 +2185,9 @@ g_length <- function(geom, quiet = FALSE) {
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- 0
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_length(geom, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_length, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -2207,9 +2222,9 @@ g_geodesic_area <- function(geom, srs, traditional_gis_order = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- -1.0
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_geodesic_area(geom, srs, traditional_gis_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_geodesic_area, srs, traditional_gis_order,
                       quiet)
     } else if (is.character(geom)) {
@@ -2247,9 +2262,9 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     ret <- -1.0
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         ret <- .g_geodesic_length(geom, srs, traditional_gis_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         ret <- sapply(geom, .g_geodesic_length, srs, traditional_gis_order,
                       quiet)
     } else if (is.character(geom)) {
@@ -2328,9 +2343,9 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
 #' @return
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
 #' geometries as WKB/WKT with length equal to the number of input geometries.
-#' `NA` is returned with a warning if WKB input cannot be converted into an
-#' OGR geometry object, or if an error occurs in the call to the underlying
-#' OGR API.
+#'  `NULL` (`as_wkb = TRUE`) / `NA` (`as_wkb = FALSE`) is returned with a
+#' warning if WKB input cannot be converted into an OGR geometry object, or if
+#' an error occurs in the call to the underlying OGR API.
 #'
 #' @note
 #' Definitions of these operations are given in the GEOS documentation
@@ -2415,9 +2430,9 @@ g_buffer <- function(geom, dist, quad_segs = 30L, as_wkb = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_buffer(geom, dist, quad_segs, as_iso, byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_buffer, dist, quad_segs, as_iso,
                       byte_order, quiet)
     } else if (is.character(geom)) {
@@ -2468,9 +2483,9 @@ g_boundary <- function(geom, as_wkb = TRUE, as_iso = FALSE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_boundary(geom, as_iso, byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_boundary, as_iso, byte_order, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -2519,9 +2534,9 @@ g_convex_hull <- function(geom, as_wkb = TRUE, as_iso = FALSE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_convex_hull(geom, as_iso, byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_convex_hull, as_iso, byte_order, quiet)
     } else if (is.character(geom)) {
         if (length(geom) == 1) {
@@ -2578,10 +2593,10 @@ g_delaunay_triangulation <- function(geom, tolerance = 0.0, only_edges = FALSE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_delaunay_triangulation(geom, tolerance, only_edges, as_iso,
                                          byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_delaunay_triangulation, tolerance, only_edges,
                       as_iso, byte_order, quiet)
     } else if (is.character(geom)) {
@@ -2644,10 +2659,10 @@ g_simplify <- function(geom, tolerance, preserve_topology = TRUE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_simplify(geom, tolerance, preserve_topology, as_iso,
                            byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_simplify, tolerance, preserve_topology, as_iso,
                       byte_order, quiet)
     } else if (is.character(geom)) {
@@ -2703,9 +2718,9 @@ g_simplify <- function(geom, tolerance, preserve_topology = TRUE,
 #' @return
 #' A geometry as WKB raw vector or WKT string, or a list/character vector of
 #' geometries as WKB/WKT with length equal to the number of input geometries.
-#' `NA` is returned with a warning if WKB input cannot be converted into an
-#' OGR geometry object, or if an error occurs in the call to the underlying
-#' OGR API.
+#'  `NULL` (`as_wkb = TRUE`) / `NA` (`as_wkb = FALSE`) is returned with a
+#' warning if WKB input cannot be converted into an OGR geometry object, or if
+#' an error occurs in the call to the underlying OGR API.
 #'
 #' @note
 #' This function uses the `OGR_GeomTransformer_Create()` and
@@ -2786,11 +2801,11 @@ g_transform <- function(geom, srs_from, srs_to, wrap_date_line = FALSE,
         stop("'quiet' must be a single logical value", call. = FALSE)
 
     wkb <- NULL
-    if (is.raw(geom)) {
+    if (.is_raw_or_null(geom)) {
         wkb <- .g_transform(geom, srs_from, srs_to, wrap_date_line,
                             date_line_offset, traditional_gis_order, as_iso,
                             byte_order, quiet)
-    } else if (is.list(geom) && is.raw(geom[[1]])) {
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
         wkb <- lapply(geom, .g_transform, srs_from, srs_to, wrap_date_line,
                       date_line_offset, traditional_gis_order, as_iso,
                       byte_order, quiet)

--- a/inst/extdata/test_ogr_geojson_mixed_timezone.geojson
+++ b/inst/extdata/test_ogr_geojson_mixed_timezone.geojson
@@ -1,0 +1,11 @@
+{
+"type": "FeatureCollection",
+"name": "test",
+"features": [
+{ "type": "Feature", "properties": { }, "geometry": null },
+{ "type": "Feature", "properties": { "datetime": "2022-05-31T12:34:56.789Z" }, "geometry": null },
+{ "type": "Feature", "properties": { }, "geometry": null },
+{ "type": "Feature", "properties": { "datetime": "2022-05-31T12:34:56.789+01:00" }, "geometry": null },
+{ "type": "Feature", "properties": { "datetime": "2022-05-31T12:34:56.789-01:00" }, "geometry": null }
+]
+}

--- a/man/g_binary_op.Rd
+++ b/man/g_binary_op.Rd
@@ -67,9 +67,9 @@ WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 A geometry as WKB raw vector or WKT string, or a list/character vector of
 geometries as WKB/WKT with length equal to the number of input geometry
 pairs.
-\code{NA} is returned with a warning if WKB input cannot be converted
-into an OGR geometry object, or if an error occurs in the call to the
-underlying OGR API function.
+\code{NULL} (\code{as_wkb = TRUE}) / \code{NA} (\code{as_wkb = FALSE}) is returned with a
+warning if WKB input cannot be converted into an OGR geometry object, or if
+an error occurs in the call to the underlying OGR API function.
 }
 \description{
 These functions implement operations on pairs of geometries in OGC WKB

--- a/man/g_make_valid.Rd
+++ b/man/g_make_valid.Rd
@@ -37,7 +37,7 @@ WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 }
 \value{
 A geometry as WKB raw vector or WKT string, or a list/character vector of
-geometries as WKB/WKT with length equal to \code{length(geom)}. \code{NA} is returned
+geometries as WKB/WKT with length equal to \code{length(geom)}. \code{NULL} is returned
 with a warning if WKB input cannot be converted into an OGR geometry object,
 or if an error occurs in the call to MakeValid() in the underlying OGR API.
 }
@@ -63,7 +63,7 @@ KEEP_COLLAPSED only applies to the STRUCTURE method:
 This function is built on the GEOS >= 3.8 library, check it for the
 definition of the geometry operation. If OGR is built without GEOS >= 3.8,
 this function will return a clone of the input geometry if it is valid, or
-\code{NA} if it is invalid.
+\code{NULL} (\code{as_wkb = TRUE}) / \code{NA} (\code{as_wkb = FALSE}) if it is invalid.
 }
 \examples{
 # requires GEOS >= 3.8, otherwise is only a validity test (see Note)

--- a/man/g_swap_xy.Rd
+++ b/man/g_swap_xy.Rd
@@ -29,8 +29,9 @@ WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 }
 \value{
 A geometry as WKB raw vector or WKT string, or a list/character vector of
-geometries as WKB/WKT with length equal to \code{length(geom)}. \code{NA} is returned
-with a warning if WKB input cannot be converted into an OGR geometry object.
+geometries as WKB/WKT with length equal to \code{length(geom)}.
+\code{NULL} (\code{as_wkb = TRUE}) / \code{NA} (\code{as_wkb = FALSE}) is returned with a
+warning if WKB input cannot be converted into an OGR geometry object.
 }
 \description{
 \code{g_swap_xy()} swaps x and y coordinates of the input geometry.

--- a/man/g_transform.Rd
+++ b/man/g_transform.Rd
@@ -55,9 +55,9 @@ WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 \value{
 A geometry as WKB raw vector or WKT string, or a list/character vector of
 geometries as WKB/WKT with length equal to the number of input geometries.
-\code{NA} is returned with a warning if WKB input cannot be converted into an
-OGR geometry object, or if an error occurs in the call to the underlying
-OGR API.
+\code{NULL} (\code{as_wkb = TRUE}) / \code{NA} (\code{as_wkb = FALSE}) is returned with a
+warning if WKB input cannot be converted into an OGR geometry object, or if
+an error occurs in the call to the underlying OGR API.
 }
 \description{
 \code{g_transform()} will transform the coordinates of a geometry from their

--- a/man/g_unary_op.Rd
+++ b/man/g_unary_op.Rd
@@ -96,9 +96,9 @@ using the standard Douglas-Peucker algorithm which is significantly faster
 \value{
 A geometry as WKB raw vector or WKT string, or a list/character vector of
 geometries as WKB/WKT with length equal to the number of input geometries.
-\code{NA} is returned with a warning if WKB input cannot be converted into an
-OGR geometry object, or if an error occurs in the call to the underlying
-OGR API.
+\code{NULL} (\code{as_wkb = TRUE}) / \code{NA} (\code{as_wkb = FALSE}) is returned with a
+warning if WKB input cannot be converted into an OGR geometry object, or if
+an error occurs in the call to the underlying OGR API.
 }
 \description{
 These functions implement algorithms that operate on one input geometry

--- a/man/g_wk2wk.Rd
+++ b/man/g_wk2wk.Rd
@@ -40,8 +40,8 @@ MultiLineString, MultiPolygon and GeometryCollection. For other geometry
 types, it is equivalent to ISO.
 
 When the return value is a list of WKB raw vectors, an element in the
-returned list will contain \code{NA} if the corresponding input string was \code{NA}
-or empty (\code{""}).
+returned list will contain \code{NULL} (and a warning emitted) if the
+corresponding input string was \code{NA} or empty (\code{""}).
 
 When input is a list of WKB raw vectors, a corresponding element in the
 returned character vector will be an empty string (\code{""}) if the input was

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1024,12 +1024,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_wkb2wkt
-std::string g_wkb2wkt(const Rcpp::RawVector& geom, bool as_iso);
+Rcpp::String g_wkb2wkt(const Rcpp::RObject& geom, bool as_iso);
 RcppExport SEXP _gdalraster_g_wkb2wkt(SEXP geomSEXP, SEXP as_isoSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     rcpp_result_gen = Rcpp::wrap(g_wkb2wkt(geom, as_iso));
     return rcpp_result_gen;
@@ -1102,24 +1102,24 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_is_valid
-Rcpp::LogicalVector g_is_valid(const Rcpp::RawVector& geom, bool quiet);
+Rcpp::LogicalVector g_is_valid(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_is_valid(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_is_valid(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_make_valid
-SEXP g_make_valid(const Rcpp::RawVector& geom, const std::string& method, bool keep_collapsed, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_make_valid(const Rcpp::RObject& geom, const std::string& method, bool keep_collapsed, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_make_valid(SEXP geomSEXP, SEXP methodSEXP, SEXP keep_collapsedSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type method(methodSEXP);
     Rcpp::traits::input_parameter< bool >::type keep_collapsed(keep_collapsedSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
@@ -1130,12 +1130,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_swap_xy
-SEXP g_swap_xy(const Rcpp::RawVector& geom, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_swap_xy(const Rcpp::RObject& geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_swap_xy(SEXP geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1144,72 +1144,72 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_is_empty
-Rcpp::LogicalVector g_is_empty(const Rcpp::RawVector& geom, bool quiet);
+Rcpp::LogicalVector g_is_empty(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_is_empty(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_is_empty(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_is_3D
-Rcpp::LogicalVector g_is_3D(const Rcpp::RawVector& geom, bool quiet);
+Rcpp::LogicalVector g_is_3D(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_is_3D(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_is_3D(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_is_measured
-Rcpp::LogicalVector g_is_measured(const Rcpp::RawVector& geom, bool quiet);
+Rcpp::LogicalVector g_is_measured(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_is_measured(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_is_measured(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_name
-SEXP g_name(const Rcpp::RawVector& geom, bool quiet);
+Rcpp::String g_name(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_name(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_name(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_summary
-SEXP g_summary(const Rcpp::RawVector& geom, bool quiet);
+Rcpp::String g_summary(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_summary(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_summary(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_envelope
-Rcpp::NumericVector g_envelope(const Rcpp::RawVector& geom, bool as_3d, bool quiet);
+Rcpp::NumericVector g_envelope(const Rcpp::RObject& geom, bool as_3d, bool quiet);
 RcppExport SEXP _gdalraster_g_envelope(SEXP geomSEXP, SEXP as_3dSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_3d(as_3dSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_envelope(geom, as_3d, quiet));
@@ -1217,116 +1217,116 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_intersects
-Rcpp::LogicalVector g_intersects(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_intersects(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_intersects(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_intersects(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_equals
-Rcpp::LogicalVector g_equals(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_equals(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_equals(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_equals(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_disjoint
-Rcpp::LogicalVector g_disjoint(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_disjoint(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_disjoint(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_disjoint(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_touches
-Rcpp::LogicalVector g_touches(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_touches(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_touches(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_touches(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_contains
-Rcpp::LogicalVector g_contains(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_contains(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_contains(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_contains(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_within
-Rcpp::LogicalVector g_within(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_within(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_within(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_within(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_crosses
-Rcpp::LogicalVector g_crosses(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_crosses(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_crosses(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_crosses(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_overlaps
-Rcpp::LogicalVector g_overlaps(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+Rcpp::LogicalVector g_overlaps(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_overlaps(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_overlaps(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_boundary
-SEXP g_boundary(const Rcpp::RawVector& geom, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_boundary(const Rcpp::RObject& geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_boundary(SEXP geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1335,12 +1335,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_buffer
-SEXP g_buffer(const Rcpp::RawVector& geom, double dist, int quad_segs, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_buffer(const Rcpp::RObject& geom, double dist, int quad_segs, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_buffer(SEXP geomSEXP, SEXP distSEXP, SEXP quad_segsSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< double >::type dist(distSEXP);
     Rcpp::traits::input_parameter< int >::type quad_segs(quad_segsSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
@@ -1351,12 +1351,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_convex_hull
-SEXP g_convex_hull(const Rcpp::RawVector& geom, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_convex_hull(const Rcpp::RObject& geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_convex_hull(SEXP geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1365,12 +1365,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_delaunay_triangulation
-SEXP g_delaunay_triangulation(const Rcpp::RawVector& geom, double tolerance, bool only_edges, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_delaunay_triangulation(const Rcpp::RObject& geom, double tolerance, bool only_edges, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_delaunay_triangulation(SEXP geomSEXP, SEXP toleranceSEXP, SEXP only_edgesSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< double >::type tolerance(toleranceSEXP);
     Rcpp::traits::input_parameter< bool >::type only_edges(only_edgesSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
@@ -1381,12 +1381,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_simplify
-SEXP g_simplify(const Rcpp::RawVector& geom, double tolerance, bool preserve_topology, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_simplify(const Rcpp::RObject& geom, double tolerance, bool preserve_topology, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_simplify(SEXP geomSEXP, SEXP toleranceSEXP, SEXP preserve_topologySEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< double >::type tolerance(toleranceSEXP);
     Rcpp::traits::input_parameter< bool >::type preserve_topology(preserve_topologySEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
@@ -1397,13 +1397,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_intersection
-SEXP g_intersection(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_intersection(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_intersection(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1412,13 +1412,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_union
-SEXP g_union(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_union(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_union(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1427,13 +1427,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_difference
-SEXP g_difference(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_difference(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_difference(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1442,13 +1442,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_sym_difference
-SEXP g_sym_difference(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_sym_difference(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_sym_difference(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1457,49 +1457,49 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_distance
-double g_distance(const Rcpp::RawVector& this_geom, const Rcpp::RawVector& other_geom, bool quiet);
+double g_distance(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool quiet);
 RcppExport SEXP _gdalraster_g_distance(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type this_geom(this_geomSEXP);
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type other_geom(other_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type this_geom(this_geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type other_geom(other_geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_distance(this_geom, other_geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_length
-double g_length(const Rcpp::RawVector& geom, bool quiet);
+double g_length(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_length(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_length(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_area
-double g_area(const Rcpp::RawVector& geom, bool quiet);
+double g_area(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_area(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_area(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_geodesic_area
-double g_geodesic_area(const Rcpp::RawVector& geom, const std::string& srs, bool traditional_gis_order, bool quiet);
+double g_geodesic_area(const Rcpp::RObject& geom, const std::string& srs, bool traditional_gis_order, bool quiet);
 RcppExport SEXP _gdalraster_g_geodesic_area(SEXP geomSEXP, SEXP srsSEXP, SEXP traditional_gis_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
     Rcpp::traits::input_parameter< bool >::type traditional_gis_order(traditional_gis_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1508,12 +1508,12 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_geodesic_length
-double g_geodesic_length(const Rcpp::RawVector& geom, const std::string& srs, bool traditional_gis_order, bool quiet);
+double g_geodesic_length(const Rcpp::RObject& geom, const std::string& srs, bool traditional_gis_order, bool quiet);
 RcppExport SEXP _gdalraster_g_geodesic_length(SEXP geomSEXP, SEXP srsSEXP, SEXP traditional_gis_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
     Rcpp::traits::input_parameter< bool >::type traditional_gis_order(traditional_gis_orderSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
@@ -1522,24 +1522,24 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_centroid
-Rcpp::NumericVector g_centroid(const Rcpp::RawVector& geom, bool quiet);
+Rcpp::NumericVector g_centroid(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_centroid(SEXP geomSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
     rcpp_result_gen = Rcpp::wrap(g_centroid(geom, quiet));
     return rcpp_result_gen;
 END_RCPP
 }
 // g_transform
-SEXP g_transform(const Rcpp::RawVector& geom, const std::string& srs_from, const std::string& srs_to, bool wrap_date_line, int date_line_offset, bool traditional_gis_order, bool as_iso, const std::string& byte_order, bool quiet);
+SEXP g_transform(const Rcpp::RObject& geom, const std::string& srs_from, const std::string& srs_to, bool wrap_date_line, int date_line_offset, bool traditional_gis_order, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_transform(SEXP geomSEXP, SEXP srs_fromSEXP, SEXP srs_toSEXP, SEXP wrap_date_lineSEXP, SEXP date_line_offsetSEXP, SEXP traditional_gis_orderSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type srs_from(srs_fromSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type srs_to(srs_toSEXP);
     Rcpp::traits::input_parameter< bool >::type wrap_date_line(wrap_date_lineSEXP);

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -24,7 +24,7 @@ OGRGeometryH createGeomFromWkb(const Rcpp::RawVector &wkb);
 bool exportGeomToWkb(OGRGeometryH hGeom, unsigned char *wkb, bool as_iso,
                      const std::string &byte_order);
 
-std::string g_wkb2wkt(const Rcpp::RawVector &geom, bool as_iso);
+Rcpp::String g_wkb2wkt(const Rcpp::RObject &geom, bool as_iso);
 
 Rcpp::CharacterVector g_wkb_list2wkt(const Rcpp::List &geom, bool as_iso);
 
@@ -42,104 +42,104 @@ Rcpp::RawVector g_add_geom(const Rcpp::RawVector &sub_geom,
                            const Rcpp::RawVector &container,
                            bool as_iso, const std::string &byte_order);
 
-Rcpp::LogicalVector g_is_valid(const Rcpp::RawVector &geom, bool quiet);
-SEXP g_make_valid(const Rcpp::RawVector &geom, const std::string &method,
+Rcpp::LogicalVector g_is_valid(const Rcpp::RObject &geom, bool quiet);
+SEXP g_make_valid(const Rcpp::RObject &geom, const std::string &method,
                   bool keep_collapsed, bool as_iso,
                   const std::string &byte_order, bool quiet);
 
-SEXP g_swap_xy(const Rcpp::RawVector &geom, bool as_iso,
+SEXP g_swap_xy(const Rcpp::RObject &geom, bool as_iso,
                const std::string &byte_order, bool quiet);
 
-Rcpp::LogicalVector g_is_empty(const Rcpp::RawVector &geom, bool quiet);
-Rcpp::LogicalVector g_is_3D(const Rcpp::RawVector &geom, bool quiet);
-Rcpp::LogicalVector g_is_measured(const Rcpp::RawVector &geom, bool quiet);
-SEXP g_name(const Rcpp::RawVector &geom, bool quiet);
-SEXP g_summary(const Rcpp::RawVector &geom, bool quiet);
-Rcpp::NumericVector g_envelope(const Rcpp::RawVector &geom, bool as_3d,
+Rcpp::LogicalVector g_is_empty(const Rcpp::RObject &geom, bool quiet);
+Rcpp::LogicalVector g_is_3D(const Rcpp::RObject &geom, bool quiet);
+Rcpp::LogicalVector g_is_measured(const Rcpp::RObject &geom, bool quiet);
+Rcpp::String g_name(const Rcpp::RObject &geom, bool quiet);
+Rcpp::String g_summary(const Rcpp::RObject &geom, bool quiet);
+Rcpp::NumericVector g_envelope(const Rcpp::RObject &geom, bool as_3d,
                                bool quiet);
 
-Rcpp::LogicalVector g_intersects(const Rcpp::RawVector &this_geom,
-                                 const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_intersects(const Rcpp::RObject &this_geom,
+                                 const Rcpp::RObject &other_geom,
                                  bool quiet);
 
-Rcpp::LogicalVector g_equals(const Rcpp::RawVector &this_geom,
-                             const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_equals(const Rcpp::RObject &this_geom,
+                             const Rcpp::RObject &other_geom,
                              bool quiet);
 
-Rcpp::LogicalVector g_disjoint(const Rcpp::RawVector &this_geom,
-                               const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_disjoint(const Rcpp::RObject &this_geom,
+                               const Rcpp::RObject &other_geom,
                                bool quiet);
 
-Rcpp::LogicalVector g_touches(const Rcpp::RawVector &this_geom,
-                              const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_touches(const Rcpp::RObject &this_geom,
+                              const Rcpp::RObject &other_geom,
                               bool quiet);
 
-Rcpp::LogicalVector g_contains(const Rcpp::RawVector &this_geom,
-                               const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_contains(const Rcpp::RObject &this_geom,
+                               const Rcpp::RObject &other_geom,
                                bool quiet);
 
-Rcpp::LogicalVector g_within(const Rcpp::RawVector &this_geom,
-                             const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_within(const Rcpp::RObject &this_geom,
+                             const Rcpp::RObject &other_geom,
                              bool quiet);
 
-Rcpp::LogicalVector g_crosses(const Rcpp::RawVector &this_geom,
-                              const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_crosses(const Rcpp::RObject &this_geom,
+                              const Rcpp::RObject &other_geom,
                               bool quiet);
 
-Rcpp::LogicalVector g_overlaps(const Rcpp::RawVector &this_geom,
-                               const Rcpp::RawVector &other_geom,
+Rcpp::LogicalVector g_overlaps(const Rcpp::RObject &this_geom,
+                               const Rcpp::RObject &other_geom,
                                bool quiet);
 
-SEXP g_boundary(const Rcpp::RawVector &geom, bool as_iso,
+SEXP g_boundary(const Rcpp::RObject &geom, bool as_iso,
                 const std::string &byte_order, bool quiet);
 
-SEXP g_buffer(const Rcpp::RawVector &geom, double dist, int quad_segs,
+SEXP g_buffer(const Rcpp::RObject &geom, double dist, int quad_segs,
               bool as_iso, const std::string &byte_order, bool quiet);
 
-SEXP g_convex_hull(const Rcpp::RawVector &geom, bool as_iso,
+SEXP g_convex_hull(const Rcpp::RObject &geom, bool as_iso,
                    const std::string &byte_order, bool quiet);
 
-SEXP g_delaunay_triangulation(const Rcpp::RawVector &geom, double tolerance,
+SEXP g_delaunay_triangulation(const Rcpp::RObject &geom, double tolerance,
                               bool only_edges, bool as_iso,
                               const std::string &byte_order, bool quiet);
 
-SEXP g_simplify(const Rcpp::RawVector &geom, double tolerance,
+SEXP g_simplify(const Rcpp::RObject &geom, double tolerance,
                 bool preserve_topology, bool as_iso,
                 const std::string &byte_order, bool quiet);
 
-SEXP g_intersection(const Rcpp::RawVector &this_geom,
-                    const Rcpp::RawVector &other_geom,
+SEXP g_intersection(const Rcpp::RObject &this_geom,
+                    const Rcpp::RObject &other_geom,
                     bool as_iso, const std::string &byte_order,
                     bool quiet);
 
-SEXP g_union(const Rcpp::RawVector &this_geom,
-             const Rcpp::RawVector &other_geom,
+SEXP g_union(const Rcpp::RObject &this_geom,
+             const Rcpp::RObject &other_geom,
              bool as_iso, const std::string &byte_order,
              bool quiet);
 
-SEXP g_difference(const Rcpp::RawVector &this_geom,
-                  const Rcpp::RawVector &other_geom,
+SEXP g_difference(const Rcpp::RObject &this_geom,
+                  const Rcpp::RObject &other_geom,
                   bool as_iso, const std::string &byte_order,
                   bool quiet);
 
-SEXP g_sym_difference(const Rcpp::RawVector &this_geom,
-                      const Rcpp::RawVector &other_geom,
+SEXP g_sym_difference(const Rcpp::RObject &this_geom,
+                      const Rcpp::RObject &other_geom,
                       bool as_iso, const std::string &byte_order,
                       bool quiet);
 
-double g_distance(const Rcpp::RawVector &this_geom,
-                  const Rcpp::RawVector &other_geom,
+double g_distance(const Rcpp::RObject &this_geom,
+                  const Rcpp::RObject &other_geom,
                   bool quiet);
 
-double g_length(const Rcpp::RawVector &geom, bool quiet);
-double g_area(const Rcpp::RawVector &geom, bool quiet);
-double g_geodesic_area(const Rcpp::RawVector &geom, const std::string &srs,
+double g_length(const Rcpp::RObject &geom, bool quiet);
+double g_area(const Rcpp::RObject &geom, bool quiet);
+double g_geodesic_area(const Rcpp::RObject &geom, const std::string &srs,
                        bool traditional_gis_order, bool quiet);
-double g_geodesic_length(const Rcpp::RawVector &geom, const std::string &srs,
+double g_geodesic_length(const Rcpp::RObject &geom, const std::string &srs,
                          bool traditional_gis_order, bool quiet);
-Rcpp::NumericVector g_centroid(const Rcpp::RawVector &geom, bool quiet);
+Rcpp::NumericVector g_centroid(const Rcpp::RObject &geom, bool quiet);
 
-SEXP g_transform(const Rcpp::RawVector &geom, const std::string &srs_from,
+SEXP g_transform(const Rcpp::RObject &geom, const std::string &srs_from,
                  const std::string &srs_to, bool wrap_date_line,
                  int date_line_offset, bool traditional_gis_order, bool as_iso,
                  const std::string &byte_order, bool quiet);

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -54,16 +54,17 @@ test_that("geom functions work on wkb/wkt geometries", {
     line <- g_create("LINESTRING", line_xy, as_wkb = FALSE)
 
     # set up vector of WKT, WKB raw vector, and list of WKB raw vectors
-    wkt_vec_1 <- c(bb, bnd)
-    wkt_vec_2 <- c(pt, pt)
+    wkt_vec_1 <- c(bb, bnd, NA_character_)
+    wkt_vec_2 <- c(pt, pt, pt)
 
     bb_wkb <- g_wk2wk(bb)
     expect_true(is.raw(bb_wkb))
     pt_wkb <- g_wk2wk(pt)
     expect_true(is.raw(pt_wkb))
 
-    wkb_list_1 <- g_wk2wk(wkt_vec_1)
-    expect_true(is.list(wkb_list_1) && is.raw(wkb_list_1[[1]]))
+    expect_warning(wkb_list_1 <- g_wk2wk(wkt_vec_1))
+    expect_true(is.list(wkb_list_1) && is.raw(wkb_list_1[[1]]) &&
+                is.null(wkb_list_1[[3]]))
     wkb_list_2 <- g_wk2wk(wkt_vec_2)
     expect_true(is.list(wkb_list_2) && is.raw(wkb_list_2[[1]]))
 
@@ -74,84 +75,96 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_error(g_intersects("invalid WKT", pt))
     expect_error(g_intersects(bnd, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(TRUE, FALSE)
-    expect_equal(g_intersects(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(TRUE, FALSE, NA)
+    expect_warning(
+        expect_equal(g_intersects(wkt_vec_1, wkt_vec_2), expected_value)
+    )
     # WKB
     expect_true(g_intersects(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_intersects(wkb_list_1, wkb_list_2), expected_value)
     # one-to-many
-    expect_equal(g_intersects(pt, wkt_vec_1), expected_value)
+    expect_equal(g_intersects(pt, wkb_list_1), expected_value)
 
     # WKT
     expect_false(g_equals(bb, bnd))
     expect_error(g_equals("invalid WKT", bnd))
     expect_error(g_equals(bb, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(FALSE, FALSE)
-    expect_equal(g_equals(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(FALSE, FALSE, NA)
+    expect_warning(
+        expect_equal(g_equals(wkt_vec_1, wkt_vec_2), expected_value)
+    )
     # WKB
     expect_false(g_equals(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_equals(wkb_list_1, wkb_list_2), expected_value)
     # one-to-many
-    expect_equal(g_equals(pt, wkt_vec_1), expected_value)
+    expect_equal(g_equals(pt, wkb_list_1), expected_value)
 
     # WKT
     expect_false(g_disjoint(bb, bnd))
     expect_error(g_disjoint("invalid WKT", bnd))
     expect_error(g_disjoint(bb, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(FALSE, TRUE)
-    expect_equal(g_disjoint(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(FALSE, TRUE, NA)
+    expect_warning(
+        expect_equal(g_disjoint(wkt_vec_1, wkt_vec_2), expected_value)
+    )
     # WKB
     expect_false(g_disjoint(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_disjoint(wkb_list_1, wkb_list_2), expected_value)
     # one-to-many
-    expect_equal(g_disjoint(pt, wkt_vec_1), expected_value)
+    expect_equal(g_disjoint(pt, wkb_list_1), expected_value)
 
     # WKT
     expect_false(g_touches(bb, bnd))
     expect_error(g_touches("invalid WKT", bnd))
     expect_error(g_touches(bb, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(FALSE, FALSE)
-    expect_equal(g_touches(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(FALSE, FALSE, NA)
+    expect_warning(
+        expect_equal(g_touches(wkt_vec_1, wkt_vec_2), expected_value)
+    )
     # WKB
     expect_false(g_touches(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_touches(wkb_list_1, wkb_list_2), expected_value)
     # one-to-many
-    expect_equal(g_touches(pt, wkt_vec_1), expected_value)
+    expect_equal(g_touches(pt, wkb_list_1), expected_value)
 
     # WKT
     expect_true(g_contains(bb, bnd))
     expect_error(g_contains("invalid WKT", bnd))
     expect_error(g_contains(bb, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(TRUE, FALSE)
-    expect_equal(g_contains(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(TRUE, FALSE, NA)
+    expect_warning(
+        expect_equal(g_contains(wkt_vec_1, wkt_vec_2), expected_value)
+    )
     # WKB
     expect_true(g_contains(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_contains(wkb_list_1, wkb_list_2), expected_value)
     # one-to-many
-    expect_equal(g_contains(bnd, wkt_vec_2), c(FALSE, FALSE))
+    expect_equal(g_contains(bnd, wkb_list_2), c(FALSE, FALSE, FALSE))
 
     # WKT
     expect_false(g_within(bb, bnd))
     expect_error(g_within("invalid WKT", bnd))
     expect_error(g_within(bb, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(TRUE, FALSE)
-    expect_equal(g_within(wkt_vec_2, wkt_vec_1), expected_value)
+    expected_value <- c(TRUE, FALSE, NA)
+    expect_warning(
+        expect_equal(g_within(wkt_vec_2, wkt_vec_1), expected_value)
+    )
     # WKB
     expect_false(g_within(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_within(wkb_list_2, wkb_list_1), expected_value)
     # one-to-many
-    expect_equal(g_within(pt, wkt_vec_1), expected_value)
+    expect_equal(g_within(pt, wkb_list_1), expected_value)
 
     # WKT
     expect_true(g_crosses(line, bnd))
@@ -159,41 +172,45 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_error(g_crosses(line, "invalid WKT"))
     expect_false(g_crosses(line, bb))
     # vector of WKT
-    expected_value <- c(FALSE, FALSE)
-    expect_equal(g_crosses(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(FALSE, FALSE, NA)
+    expect_warning(
+        expect_equal(g_crosses(wkt_vec_1, wkt_vec_2), expected_value)
+    )
     # WKB
     expect_false(g_crosses(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_crosses(wkb_list_1, wkb_list_2), expected_value)
     # one-to-many
-    expect_equal(g_crosses(pt, wkt_vec_1), expected_value)
+    expect_equal(g_crosses(pt, wkb_list_1), expected_value)
 
     # WKT
     expect_false(g_overlaps(bb, bnd))
     expect_error(g_overlaps("invalid WKT", bnd))
     expect_error(g_overlaps(bb, "invalid WKT"))
     # vector of WKT
-    expected_value <- c(FALSE, FALSE)
-    expect_equal(g_overlaps(wkt_vec_1, wkt_vec_2), expected_value)
+    expected_value <- c(FALSE, FALSE, NA)
+    expect_warning(
+        expect_equal(g_overlaps(wkt_vec_1, wkt_vec_2), expected_value)
+    )
     # WKB
     expect_false(g_overlaps(bb_wkb, pt_wkb))
     # list of WKB
     expect_equal(g_overlaps(wkb_list_1, wkb_list_2), expected_value)
     # one-to-many
-    expect_equal(g_overlaps(pt, wkt_vec_1), expected_value)
+    expect_equal(g_overlaps(pt, wkb_list_1), expected_value)
 
     # buffer
     expect_equal(round(bbox_from_wkt(g_buffer(bnd, 100, as_wkb = FALSE))),
                  round(c(323694.2, 5102785.8, 326520.0, 5105029.4)))
     expect_error(g_buffer("invalid WKT", 100))
     # vector of WKT
-    res <- g_buffer(wkt_vec_1, 100)
-    expect_true(is.list(res) && length(res) == 2 && is.raw(res[[1]]))
+    expect_warning(res <- g_buffer(wkt_vec_1, 100))
+    expect_true(is.list(res) && length(res) == 3 && is.raw(res[[1]]))
     # WKB
     expect_true(is.raw(g_buffer(pt_wkb, 10)))
     # list of WKB
     res <- g_buffer(wkb_list_1, 100)
-    expect_true(is.list(res) && length(res) == 2 && is.raw(res[[1]]))
+    expect_true(is.list(res) && length(res) == 3 && is.raw(res[[1]]))
 
     # area
     expect_equal(round(g_area(bnd)), 4039645)
@@ -205,21 +222,21 @@ test_that("geom functions work on wkb/wkt geometries", {
                  9731255)
     expect_error(g_area("invalid WKT"))
     # vector of WKT
-    res <- g_area(wkt_vec_1)
-    expect_vector(res, numeric(), size = 2)
+    expect_warning(res <- g_area(wkt_vec_1))
+    expect_vector(res, numeric(), size = 3)
     expect_equal(round(res[2]), 4039645)
     # WKB
     expect_equal(g_area(pt_wkb), 0)
     # list of WKB
     res <- g_area(wkb_list_1)
-    expect_vector(res, numeric(), size = 2)
+    expect_vector(res, numeric(), size = 3)
     expect_equal(round(res[2]), 4039645)
 
     # distance
     expect_equal(g_distance(pt, bnd), 215.0365, tolerance = 1e-4)
     expect_error(g_distance("invalid WKT"))
     # vector of WKT
-    res <- g_distance(wkt_vec_1, wkt_vec_2)
+    expect_warning(res <- g_distance(wkt_vec_1, wkt_vec_2))
     expect_equal(res[2], 215.0365, tolerance = 1e-4)
     # WKB
     expect_equal(g_distance(pt_wkb, bb_wkb), 0)
@@ -227,14 +244,18 @@ test_that("geom functions work on wkb/wkt geometries", {
     res <- g_distance(wkb_list_1, wkb_list_2)
     expect_equal(res[2], 215.0365, tolerance = 1e-4)
     # one-to-many
-    expect_equal(g_distance(pt, wkt_vec_1), c(0, 215.0365), tolerance = 1e-4)
+    expect_equal(g_distance(pt, wkb_list_1), c(0, 215.0365, NA_real_),
+                 tolerance = 1e-4)
 
     # length
     expect_equal(g_length(line), 3822.927, tolerance = 1e-2)
     expect_error(g_length("invalid WKT"))
-    # vector of WKT
-    res <- g_length(wkt_vec_2)
+    # vector of WKT with missing value
+    expect_warning(
+        res <- g_length(c(wkt_vec_2, NA_character_))
+    )
     expect_equal(res[1], 0)
+    expect_true(is.na(res[4]))
     # WKB
     expect_equal(g_length(pt_wkb), 0)
     # list of WKB
@@ -248,8 +269,8 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_equal(res, c(325134.9, 5103985.4), tolerance = 0.1)
     expect_error(g_centroid("invalid WKT"))
     # vector of WKT
-    res <- g_centroid(wkt_vec_1)
-    expect_true(is.matrix(res) && ncol(res) == 2 && nrow(res) == 2)
+    expect_warning(res <- g_centroid(wkt_vec_1))
+    expect_true(is.matrix(res) && ncol(res) == 2 && nrow(res) == 3)
     expect_equal(colnames(res), c("x", "y"))
     colnames(res) <- NULL
     expect_equal(res[2, ], c(325134.9, 5103985.4), tolerance = 0.1)
@@ -257,7 +278,7 @@ test_that("geom functions work on wkb/wkt geometries", {
     expect_equal(g_centroid(bb_wkb), g_centroid(bb))
     # list of WKB
     res <- g_centroid(wkb_list_1)
-    expect_true(is.matrix(res) && ncol(res) == 2 && nrow(res) == 2)
+    expect_true(is.matrix(res) && ncol(res) == 2 && nrow(res) == 3)
     expect_equal(colnames(res), c("x", "y"))
     colnames(res) <- NULL
     expect_equal(res[2, ], c(325134.9, 5103985.4), tolerance = 0.1)
@@ -438,7 +459,7 @@ test_that("WKB/WKT conversion functions work", {
     rm(wkb_list)
     expect_warning(wkb_list <- g_wk2wk(wkt_vec))
     expect_length(wkb_list, 2)
-    expect_true(is.na(wkb_list[[1]]))
+    expect_true(is.null(wkb_list[[1]]))
     expect_true(g_equals(wkb_list[[2]] |> g_wk2wk(), g2))
 
     # POINT EMPTY special case
@@ -523,12 +544,15 @@ test_that("g_transform / bbox_transform return correct values", {
     expect_vector(res, character(), size = 2)
     expect_equal(bbox_from_wkt(res[1]), bbox_wgs84, tolerance = 1e-4)
 
-    # input list of WKB raw vectors
-    res <- g_transform(wkb_list, ds_srs, epsg_to_wkt(4326))
+    # input list of WKB raw vectors with a NULL geometry
+    res <- g_transform(append(wkb_list, list(NULL)),
+                       srs_from = ds_srs,
+                       srs_to = epsg_to_wkt(4326))
     expect_true(is.list(res) &&
-                length(res) == 2 &&
+                length(res) == 3 &&
                 is.raw(res[[1]]) &&
-                is.raw(res[[2]]))
+                is.raw(res[[2]]) &&
+                is.null(res[[3]]))
     expect_equal(g_wk2wk(res[[1]]) |> bbox_from_wkt(),
                  bbox_wgs84,
                  tolerance = 1e-4)
@@ -561,15 +585,19 @@ test_that("geometry properties are correct", {
     expect_equal(res, c(bb[1], bb[3], bb[2], bb[4]))
 
     # input as vector of WKT / list of WKB
-    wkt_vec <- c(g1, g2, g3)
-    wkb_list <- g_wk2wk(wkt_vec)
+    wkt_vec <- c(g1, g2, g3, NA_character_)
+    expect_warning(wkb_list <- g_wk2wk(wkt_vec))
 
-    expected_value <- c(TRUE, FALSE, TRUE)
-    expect_equal(g_is_valid(wkt_vec), expected_value)
+    expected_value <- c(TRUE, FALSE, TRUE, NA)
+    expect_warning(
+        expect_equal(g_is_valid(wkt_vec), expected_value)
+    )
     expect_equal(g_is_valid(wkb_list), expected_value)
 
-    expected_value <- c(FALSE, FALSE, TRUE)
-    expect_equal(g_is_empty(wkt_vec), expected_value)
+    expected_value <- c(FALSE, FALSE, TRUE, NA)
+    expect_warning(
+        expect_equal(g_is_empty(wkt_vec), expected_value)
+    )
     expect_equal(g_is_empty(wkb_list), expected_value)
 
     # 3D/measured
@@ -718,14 +746,16 @@ test_that("unary ops return correct values", {
     expect_true(nrow(g_coords(g_bnd)) > 1)
     # vector/list input
     # character vector of wkt input
-    g_bnd <- g_boundary(c(g1, g2, g3, g4))
+    expect_warning(
+        g_bnd <- g_boundary(c(g1, g2, g3, g4, NA))
+    )
     expected_names <- c("GEOMETRYCOLLECTION", "GEOMETRYCOLLECTION",
-                        "MULTIPOINT", "LINESTRING")
+                        "MULTIPOINT", "LINESTRING", NA)
     expect_equal(g_name(g_bnd), expected_names)
     # list of wkb input
-    g_bnd <- g_boundary(g_wk2wk(c(g1, g2, g3, g4)))
-    expected_names <- c("GEOMETRYCOLLECTION", "GEOMETRYCOLLECTION",
-                        "MULTIPOINT", "LINESTRING")
+    expect_warning(
+        g_bnd <- g_boundary(g_wk2wk(c(g1, g2, g3, g4, NA)))
+    )
     expect_equal(g_name(g_bnd), expected_names)
 
     # g_convex_hull
@@ -738,11 +768,14 @@ test_that("unary ops return correct values", {
     expect_equal(g_conv_hull, g_expect)
     # vector/list input
     # character vector of wkt input
-    g_conv_hull <- g_convex_hull(c(g1, g1), as_wkb = FALSE)
-    expect_equal(g_conv_hull, rep(g_expect, 2))
+    wkt_vec <- c(g1, g1, NA)
+    expect_warning(g_conv_hull <- g_convex_hull(wkt_vec, as_wkb = FALSE)) |>
+        expect_warning()  # for as_wkb = FASLE
+    expect_equal(g_conv_hull, c(g_expect, g_expect, NA))
     # list of wkb input
-    g_conv_hull <- g_convex_hull(g_wk2wk(c(g1, g1)), as_wkb = FALSE)
-    expect_equal(g_conv_hull, rep(g_expect, 2))
+    expect_warning(wkb_list <- g_wk2wk(wkt_vec))
+    expect_warning(g_conv_hull <- g_convex_hull(wkb_list, as_wkb = FALSE))
+    expect_equal(g_conv_hull, c(g_expect, g_expect, NA))
 
     # g_delaunay_triangulation
     g1 <- "MULTIPOINT(0 0,0 1,1 1,1 0)"
@@ -753,13 +786,17 @@ test_that("unary ops return correct values", {
     g_dt <- g_delaunay_triangulation(g_wk2wk(g1), as_wkb = FALSE)
     expect_equal(g_dt, g_expect)
     # vector/list input
-    g_expect <- rep(g_expect, 2)
+    g_expect <- c(g_expect, g_expect, NA)
     g2 <- "LINESTRING(0 0,1 1,10 0)"
     # character vector of wkt input
-    g_dt <- g_delaunay_triangulation(c(g1, g1), as_wkb = FALSE)
+    expect_warning(g_dt <- g_delaunay_triangulation(c(g1, g1, NA),
+                                                    as_wkb = FALSE)) |>
+        expect_warning()  # for as_wkb = FASLE
     expect_equal(g_dt, g_expect)
     # list of wkb input
-    g_dt <- g_delaunay_triangulation(g_wk2wk(c(g1, g1)), as_wkb = FALSE)
+    expect_warning(g_dt <- g_delaunay_triangulation(g_wk2wk(c(g1, g1, NA)),
+                                                    as_wkb = FALSE)) |>
+        expect_warning()  # for as_wkb = FALSE
     expect_equal(g_dt, g_expect)
 
     # g_simplify
@@ -775,13 +812,17 @@ test_that("unary ops return correct values", {
                          as_wkb = FALSE)
     expect_equal(g_simp, g_expect)
     # vector/list input
-    g_expect <- rep(g_expect, 2)
+    g_expect <- c(g_expect, g_expect, NA)
     g2 <- "LINESTRING(0 0,1 1,10 0)"
     # character vector of wkt input
-    g_simp <- g_simplify(c(g1, g2), tolerance = 5, as_wkb = FALSE)
+    expect_warning(g_simp <- g_simplify(c(g1, g2, NA), tolerance = 5,
+                                        as_wkb = FALSE)) |>
+        expect_warning()  # for as_wkb = FALSE
     expect_equal(g_simp, g_expect)
     # list of wkb input
-    g_simp <- g_simplify(g_wk2wk(c(g1, g2)), tolerance = 5, as_wkb = FALSE)
+    expect_warning(g_simp <- g_simplify(g_wk2wk(c(g1, g2, NA)), tolerance = 5,
+                                        as_wkb = FALSE)) |>
+        expect_warning()  # for as_wkb = FALSE
     expect_equal(g_simp, g_expect)
 })
 
@@ -885,7 +926,7 @@ test_that("make_valid works", {
     # invalid - error
     wkt2 <- "LINESTRING (0 0)"
     expect_warning(wkb2 <- g_make_valid(wkt2))
-    expect_true(is.na(wkb2))
+    expect_true(is.null(wkb2))
 
     # invalid to valid
     wkt3 <- "POLYGON ((0 0,10 10,0 10,10 0,0 0))"
@@ -902,18 +943,22 @@ test_that("make_valid works", {
     expect_true(g_equals(g_wk2wk(wkb4), expected_wkt4))
 
     # vector of WKT input
-    wkt_vec <- c(wkt1, wkt2, wkt3, wkt4)
-    expect_warning(wkb_list <- g_make_valid(wkt_vec, method = "STRUCTURE"))
+    wkt_vec <- c(wkt1, wkt2, wkt3, wkt4, NA)
+    expect_warning(wkb_list <- g_make_valid(wkt_vec, method = "STRUCTURE",
+                                            quiet = TRUE))
     expect_equal(length(wkb_list), length(wkt_vec))
-    expect_true(is.na(wkb_list[[2]]))
+    expect_true(is.null(wkb_list[[2]]))
+    expect_true(is.null(wkb_list[[5]]))
     expect_true(g_equals(g_wk2wk(wkb_list[[4]]), expected_wkt4))
 
     # list of WKB input
     rm(wkb_list)
     expect_warning(wkb_list <- g_make_valid(g_wk2wk(wkt_vec),
-                                            method = "STRUCTURE"))
+                                            method = "STRUCTURE",
+                                            quiet = TRUE))
     expect_equal(length(wkb_list), length(wkt_vec))
-    expect_true(is.na(wkb_list[[2]]))
+    expect_true(is.null(wkb_list[[2]]))
+    expect_true(is.null(wkb_list[[5]]))
     expect_true(g_equals(g_wk2wk(wkb_list[[4]]), expected_wkt4))
 })
 
@@ -928,12 +973,16 @@ test_that("swap xy works", {
     # vector/list input
     g1 <- "POINT(1 2)"
     g2 <- "POINT(2 3)"
-    g_expect <- c("POINT (2 1)", "POINT (3 2)")
+    g_expect <- c("POINT (2 1)", "POINT (3 2)", NA)
     # character vector of wkt input
-    g_swapped <- g_swap_xy(c(g1, g2), as_wkb = FALSE)
+    expect_warning(g_swapped <- g_swap_xy(c(g1, g2, NA), as_wkb = FALSE,
+                                          quiet = TRUE)) |>
+        expect_warning()  # for as_wkb = FALSE
     expect_equal(g_swapped, g_expect)
     # list of wkb input
-    g_swapped <- g_swap_xy(g_wk2wk(c(g1, g2)), as_wkb = FALSE)
+    expect_warning(g_swapped <- g_swap_xy(g_wk2wk(c(g1, g2, NA)), as_wkb = FALSE,
+                                          quiet = TRUE)) |>
+        expect_warning()  # for as_wkb = FALSE
     expect_equal(g_swapped, g_expect)
 })
 

--- a/tests/testthat/test-s3_methods.R
+++ b/tests/testthat/test-s3_methods.R
@@ -76,4 +76,16 @@ test_that("print.OGRFeature / print.OGRFeatureSet work", {
     expect_identical(print(feat_set), feat_set)
 
     lyr$close()
+
+    # GeoJSON with NULL geometries
+    f <- system.file("extdata/test_ogr_geojson_mixed_timezone.geojson",
+                     package = "gdalraster")
+    lyr <- new(GDALVector, f, "test")
+
+    feat <- lyr$getNextFeature()
+    expect_identical(print(feat), feat)
+    feat_set <- lyr$fetch(-1)
+    expect_identical(print(feat_set), feat_set)
+
+    lyr$close()
 })


### PR DESCRIPTION
This PR affects the Geometry API `g_*()` functions. It improves handling of OGR NULL geometries:

* Make I/O consistent with the data type specifications for class `GDALVector`
* `g_wk2wk()` should round trip when `NA` / `NULL` are involved
* `print.OGRFeature()` and `print.OGRFeatureSet()` should denote NULL geometries

TODO:

- [x] Add tests
- [x] Check documentation and update  if needed