### PR TITLE
performance improve for display via col_tbl

### DIFF
--- a/R/display.R
+++ b/R/display.R
@@ -54,8 +54,8 @@
         ct[, 6] <- rgb(ct[, 2], ct[, 3], ct[, 4], ct[, 5],
                        maxColorValue=maxColorValue)
         names(ct) <- c("value", "r", "g", "b", "a", "rgb")
-        f <- function(x) { ct$rgb[match(x, ct$value)] }
-        r <- vapply(a, FUN=f, FUN.VALUE="#00000000", USE.NAMES=FALSE)
+        r <- ct$rgb[match(as.vector(a), ct$value)]
+
         if (anyNA(r))
             r[is.na(r)] <- na_col
         dim(r) <- dim(a)[2:1]


### PR DESCRIPTION
I see a speed up by avoiding vapply, as far as I can tell the result is identical. 

```R
library(gdalraster)

elev_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
ds <- new(GDALRaster, elev_file)

vals <- read_ds(ds) %/% 61
vv <- sort(unique(na.omit(vals)))
tab <- cbind(val = vv, 
             col = scales::rescale(t(col2rgb(hcl.colors(length(vv))))))

system.time(plot_raster(vals, col_tbl = tab, interpolate = F))
# user  system elapsed 
#  0.017   0.000   0.017
```

Prior, I saw more like

```
#  0.143   0.031   0.172
```

(I'm doing this a *lot* with Sentinel 2 classifications, so it's really noticeable)

