### PR TITLE
Add write support for field domains

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2522,6 +2522,27 @@ bbox_to_wkt <- function(bbox, extend_x = 0, extend_y = 0) {
     .Call(`_gdalraster_ogr_ds_layer_names`, dsn)
 }
 
+#' Return a list of the names of all field domains stored in the dataset
+#'
+#' @noRd
+.ogr_ds_field_domain_names <- function(dsn) {
+    .Call(`_gdalraster_ogr_ds_field_domain_names`, dsn)
+}
+
+#' Add a field domain to a dataset
+#'
+#' @noRd
+.ogr_ds_add_field_domain <- function(dsn, fld_dom_defn) {
+    .Call(`_gdalraster_ogr_ds_add_field_domain`, dsn, fld_dom_defn)
+}
+
+#' Delete a field domain from a dataset
+#'
+#' @noRd
+.ogr_ds_delete_field_domain <- function(dsn, domain_name) {
+    .Call(`_gdalraster_ogr_ds_delete_field_domain`, dsn, domain_name)
+}
+
 #' Does layer exist
 #'
 #' @noRd
@@ -2567,8 +2588,8 @@ bbox_to_wkt <- function(bbox, extend_x = 0, extend_y = 0) {
 #' Create a new field on layer
 #'
 #' @noRd
-.ogr_field_create <- function(dsn, layer, fld_name, fld_type, fld_subtype = "OFSTNone", fld_width = 0L, fld_precision = 0L, is_nullable = TRUE, is_unique = FALSE, default_value = "") {
-    .Call(`_gdalraster_ogr_field_create`, dsn, layer, fld_name, fld_type, fld_subtype, fld_width, fld_precision, is_nullable, is_unique, default_value)
+.ogr_field_create <- function(dsn, layer, fld_name, fld_type, fld_subtype = "OFSTNone", fld_width = 0L, fld_precision = 0L, is_nullable = TRUE, is_unique = FALSE, default_value = "", domain_name = "") {
+    .Call(`_gdalraster_ogr_field_create`, dsn, layer, fld_name, fld_type, fld_subtype, fld_width, fld_precision, is_nullable, is_unique, default_value, domain_name)
 }
 
 #' Create a new geom field on layer
@@ -2583,6 +2604,13 @@ bbox_to_wkt <- function(bbox, extend_x = 0, extend_y = 0) {
 #' @noRd
 .ogr_field_rename <- function(dsn, layer, fld_name, new_name) {
     .Call(`_gdalraster_ogr_field_rename`, dsn, layer, fld_name, new_name)
+}
+
+#' Set the field domain of an existing attribute field on a vector layer
+#'
+#' @noRd
+.ogr_field_set_domain_name <- function(dsn, layer, fld_name, domain_name) {
+    .Call(`_gdalraster_ogr_field_set_domain_name`, dsn, layer, fld_name, domain_name)
 }
 
 #' Delete an attribute field on a vector layer

--- a/R/ogr_define.R
+++ b/R/ogr_define.R
@@ -1,4 +1,4 @@
-# Documentation and helper fucntion for OGR feature class definition
+# Documentation and helper functions for OGR feature class definition
 # Chris Toney <chris.toney at usda.gov>
 
 #' OGR feature class definition for vector data
@@ -8,7 +8,7 @@
 #' A named list containing zero or more attribute field definitions, along with
 #' one or more geometry field definitions, comprise an OGR feature class
 #' definition (a.k.a. layer definition). `ogr_def_layer()` initializes such a
-#' list with a geometry type and (optionally) a spatial reference system.
+#' list with the geometry type and (optionally) a spatial reference system.
 #' Attribute fields may then be added to the layer definition.
 #' `ogr_def_field()` creates an attribute field definition, a list
 #' containing the field's data type and potentially other optional field
@@ -16,6 +16,12 @@
 #' `ogr_def_geom_field()` similarly creates a geometry field definition. This
 #' might be used with certain vector formats that support multiple geometry
 #' columns (e.g., PostGIS).
+#' `ogr_def_field_domain()` creates a field domain definition. A field domain
+#' is a set of constraints that apply to one or several fields. This is a
+#' concept found, e.g., in ESRI File Geodatabase and in GeoPackage via the
+#' Schema extension (see \url{https://github.com/OSGeo/gdal/pull/3638}).
+#' GDAL >= 3.3 supports reading and writing field domains with certain drivers
+#' (e.g., GPKG and OpenFileGDB).
 #'
 #' @name ogr_define
 #' @details
@@ -35,6 +41,7 @@
 #' $is_nullable: optional NOT NULL constraint (logical value)
 #' $is_unique  : optional UNIQUE constraint (logical value)
 #' $default    : optional default value as character string
+#' $domain     : optional field domain name
 #' $is_geom    : FALSE (the default) for attribute fields
 #' ```
 #'
@@ -48,9 +55,8 @@
 #' `OFSTNone`, `OFSTBoolean`, `OFSTInt16`, `OFSTFloat32`, `OFSTJSON`,
 #' `OFSTUUID`.
 #'
-#' By default, fields are nullable, have no unique constraint, and are not
-#' ignored (i.e., not omitted when fetching features). Not-null and unique
-#' constraints are not supported by all format drivers.
+#' By default, fields are nullable and have no unique constraint. Not-null and
+#' unique constraints are not supported by all format drivers.
 #'
 #' A default field value is taken into account by format drivers (generally
 #' those with a SQL interface) that support it at field creation time.
@@ -88,6 +94,45 @@
 #' example, GeoPackage format has a layer creation option
 #' `GEOMETRY_NULLABLE=[YES/NO]`.
 #'
+#' The definition for a field domain is a named list with elements:
+#' ```
+#' $type             : domain type ("Coded", "Range", "RangeDateTime", "GLOB")
+#' $domain_name      : name of the field domain (character string)
+#' $description      : optional domain description (character string)
+#' $field_type       : OGR Field Type (see attribute field definitions above)
+#' $field_subtype    : optional OGR Field Subtype ("OFSTBoolean", ...)
+#' $split_policy     : split policy of the field domain (see below)
+#' $merge_policy     : merge policy of the field domain (see below)
+#' $coded_values     : character vector of codes, or `"CODE=VALUE"` pairs
+#' $min_value        : minimum value (data type compatible with $field_type)
+#' $min_is_inclusive : whether the minimum value is included in the range
+#' $max_value        : maximum value (data type compatible with $field_type)
+#' $max_is_inclusive : whether the maximum value is included in the range
+#' $glob             : GLOB expression (character string)
+#' ```
+#'
+#' A field domain can be one of three types:
+#' * `Coded`: an enumerated list of allowed codes with their descriptive values
+#' * `Range`: a range constraint (min, max)
+#' * `GLOB`: a GLOB expression (matching expression like `"*[a-z][0-1]?"`)
+#'
+#' `$type` can also be specified as `"RangeDateTime"`, a range constraint for
+#' `OFTDateTime` fields with `$min_value` and `$max_value` given as
+#' `"POSIXct"` DateTimes.
+#'
+#' Split and merge policies are supported by ESRI File Geodatabase format via
+#' OpenFileGDB driver (or FileGDB driver dependent on FileGDB API library).
+#' When a feature is split in two, `$split_policy` defines how the value of
+#' attributes following the domain are computed. Possible values are
+#' `"DEFAULT_VALUE"` (default value), `"DUPLICATE"` (duplicate), and
+#' `"GEOMETRY_RATIO"` (new values are computed by the ratio of their
+#' area/length compared to the area/length of the original feature).
+#' When a feature is built by merging two features, `$merge_policy` defines
+#' how the value of attributes following the domain are computed. Possible
+#' values are `"DEFAULT_VALUE"` (default value), `"SUM"` (sum), and
+#' `"GEOMETRY_WEIGHTED"` (new values are computed as the weighted average of
+#' the source values).
+#'
 #' @param geom_type Character string specifying a geometry type (see Details).
 #' @param geom_fld_name Character string specifying a geometry field name
 #' Defaults to `"geom"`.
@@ -95,10 +140,10 @@
 #' as OGC WKT or other well-known format (e.g., the input formats usable with
 #' [srs_to_wkt()]).
 #' @param fld_type Character string containing the name of a field data type
-#' (e.g., `OFTInteger`, `OFTInteger64`, `OFTReal`, `OFTString`).
+#' (e.g., `"OFTInteger"`, `"OFTInteger64"`, `"OFTReal"`, `"OFTString"`, ...).
 #' @param fld_subtype Character string containing the name of a field subtype.
-#' One of  `OFSTNone` (the default), `OFSTBoolean`, `OFSTInt16`, `OFSTFloat32`,
-#' `OFSTJSON`, `OFSTUUID`.
+#' One of `"OFSTNone"` (the default), `"OFSTBoolean"`, `"OFSTInt16"`,
+#' `"OFSTFloat32"`, `"OFSTJSON"`, `"OFSTUUID"`.
 #' @param fld_width Optional integer value specifying max number of characters.
 #' @param fld_precision Optional integer value specifying number of digits
 #' after the decimal point.
@@ -106,8 +151,39 @@
 #' Defaults to `TRUE`.
 #' @param is_unique Optional UNIQUE constraint on the field (logical value).
 #' Defaults to `FALSE`.
-#' @param default_value Optional default value for the field as a character
-#' string.
+#' @param default_value Optional default value for the field given as a
+#' character string.
+#' @param domain_type Character string specifying a field domain type (see
+#' Details). Must be one of `"Coded"`, `"Range"`, `"RangeDateTime"`, `"GLOB"`
+#' (case-insensitive).
+#' @param domain_name Character string specifying the name of the field domain.
+#' Optional for `ogr_def_field()`, required for `ogr_def_field_domain()`.
+#' @param description Optional character string giving a description of the
+#' field domain.
+#' @param split_policy Character string specifying the split policy of the
+#' field domain. One of `"DEFAULT_VALUE"`, `"DUPLICATE"`, `"GEOMETRY_RATIO"`
+#' (supported by ESRI File Geodatabase format via OpenFileGDB driver).
+#' @param merge_policy Character string specifying the merge policy of the
+#' field domain. One of `"DEFAULT_VALUE"`, `"SUM"`, `"GEOMETRY_WEIGHTED"`
+#' (supported by ESRI File Geodatabase format via OpenFileGDB driver).
+#' @param coded_values A vector of the allowed codes or `"CODE=VALUE"` pairs
+#' (the expanded "value" associated with a code is optional). Required
+#' if `domain_type = "Coded"`. Each code should appear only once, but it is the
+#' responsibility of the user to check it.
+#' @param range_min Minimum value in a Range or RangeDateTime field domain (can
+#' be NULL). The data type must be consistent with with the field type given in
+#' the `fld_type` argument.
+#' @param min_is_inclusive = Logical value, whether the minimum value is
+#' included in the range. Defaults to `TRUE`. Required if `domain_type` is
+#' `"Range"` or `"RangeDateTime"`.
+#' @param range_max Maximum value in a Range or RangeDateTime field domain (can
+#' be NULL). The data type must be consistent with with the field type given in
+#' the `fld_type` argument.
+#' @param max_is_inclusive = Logical value, whether the maximum value is
+#' included in the range. Defaults to `TRUE`. Required if `domain_type` is
+#' `"Range"` or `"RangeDateTime"`.
+#' @param glob Character string containing the GLOB expression. Required if
+#' `domain_type` is `"GLOB"`.
 #'
 #' @note
 #' The feature id (FID) is a special property of a feature and not treated as
@@ -130,6 +206,11 @@
 #'
 #' WKT representation of geometry:\cr
 #' \url{https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry}
+#'
+#' Field domains:\cr
+#' \url{https://desktop.arcgis.com/en/arcmap/latest/manage-data/geodatabases/an-overview-of-attribute-domains.htm}\cr
+#' \url{https://www.geopackage.org/spec/#extension_schema}\cr
+#' \url{https://gdal.org/en/stable/doxygen/classOGRFieldDomain.html#details}
 #'
 #' @examples
 #' # create a SQLite data source, with SpatiaLite extensions if available
@@ -164,8 +245,11 @@ ogr_def_layer <- function(geom_type, geom_fld_name = "geom", srs = NULL) {
 
     defn <- list()
 
-    if (is.null(srs))
+    if (missing(srs) || is.null(srs))
         srs <- ""
+
+    if (missing(geom_fld_name) || is.null(geom_fld_name))
+        geom_fld_name <- "geom"
 
     if (!(is.character(geom_fld_name) && length(geom_fld_name) == 1))
         stop("'geom_fld_name' must be a length-1 character vector",
@@ -180,7 +264,8 @@ ogr_def_layer <- function(geom_type, geom_fld_name = "geom", srs = NULL) {
 #' @export
 ogr_def_field <- function(fld_type, fld_subtype = NULL, fld_width = NULL,
                           fld_precision = NULL, is_nullable = NULL,
-                          is_unique = NULL, default_value = NULL) {
+                          is_unique = NULL, default_value = NULL,
+                          domain_name = NULL) {
 
     defn <- list()
 
@@ -226,11 +311,20 @@ ogr_def_field <- function(fld_type, fld_subtype = NULL, fld_width = NULL,
     }
 
     if (!is.null(default_value)) {
-        if (!(is.character(default_value) && length(default_value) == 1))
+        default_value <- as.character(default_value)
+        if (!(length(default_value) == 1))
             stop("'default_value' must be a length-1 character vector",
                  call. = FALSE)
         else
             defn$default <- default_value
+    }
+
+    if (!is.null(domain_name)) {
+        if (!(is.character(domain_name) && length(domain_name) == 1))
+            stop("'domain_name' must be a length-1 character vector",
+                 call. = FALSE)
+        else
+            defn$domain <- domain_name
     }
 
     defn$is_geom <- FALSE
@@ -249,7 +343,7 @@ ogr_def_geom_field <- function(geom_type, srs = NULL, is_nullable = NULL) {
     else
         defn$type <- geom_type
 
-    if (is.null(srs))
+    if (missing(srs) || is.null(srs))
         srs <- ""
 
     if (!(is.character(srs) && length(srs) == 1))
@@ -270,3 +364,190 @@ ogr_def_geom_field <- function(geom_type, srs = NULL, is_nullable = NULL) {
     return(defn)
 }
 
+#' @name ogr_define
+#' @export
+ogr_def_field_domain <- function(domain_type, domain_name, description = NULL,
+                                 fld_type = NULL, fld_subtype = "OFSTNone",
+                                 split_policy = "DEFAULT_VALUE",
+                                 merge_policy = "DEFAULT_VALUE",
+                                 coded_values = NULL,
+                                 range_min = NULL, min_is_inclusive = TRUE,
+                                 range_max = NULL, max_is_inclusive = TRUE,
+                                 glob = "") {
+
+    if (gdal_version_num() <= gdal_compute_version(3, 3, 0)) {
+        warning("GDAL >= 3.3 is required for writing field domains",
+                call. = FALSE)
+    }
+
+    defn <- list()
+
+    if (!(is.character(domain_type) && length(domain_type) == 1)) {
+        stop("'domain_type' must be a length-1 character vector", call. = FALSE)
+    }
+    if (is.na(domain_type) || !nzchar(domain_type)) {
+        stop("'domain_type' is required", call. = FALSE)
+    }
+    if (!(tolower(domain_type) %in% c("coded", "range", "rangedatetime", "glob"))) {
+        stop("'domain_type' must be one of \"Coded\", \"Range\", \"RangeDateTime\", \"GLOB\"",
+             call. = FALSE)
+    }
+    defn$type <- domain_type
+
+    if (!(is.character(domain_name) && length(domain_name) == 1)) {
+        stop("'domain_name' must be a length-1 character vector", call. = FALSE)
+    }
+    if (is.na(domain_name) || !nzchar(domain_name)) {
+        stop("'domain_name' is required", call. = FALSE)
+    }
+    defn$domain_name <- domain_name
+
+    if (missing(description) || is.null(description) || is.na(description)) {
+        description <- ""
+    } else if (!(is.character(description) && length(description) == 1)) {
+        stop("'description' must be a length-1 character vector", call. = FALSE)
+    }
+    defn$description <- description
+
+    if (missing(fld_type) || is.null(fld_type) || is.na(fld_type)) {
+        stop("'fld_type' is required", call. = FALSE)
+    }
+    if (!(is.character(fld_type) && length(fld_type) == 1)) {
+        stop("'fld_type' must be a length-1 character vector", call. = FALSE)
+    }
+    defn$field_type <- fld_type
+
+    if (missing(fld_subtype) || is.null(fld_subtype) || is.na(fld_subtype)) {
+        fld_subtype <- "OFSTNone"
+    } else if (!(is.character(fld_subtype) && length(fld_subtype) == 1)) {
+        stop("'fld_subtype' must be a length-1 character vector",
+             call. = FALSE)
+    }
+    defn$field_subtype <- fld_subtype
+
+    if (!(is.character(split_policy) && length(split_policy) == 1)) {
+        stop("'split_policy' must be a length-1 character vector",
+             call. = FALSE)
+    }
+    if (is.na(split_policy) || !nzchar(split_policy)) {
+        split_policy <- "DEFAULT_VALUE"
+    }
+    if (!(toupper(split_policy) %in% c("DEFAULT_VALUE", "DUPLICATE", "GEOMETRY_RATIO"))) {
+        stop("'split_policy' must be one of \"DEFAULT_VALUE\", \"DUPLICATE\", \"GEOMETRY_RATIO\"",
+             call. = FALSE)
+    }
+    defn$split_policy <- toupper(split_policy)
+
+    if (!(is.character(merge_policy) && length(merge_policy) == 1)) {
+        stop("'merge_policy' must be a length-1 character vector",
+             call. = FALSE)
+    }
+    if (is.na(merge_policy) || !nzchar(merge_policy)) {
+        merge_policy <- "DEFAULT_VALUE"
+    }
+    if (!(toupper(merge_policy) %in% c("DEFAULT_VALUE", "SUM", "GEOMETRY_WEIGHTED"))) {
+        stop("'merge_policy' must be one of \"DEFAULT_VALUE\", \"SUM\", \"GEOMETRY_WEIGHTED\"",
+             call. = FALSE)
+    }
+    defn$merge_policy <- toupper(merge_policy)
+
+    defn["coded_values"] <- list(NULL)
+    defn["min_value"] <- list(NULL)
+    defn$min_is_inclusive <- TRUE
+    defn["max_value"] <- list(NULL)
+    defn$max_is_inclusive <- TRUE
+    defn$glob <- ""
+
+    if (tolower(domain_type) == "coded") {
+        if (!missing(coded_values)) {
+            coded_values <- as.character(coded_values)
+        } else {
+            stop("'coded_values' is required for Coded domain type",
+                 call. = FALSE)
+        }
+        if (length(coded_values) == 0) {
+            stop("'coded_values' is empty", call. = FALSE)
+        }
+        if (any(is.na(coded_values))) {
+            stop("'coded_values' contains NA", call. = FALSE)
+        }
+        defn$coded_values <- coded_values
+
+    } else if (tolower(domain_type) == "range") {
+        if (!is.null(range_min) && !all(is.na(range_min))) {
+            if (!(is.numeric(range_min) && length(range_min) == 1)) {
+                stop("'range_min' must be a single numeric value or NULL",
+                        call. = FALSE)
+            } else {
+                defn$min_value <- range_min
+            }
+        }
+        if (!(is.logical(min_is_inclusive) && length(min_is_inclusive) == 1)) {
+            stop("'min_is_inclusive' must be a single logical value",
+                 call. = FALSE)
+        } else {
+            defn$min_is_inclusive <- min_is_inclusive
+        }
+        if (!is.null(range_max) && !all(is.na(range_max))) {
+            if (!(is.numeric(range_max) && length(range_max) == 1)) {
+                stop("'range_max' must be a single numeric value or NULL",
+                        call. = FALSE)
+            } else {
+                defn$max_value <- range_max
+            }
+        }
+        if (!(is.logical(max_is_inclusive) && length(max_is_inclusive) == 1)) {
+            stop("'max_is_inclusive' must be a single logical value",
+                 call. = FALSE)
+        } else {
+            defn$max_is_inclusive <- max_is_inclusive
+        }
+
+    } else if (tolower(domain_type) == "rangedatetime") {
+        if (!is.null(range_min) && !all(is.na(range_min))) {
+            if (!(is(range_min, "POSIXct") && length(range_min) == 1)) {
+                stop("'range_min' must be a single POSIXct value or NULL",
+                     call. = FALSE)
+            } else {
+                defn$min_value <- range_min
+            }
+        }
+        if (!(is.logical(min_is_inclusive) && length(min_is_inclusive) == 1)) {
+            stop("'min_is_inclusive' must be a single logical value",
+                 call. = FALSE)
+        } else {
+            defn$min_is_inclusive <- min_is_inclusive
+        }
+        if (!is.null(range_max) && !all(is.na(range_max))) {
+            if (!(is(range_max, "POSIXct") && length(range_max) == 1)) {
+                stop("'range_max' must be a single POSIXct value or NULL",
+                     call. = FALSE)
+            } else {
+                defn$max_value <- range_max
+            }
+        }
+        if (!(is.logical(max_is_inclusive) && length(max_is_inclusive) == 1)) {
+            stop("'max_is_inclusive' must be a single logical value",
+                 call. = FALSE)
+        } else {
+            defn$max_is_inclusive <- max_is_inclusive
+        }
+
+    } else if (tolower(domain_type) == "glob") {
+        if (missing(glob) || is.null(glob)) {
+            stop("'glob' is required", call. = FALSE)
+        }
+        if (!(is.character(glob) && length(glob) == 1)) {
+            stop("'glob' must be a length-1 character vector", call. = FALSE)
+        }
+        if (is.na(glob) || !nzchar(glob)) {
+            stop("'glob' is required", call. = FALSE)
+        }
+        defn$glob <- glob
+
+    } else {
+        stop("'domain_type' not recognized", call. = FALSE)
+    }
+
+    return(defn)
+}

--- a/man/ogr_define.Rd
+++ b/man/ogr_define.Rd
@@ -5,6 +5,7 @@
 \alias{ogr_def_layer}
 \alias{ogr_def_field}
 \alias{ogr_def_geom_field}
+\alias{ogr_def_field_domain}
 \title{OGR feature class definition for vector data}
 \usage{
 ogr_def_layer(geom_type, geom_fld_name = "geom", srs = NULL)
@@ -16,10 +17,27 @@ ogr_def_field(
   fld_precision = NULL,
   is_nullable = NULL,
   is_unique = NULL,
-  default_value = NULL
+  default_value = NULL,
+  domain_name = NULL
 )
 
 ogr_def_geom_field(geom_type, srs = NULL, is_nullable = NULL)
+
+ogr_def_field_domain(
+  domain_type,
+  domain_name,
+  description = NULL,
+  fld_type = NULL,
+  fld_subtype = "OFSTNone",
+  split_policy = "DEFAULT_VALUE",
+  merge_policy = "DEFAULT_VALUE",
+  coded_values = NULL,
+  range_min = NULL,
+  min_is_inclusive = TRUE,
+  range_max = NULL,
+  max_is_inclusive = TRUE,
+  glob = ""
+)
 }
 \arguments{
 \item{geom_type}{Character string specifying a geometry type (see Details).}
@@ -32,11 +50,11 @@ as OGC WKT or other well-known format (e.g., the input formats usable with
 \code{\link[=srs_to_wkt]{srs_to_wkt()}}).}
 
 \item{fld_type}{Character string containing the name of a field data type
-(e.g., \code{OFTInteger}, \code{OFTInteger64}, \code{OFTReal}, \code{OFTString}).}
+(e.g., \code{"OFTInteger"}, \code{"OFTInteger64"}, \code{"OFTReal"}, \code{"OFTString"}, ...).}
 
 \item{fld_subtype}{Character string containing the name of a field subtype.
-One of  \code{OFSTNone} (the default), \code{OFSTBoolean}, \code{OFSTInt16}, \code{OFSTFloat32},
-\code{OFSTJSON}, \code{OFSTUUID}.}
+One of \code{"OFSTNone"} (the default), \code{"OFSTBoolean"}, \code{"OFSTInt16"},
+\code{"OFSTFloat32"}, \code{"OFSTJSON"}, \code{"OFSTUUID"}.}
 
 \item{fld_width}{Optional integer value specifying max number of characters.}
 
@@ -49,8 +67,50 @@ Defaults to \code{TRUE}.}
 \item{is_unique}{Optional UNIQUE constraint on the field (logical value).
 Defaults to \code{FALSE}.}
 
-\item{default_value}{Optional default value for the field as a character
-string.}
+\item{default_value}{Optional default value for the field given as a
+character string.}
+
+\item{domain_name}{Character string specifying the name of the field domain.
+Optional for \code{ogr_def_field()}, required for \code{ogr_def_field_domain()}.}
+
+\item{domain_type}{Character string specifying a field domain type (see
+Details). Must be one of \code{"Coded"}, \code{"Range"}, \code{"RangeDateTime"}, \code{"GLOB"}
+(case-insensitive).}
+
+\item{description}{Optional character string giving a description of the
+field domain.}
+
+\item{split_policy}{Character string specifying the split policy of the
+field domain. One of \code{"DEFAULT_VALUE"}, \code{"DUPLICATE"}, \code{"GEOMETRY_RATIO"}
+(supported by ESRI File Geodatabase format via OpenFileGDB driver).}
+
+\item{merge_policy}{Character string specifying the merge policy of the
+field domain. One of \code{"DEFAULT_VALUE"}, \code{"SUM"}, \code{"GEOMETRY_WEIGHTED"}
+(supported by ESRI File Geodatabase format via OpenFileGDB driver).}
+
+\item{coded_values}{A vector of the allowed codes or \code{"CODE=VALUE"} pairs
+(the expanded "value" associated with a code is optional). Required
+if \code{domain_type = "Coded"}. Each code should appear only once, but it is the
+responsibility of the user to check it.}
+
+\item{range_min}{Minimum value in a Range or RangeDateTime field domain (can
+be NULL). The data type must be consistent with with the field type given in
+the \code{fld_type} argument.}
+
+\item{min_is_inclusive}{= Logical value, whether the minimum value is
+included in the range. Defaults to \code{TRUE}. Required if \code{domain_type} is
+\code{"Range"} or \code{"RangeDateTime"}.}
+
+\item{range_max}{Maximum value in a Range or RangeDateTime field domain (can
+be NULL). The data type must be consistent with with the field type given in
+the \code{fld_type} argument.}
+
+\item{max_is_inclusive}{= Logical value, whether the maximum value is
+included in the range. Defaults to \code{TRUE}. Required if \code{domain_type} is
+\code{"Range"} or \code{"RangeDateTime"}.}
+
+\item{glob}{Character string containing the GLOB expression. Required if
+\code{domain_type} is \code{"GLOB"}.}
 }
 \description{
 This topic contains documentation and helper functions for defining an
@@ -58,7 +118,7 @@ OGR feature class.
 A named list containing zero or more attribute field definitions, along with
 one or more geometry field definitions, comprise an OGR feature class
 definition (a.k.a. layer definition). \code{ogr_def_layer()} initializes such a
-list with a geometry type and (optionally) a spatial reference system.
+list with the geometry type and (optionally) a spatial reference system.
 Attribute fields may then be added to the layer definition.
 \code{ogr_def_field()} creates an attribute field definition, a list
 containing the field's data type and potentially other optional field
@@ -66,6 +126,12 @@ properties.
 \code{ogr_def_geom_field()} similarly creates a geometry field definition. This
 might be used with certain vector formats that support multiple geometry
 columns (e.g., PostGIS).
+\code{ogr_def_field_domain()} creates a field domain definition. A field domain
+is a set of constraints that apply to one or several fields. This is a
+concept found, e.g., in ESRI File Geodatabase and in GeoPackage via the
+Schema extension (see \url{https://github.com/OSGeo/gdal/pull/3638}).
+GDAL >= 3.3 supports reading and writing field domains with certain drivers
+(e.g., GPKG and OpenFileGDB).
 }
 \details{
 All features in an OGR Layer share a common schema (feature class), modeled
@@ -84,6 +150,7 @@ $precision  : optional number of digits after the decimal point
 $is_nullable: optional NOT NULL constraint (logical value)
 $is_unique  : optional UNIQUE constraint (logical value)
 $default    : optional default value as character string
+$domain     : optional field domain name
 $is_geom    : FALSE (the default) for attribute fields
 }\if{html}{\out{</div>}}
 
@@ -97,9 +164,8 @@ values:
 \code{OFSTNone}, \code{OFSTBoolean}, \code{OFSTInt16}, \code{OFSTFloat32}, \code{OFSTJSON},
 \code{OFSTUUID}.
 
-By default, fields are nullable, have no unique constraint, and are not
-ignored (i.e., not omitted when fetching features). Not-null and unique
-constraints are not supported by all format drivers.
+By default, fields are nullable and have no unique constraint. Not-null and
+unique constraints are not supported by all format drivers.
 
 A default field value is taken into account by format drivers (generally
 those with a SQL interface) that support it at field creation time.
@@ -136,6 +202,47 @@ this is generally before creating any features to the layer. In some cases,
 a not-null constraint may be available as a layer creation option. For
 example, GeoPackage format has a layer creation option
 \verb{GEOMETRY_NULLABLE=[YES/NO]}.
+
+The definition for a field domain is a named list with elements:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{$type             : domain type ("Coded", "Range", "RangeDateTime", "GLOB")
+$domain_name      : name of the field domain (character string)
+$description      : optional domain description (character string)
+$field_type       : OGR Field Type (see attribute field definitions above)
+$field_subtype    : optional OGR Field Subtype ("OFSTBoolean", ...)
+$split_policy     : split policy of the field domain (see below)
+$merge_policy     : merge policy of the field domain (see below)
+$coded_values     : character vector of codes, or `"CODE=VALUE"` pairs
+$min_value        : minimum value (data type compatible with $field_type)
+$min_is_inclusive : whether the minimum value is included in the range
+$max_value        : maximum value (data type compatible with $field_type)
+$max_is_inclusive : whether the maximum value is included in the range
+$glob             : GLOB expression (character string)
+}\if{html}{\out{</div>}}
+
+A field domain can be one of three types:
+\itemize{
+\item \code{Coded}: an enumerated list of allowed codes with their descriptive values
+\item \code{Range}: a range constraint (min, max)
+\item \code{GLOB}: a GLOB expression (matching expression like \code{"*[a-z][0-1]?"})
+}
+
+\verb{$type} can also be specified as \code{"RangeDateTime"}, a range constraint for
+\code{OFTDateTime} fields with \verb{$min_value} and \verb{$max_value} given as
+\code{"POSIXct"} DateTimes.
+
+Split and merge policies are supported by ESRI File Geodatabase format via
+OpenFileGDB driver (or FileGDB driver dependent on FileGDB API library).
+When a feature is split in two, \verb{$split_policy} defines how the value of
+attributes following the domain are computed. Possible values are
+\code{"DEFAULT_VALUE"} (default value), \code{"DUPLICATE"} (duplicate), and
+\code{"GEOMETRY_RATIO"} (new values are computed by the ratio of their
+area/length compared to the area/length of the original feature).
+When a feature is built by merging two features, \verb{$merge_policy} defines
+how the value of attributes following the domain are computed. Possible
+values are \code{"DEFAULT_VALUE"} (default value), \code{"SUM"} (sum), and
+\code{"GEOMETRY_WEIGHTED"} (new values are computed as the weighted average of
+the source values).
 }
 \note{
 The feature id (FID) is a special property of a feature and not treated as
@@ -187,4 +294,9 @@ deleteDataset(dsn)
 
 WKT representation of geometry:\cr
 \url{https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry}
+
+Field domains:\cr
+\url{https://desktop.arcgis.com/en/arcmap/latest/manage-data/geodatabases/an-overview-of-attribute-domains.htm}\cr
+\url{https://www.geopackage.org/spec/#extension_schema}\cr
+\url{https://gdal.org/en/stable/doxygen/classOGRFieldDomain.html#details}
 }

--- a/man/ogr_manage.Rd
+++ b/man/ogr_manage.Rd
@@ -8,6 +8,9 @@
 \alias{ogr_ds_create}
 \alias{ogr_ds_layer_count}
 \alias{ogr_ds_layer_names}
+\alias{ogr_ds_field_domain_names}
+\alias{ogr_ds_add_field_domain}
+\alias{ogr_ds_delete_field_domain}
 \alias{ogr_layer_exists}
 \alias{ogr_layer_test_cap}
 \alias{ogr_layer_create}
@@ -18,6 +21,7 @@
 \alias{ogr_field_create}
 \alias{ogr_geom_field_create}
 \alias{ogr_field_rename}
+\alias{ogr_field_set_domain_name}
 \alias{ogr_field_delete}
 \alias{ogr_execute_sql}
 \title{Utility functions for managing vector data sources}
@@ -46,6 +50,12 @@ ogr_ds_create(
 ogr_ds_layer_count(dsn)
 
 ogr_ds_layer_names(dsn)
+
+ogr_ds_field_domain_names(dsn)
+
+ogr_ds_add_field_domain(dsn, fld_dom_defn)
+
+ogr_ds_delete_field_domain(dsn, domain_name)
 
 ogr_layer_exists(dsn, layer)
 
@@ -80,7 +90,8 @@ ogr_field_create(
   fld_precision = 0L,
   is_nullable = TRUE,
   is_unique = FALSE,
-  default_value = ""
+  default_value = "",
+  domain_name = NULL
 )
 
 ogr_geom_field_create(
@@ -95,6 +106,8 @@ ogr_geom_field_create(
 
 ogr_field_rename(dsn, layer, fld_name, new_name)
 
+ogr_field_set_domain_name(dsn, layer, fld_name, domain_name)
+
 ogr_field_delete(dsn, layer, fld_name)
 
 ogr_execute_sql(dsn, sql, spatial_filter = NULL, dialect = NULL)
@@ -103,7 +116,7 @@ ogr_execute_sql(dsn, sql, spatial_filter = NULL, dialect = NULL)
 \item{dsn}{Character string. The vector data source name, e.g., a filename
 or database connection string.}
 
-\item{with_update}{Logical scalar. \code{TRUE} to request update access when
+\item{with_update}{Logical value. \code{TRUE} to request update access when
 opening the dataset, or \code{FALSE} to open read-only.}
 
 \item{format}{GDAL short name of the vector format as character string.
@@ -139,7 +152,7 @@ as OGC WKT or other well-known format (e.g., the input formats usable with
 in \code{layer}.}
 
 \item{fld_type}{Character string containing the name of a field data type
-(e.g., \code{OFTInteger}, \code{OFTReal}, \code{OFTString}).}
+(e.g., \code{"OFTInteger"}, \code{"OFTInteger64"}, \code{"OFTReal"}, \code{"OFTString"}, ...).}
 
 \item{dsco}{Optional character vector of format-specific creation options
 for \code{dsn} (\code{"NAME=VALUE"} pairs).}
@@ -147,13 +160,18 @@ for \code{dsn} (\code{"NAME=VALUE"} pairs).}
 \item{lco}{Optional character vector of format-specific creation options
 for \code{layer} (\code{"NAME=VALUE"} pairs).}
 
-\item{overwrite}{Logical scalar. \code{TRUE} to overwrite \code{dsn} if it already
+\item{overwrite}{Logical value. \code{TRUE} to overwrite \code{dsn} if it already
 exists when calling \code{ogr_ds_create()}. Default is \code{FALSE}.}
 
-\item{return_obj}{Logical scalar. If \code{TRUE}, an object of class
+\item{return_obj}{Logical value. If \code{TRUE}, an object of class
 \code{\link{GDALVector}} open on the newly created layer will be
 returned. Defaults to \code{FALSE}. Must be used with either the \code{layer} or
 \code{layer_defn} arguments.}
+
+\item{fld_dom_defn}{A field domain definition, i.e., a list generated with
+\code{\link[=ogr_def_field_domain]{ogr_def_field_domain()}}.}
+
+\item{domain_name}{Character string specifying the name of the field domain.}
 
 \item{new_name}{Character string containing a new name to assign.}
 
@@ -162,27 +180,26 @@ Additional arguments in \code{ogr_field_create()} will be ignored if a \code{fld
 is given.}
 
 \item{fld_subtype}{Character string containing the name of a field subtype.
-One of  \code{OFSTNone} (the default), \code{OFSTBoolean}, \code{OFSTInt16}, \code{OFSTFloat32},
-\code{OFSTJSON}, \code{OFSTUUID}.}
+One of \code{"OFSTNone"} (the default), \code{"OFSTBoolean"}, \code{"OFSTInt16"},
+\code{"OFSTFloat32"}, \code{"OFSTJSON"}, \code{"OFSTUUID"}.}
 
-\item{fld_width}{Optional integer scalar specifying max number of characters.}
+\item{fld_width}{Optional integer value specifying max number of characters.}
 
-\item{fld_precision}{Optional integer scalar specifying number of digits
+\item{fld_precision}{Optional integer value specifying number of digits
 after the decimal point.}
 
-\item{is_nullable}{Optional NOT NULL field constraint (logical scalar).
+\item{is_nullable}{Optional NOT NULL field constraint (logical value).
 Defaults to \code{TRUE}.}
 
-\item{is_unique}{Optional UNIQUE constraint on the field (logical scalar).
+\item{is_unique}{Optional UNIQUE constraint on the field (logical value).
 Defaults to \code{FALSE}.}
 
 \item{default_value}{Optional default value for the field as a character
 string.}
 
-\item{geom_fld_defn}{A geometry field definition as list
-(see \code{\link[=ogr_def_geom_field]{ogr_def_geom_field()}}).
-Additional arguments in \code{ogr_geom_field_create()} will be ignored if a
-\code{geom_fld_defn} is given.}
+\item{geom_fld_defn}{A geometry field definition as list (see
+\code{\link[=ogr_def_geom_field]{ogr_def_geom_field()}}). Additional arguments in \code{ogr_geom_field_create()}
+will be ignored if a \code{geom_fld_defn} is given.}
 
 \item{sql}{Character string containing an SQL statement (see Note).}
 
@@ -197,8 +214,9 @@ given. The \code{"SQLite"} dialect can also be used (see Note).}
 \description{
 This set of functions can be used to create new vector datasets,
 test existence of dataset/layer/field, test dataset and layer capabilities,
-create new layers in an existing dataset, delete layers, create new
-attribute and geometry fields on an existing layer, rename and delete
+create new layers in an existing dataset, get the names of field domains
+stored in a dataset, write field domains in a dataset, delete layers, create
+new attribute and geometry fields on an existing layer, rename and delete
 fields, and edit data with SQL statements.
 }
 \details{
@@ -209,7 +227,7 @@ Vector API (ogr_core.h and ogr_api.h,
 
 \code{ogr_ds_exists()} tests whether a vector dataset can be opened from the
 given data source name (DSN), potentially testing for update access.
-Returns a logical scalar.
+Returns a logical value.
 
 \code{ogr_ds_format()} returns a character string containing the short name of
 the format driver for a given DSN, or \code{NULL} if the dataset cannot be
@@ -222,23 +240,29 @@ returned if \code{dsn} cannot be opened with the requested access.
 Wrapper of \code{GDALDatasetTestCapability()} in the GDAL API.
 The returned list contains the following named elements:
 \itemize{
-\item \code{CreateLayer}: \code{TRUE} if this datasource can create new layers
-\item \code{DeleteLayer}: \code{TRUE} if this datasource can delete existing layers
+\item \code{CreateLayer}: \code{TRUE} if this dataset can create new layers
+\item \code{DeleteLayer}: \code{TRUE} if this dataset can delete existing layers
 \item \code{CreateGeomFieldAfterCreateLayer}: \code{TRUE} if the layers of this
-datasource support geometry field creation just after layer creation
-\item \code{CurveGeometries}: \code{TRUE} if this datasource supports curve geometries
-\item \code{Transactions}: \code{TRUE} if this datasource supports (efficient)
+dataset supports geometry field creation just after layer creation
+\item \code{CurveGeometries}: \code{TRUE} if this dataset supports curve geometries
+\item \code{Transactions}: \code{TRUE} if this dataset supports (efficient)
 transactions
-\item \code{EmulatedTransactions}: \code{TRUE} if this datasource supports transactions
+\item \code{EmulatedTransactions}: \code{TRUE} if this dataset supports transactions
 through emulation
-\item \code{RandomLayerRead}: \code{TRUE} if this datasource has a dedicated
+\item \code{RandomLayerRead}: \code{TRUE} if this dataset has a dedicated
 \code{GetNextFeature()} implementation, potentially returning features from
 layers in a non-sequential way
-\item \code{RandomLayerWrite}: \code{TRUE} if this datasource supports calling
+\item \code{RandomLayerWrite}: \code{TRUE} if this dataset supports calling
 \code{CreateFeature()} on layers in a non-sequential way
+\item \code{AddFieldDomain}: \code{TRUE} if this dataset supports adding field domains
+(GDAL >= 3.3)
+\item \code{DeleteFieldDomain}: \code{TRUE} if this dataset supports deleting field
+domains (GDAL >= 3.5)
+\code{UpdateFieldDomain}: \code{TRUE} if this dataset supports updating a an existing
+field domain by replacing its definition (GDAL >= 3.5)
 }
 
-\code{ogr_ds_create()} creates a new vector datasource, optionally also creating
+\code{ogr_ds_create()} creates a new vector dataset, optionally also creating
 a layer, and optionally creating one or more fields on the layer.
 The attribute fields and geometry field(s) to create can be specified as a
 feature class definition (\code{layer_defn} as list, see \link{ogr_define}), or
@@ -254,8 +278,27 @@ the operation fails.
 \code{ogr_ds_layer_names()} returns a character vector of layer names in a
 vector dataset, or \code{NULL} if no layers are found.
 
+\code{ogr_ds_field_domain_names()} returns a character vector with the names of
+all field domains stored in the dataset. Returns \code{NULL} and emits a warning
+if an error occurs or if the format does not support reading field domains.
+Returns a character vector of length 0 (\code{character(0)}) if the format
+supports field domains but none are present in the dataset.
+Requires GDAL >= 3.5. See \link{ogr_define} for information on field domains.
+
+\code{ogr_ds_add_field_domain()} adds a field domain to a vector dataset. Only a
+few drivers will support this operation, and some of them might only support
+it only for some types of field domains. GeoPackage and OpenFileGDB drivers
+support this operation. A dataset having at least some support should report
+the \code{AddFieldDomain} dataset capability (see \code{ogr_ds_test_cap()}above).
+Returns a logical value, \code{TRUE} indicating success. Requires GDAL >= 3.3.
+
+\code{ogr_ds_delete_field_domain()} deletes a field domain from a vector dataset
+if supported (see \code{ogr_ds_test_cap()}above for the \code{DeleteFieldDomain}
+dataset capability). Returns a logical value, \code{TRUE} indicating success.
+Requires GDAL >= 3.5.
+
 \code{ogr_layer_exists()} tests whether a layer can be accessed by name in a
-given vector dataset. Returns a logical scalar.
+given vector dataset. Returns a logical value
 
 \code{ogr_layer_test_cap()} tests whether a layer supports named capabilities,
 attempting to open the dataset with update access by default.
@@ -287,11 +330,11 @@ if \code{NULL} is given for the \code{layer} argument.
 \code{ogr_layer_rename()} renames a layer in a vector dataset. This operation is
 implemented only by layers that expose the \code{Rename} capability (see
 \code{ogr_layer_test_cap()} above). This operation will fail if a layer with the
-new name already exists. Returns a logical scalar, \code{TRUE} indicating success.
+new name already exists. Returns a logical value, \code{TRUE} indicating success.
 Requires GDAL >= 3.5.
 
 \code{ogr_layer_delete()} deletes an existing layer in a vector dataset.
-Returns a logical scalar, \code{TRUE} indicating success.
+Returns a logical value, \code{TRUE} indicating success.
 
 \code{ogr_field_index()} tests for existence of an attribute field by name.
 Returns the field index on the layer (0-based), or \code{-1} if the field does
@@ -299,21 +342,26 @@ not exist.
 
 \code{ogr_field_create()} creates a new attribute field of specified data type in
 a given DSN/layer. Several optional field properties can be specified in
-addition to the type. Returns a logical scalar, \code{TRUE} indicating success.
+addition to the type. Returns a logical value, \code{TRUE} indicating success.
 
 \code{ogr_geom_field_create()} creates a new geometry field of specified type in
-a given DSN/layer. Returns a logical scalar, \code{TRUE} indicating success.
+a given DSN/layer. Returns a logical value, \code{TRUE} indicating success.
 
 \code{ogr_field_rename()} renames an existing field on a vector layer.
 Not all format drivers support this function. Some drivers may only support
 renaming a field while there are still no features in the layer.
 \code{AlterFieldDefn} is the relevant layer capability to check.
-Returns a logical scalar, \code{TRUE} indicating success.
+Returns a logical value, \code{TRUE} indicating success.
+
+\code{ogr_field_set_domain_name()} sets the field domain name for an existing
+attribute field on a vector layer. \code{AlterFieldDefn} layer capability is
+required. Returns a logical value, \code{TRUE} indicating success.
+Requires GDAL >= 3.3.
 
 \code{ogr_field_delete()} deletes an existing field on a vector layer.
 Not all format drivers support this function. Some drivers may only support
 deleting a field while there are still no features in the layer.
-Returns a logical scalar, \code{TRUE} indicating success.
+Returns a logical value, \code{TRUE} indicating success.
 
 \code{ogr_execute_sql()} executes an SQL statement against the data store.
 This function can be used to modify the schema or edit data using SQL

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1635,6 +1635,41 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// ogr_ds_field_domain_names
+SEXP ogr_ds_field_domain_names(const std::string& dsn);
+RcppExport SEXP _gdalraster_ogr_ds_field_domain_names(SEXP dsnSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    rcpp_result_gen = Rcpp::wrap(ogr_ds_field_domain_names(dsn));
+    return rcpp_result_gen;
+END_RCPP
+}
+// ogr_ds_add_field_domain
+bool ogr_ds_add_field_domain(const std::string& dsn, const Rcpp::List& fld_dom_defn);
+RcppExport SEXP _gdalraster_ogr_ds_add_field_domain(SEXP dsnSEXP, SEXP fld_dom_defnSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::List& >::type fld_dom_defn(fld_dom_defnSEXP);
+    rcpp_result_gen = Rcpp::wrap(ogr_ds_add_field_domain(dsn, fld_dom_defn));
+    return rcpp_result_gen;
+END_RCPP
+}
+// ogr_ds_delete_field_domain
+bool ogr_ds_delete_field_domain(const std::string& dsn, const std::string& domain_name);
+RcppExport SEXP _gdalraster_ogr_ds_delete_field_domain(SEXP dsnSEXP, SEXP domain_nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type domain_name(domain_nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(ogr_ds_delete_field_domain(dsn, domain_name));
+    return rcpp_result_gen;
+END_RCPP
+}
 // ogr_layer_exists
 bool ogr_layer_exists(const std::string& dsn, const std::string& layer);
 RcppExport SEXP _gdalraster_ogr_layer_exists(SEXP dsnSEXP, SEXP layerSEXP) {
@@ -1711,8 +1746,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // ogr_field_create
-bool ogr_field_create(const std::string& dsn, const std::string& layer, const std::string& fld_name, const std::string& fld_type, const std::string& fld_subtype, int fld_width, int fld_precision, bool is_nullable, bool is_unique, const std::string& default_value);
-RcppExport SEXP _gdalraster_ogr_field_create(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP, SEXP fld_typeSEXP, SEXP fld_subtypeSEXP, SEXP fld_widthSEXP, SEXP fld_precisionSEXP, SEXP is_nullableSEXP, SEXP is_uniqueSEXP, SEXP default_valueSEXP) {
+bool ogr_field_create(const std::string& dsn, const std::string& layer, const std::string& fld_name, const std::string& fld_type, const std::string& fld_subtype, int fld_width, int fld_precision, bool is_nullable, bool is_unique, const std::string& default_value, const std::string& domain_name);
+RcppExport SEXP _gdalraster_ogr_field_create(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP, SEXP fld_typeSEXP, SEXP fld_subtypeSEXP, SEXP fld_widthSEXP, SEXP fld_precisionSEXP, SEXP is_nullableSEXP, SEXP is_uniqueSEXP, SEXP default_valueSEXP, SEXP domain_nameSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1726,7 +1761,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type is_nullable(is_nullableSEXP);
     Rcpp::traits::input_parameter< bool >::type is_unique(is_uniqueSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type default_value(default_valueSEXP);
-    rcpp_result_gen = Rcpp::wrap(ogr_field_create(dsn, layer, fld_name, fld_type, fld_subtype, fld_width, fld_precision, is_nullable, is_unique, default_value));
+    Rcpp::traits::input_parameter< const std::string& >::type domain_name(domain_nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(ogr_field_create(dsn, layer, fld_name, fld_type, fld_subtype, fld_width, fld_precision, is_nullable, is_unique, default_value, domain_name));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1757,6 +1793,20 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::string& >::type fld_name(fld_nameSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type new_name(new_nameSEXP);
     rcpp_result_gen = Rcpp::wrap(ogr_field_rename(dsn, layer, fld_name, new_name));
+    return rcpp_result_gen;
+END_RCPP
+}
+// ogr_field_set_domain_name
+bool ogr_field_set_domain_name(const std::string& dsn, const std::string& layer, const std::string& fld_name, const std::string& domain_name);
+RcppExport SEXP _gdalraster_ogr_field_set_domain_name(SEXP dsnSEXP, SEXP layerSEXP, SEXP fld_nameSEXP, SEXP domain_nameSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type dsn(dsnSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type layer(layerSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type fld_name(fld_nameSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type domain_name(domain_nameSEXP);
+    rcpp_result_gen = Rcpp::wrap(ogr_field_set_domain_name(dsn, layer, fld_name, domain_name));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2234,15 +2284,19 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_ogr_ds_test_cap", (DL_FUNC) &_gdalraster_ogr_ds_test_cap, 2},
     {"_gdalraster_ogr_ds_layer_count", (DL_FUNC) &_gdalraster_ogr_ds_layer_count, 1},
     {"_gdalraster_ogr_ds_layer_names", (DL_FUNC) &_gdalraster_ogr_ds_layer_names, 1},
+    {"_gdalraster_ogr_ds_field_domain_names", (DL_FUNC) &_gdalraster_ogr_ds_field_domain_names, 1},
+    {"_gdalraster_ogr_ds_add_field_domain", (DL_FUNC) &_gdalraster_ogr_ds_add_field_domain, 2},
+    {"_gdalraster_ogr_ds_delete_field_domain", (DL_FUNC) &_gdalraster_ogr_ds_delete_field_domain, 2},
     {"_gdalraster_ogr_layer_exists", (DL_FUNC) &_gdalraster_ogr_layer_exists, 2},
     {"_gdalraster_ogr_layer_test_cap", (DL_FUNC) &_gdalraster_ogr_layer_test_cap, 3},
     {"_gdalraster_ogr_layer_rename", (DL_FUNC) &_gdalraster_ogr_layer_rename, 3},
     {"_gdalraster_ogr_layer_delete", (DL_FUNC) &_gdalraster_ogr_layer_delete, 2},
     {"_gdalraster_ogr_layer_field_names", (DL_FUNC) &_gdalraster_ogr_layer_field_names, 2},
     {"_gdalraster_ogr_field_index", (DL_FUNC) &_gdalraster_ogr_field_index, 3},
-    {"_gdalraster_ogr_field_create", (DL_FUNC) &_gdalraster_ogr_field_create, 10},
+    {"_gdalraster_ogr_field_create", (DL_FUNC) &_gdalraster_ogr_field_create, 11},
     {"_gdalraster_ogr_geom_field_create", (DL_FUNC) &_gdalraster_ogr_geom_field_create, 6},
     {"_gdalraster_ogr_field_rename", (DL_FUNC) &_gdalraster_ogr_field_rename, 4},
+    {"_gdalraster_ogr_field_set_domain_name", (DL_FUNC) &_gdalraster_ogr_field_set_domain_name, 4},
     {"_gdalraster_ogr_field_delete", (DL_FUNC) &_gdalraster_ogr_field_delete, 3},
     {"_gdalraster_ogr_execute_sql", (DL_FUNC) &_gdalraster_ogr_execute_sql, 4},
     {"_gdalraster_epsg_to_wkt", (DL_FUNC) &_gdalraster_epsg_to_wkt, 2},

--- a/src/ogr_util.h
+++ b/src/ogr_util.h
@@ -163,6 +163,14 @@ int ogr_ds_layer_count(const std::string &dsn);
 
 SEXP ogr_ds_layer_names(const std::string &dsn);
 
+SEXP ogr_ds_field_domain_names(const std::string &dsn);
+
+bool ogr_ds_add_field_domain(const std::string &dsn,
+                             const Rcpp::List &fld_dom_defn);
+
+bool ogr_ds_delete_field_domain(const std::string &dsn,
+                                const std::string &domain_name);
+
 bool ogr_layer_exists(const std::string &dsn, const std::string &layer);
 
 SEXP ogr_layer_test_cap(const std::string &dsn, const std::string &layer,
@@ -196,13 +204,15 @@ bool CreateField_(GDALDatasetH hDS, OGRLayerH hLayer,
                   const std::string &fld_name,
                   const std::string &fld_type, const std::string &fld_subtype,
                   int fld_width, int fld_precision, bool is_nullable,
-                  bool is_unique, const std::string &default_value);
+                  bool is_unique, const std::string &default_value,
+                  const std::string &domain_name);
 
 bool ogr_field_create(const std::string &dsn, const std::string &layer,
                       const std::string &fld_name, const std::string &fld_type,
                       const std::string &fld_subtype, int fld_width ,
                       int fld_precision, bool is_nullable,
-                      bool is_unique, const std::string &default_value);
+                      bool is_unique, const std::string &default_value,
+                      const std::string &domain_name);
 
 // internal CreateGeomField
 bool CreateGeomField_(GDALDatasetH hDS, OGRLayerH hLayer,
@@ -218,6 +228,11 @@ bool ogr_geom_field_create(const std::string &dsn, const std::string &layer,
 bool ogr_field_rename(const std::string &dsn, const std::string &layer,
                       const std::string &fld_name,
                       const std::string &new_name);
+
+bool ogr_field_set_domain_name(const std::string &dsn,
+                               const std::string &layer,
+                               const std::string &fld_name,
+                               const std::string &domain_name);
 
 bool ogr_field_delete(const std::string &dsn, const std::string &layer,
                       const std::string &fld_name);

--- a/vignettes/vector-api-overview.Rmd
+++ b/vignettes/vector-api-overview.Rmd
@@ -72,6 +72,7 @@ Several of the stand-alone `ogr_*()` functions are grouped under the documentati
 * delete layers
 * create new attribute and geometry fields on an existing layer
 * rename and delete fields
+* read and write field domains
 * edit data with SQL statements
 
 `ogr_define` provides documentation and helper functions for defining feature classes. An OGR feature class definition (a.k.a. layer definition) is modeled in R as a named list containing zero or more attribute field definitions, along with one or more geometry field definitions. Specifications of the the list structures for these definitions are given in `?ogr_define`. The associated helper functions make it easy to create new layer definitions from scratch or modify an existing definition. A layer definition is convenient but not required for creating a new vector dataset, or a new layer within an existing dataset, using `ogr_ds_create()` / `ogr_layer_create()`.


### PR DESCRIPTION
A field domain is a set of constraints that apply to one or several fields, e.g., in ESRI File Geodatabase, and in GeoPackage via the Schema extension. GDAL >= 3.3 supports reading and writing field domains with certain drivers (e.g., mainly GPKG, OpenFileGDB).

See:
* original GDAL PR: https://github.com/OSGeo/gdal/pull/3638
* https://www.geopackage.org/spec/#extension_schema
* https://desktop.arcgis.com/en/arcmap/latest/manage-data/geodatabases/an-overview-of-attribute-domains.htm

This PR adds write support for field domains (on top of existing read support in class `GDALVector`):
* adds `ogr_def_field_domain()`: create a field domain definition
* `ogr_def_field()`: adds argument `domain_name` , and adds element `$domain_name` in the returned field definition
* the `ogr_define` help topic adds documentation and the specification for a field domain definition
* `ogr_field_create()`: adds arg `domain_name`, and also accepts the updated form of field definition containing a `$domain_name` element
* `ogr_ds_test_cap()` adds the following elements in the returned list of capabilities:
  * `AddFieldDomain`: `TRUE` if dataset capability for supporting AddFieldDomain()
  * `DeleteFieldDomain`: `TRUE` if dataset capability for supporting DeleteFieldDomain()
  * `UpdateFieldDomain`: `TRUE` if dataset capability for supporting UpdateFieldDomain()
* adds `ogr_ds_field_domain_names()`: return a list of field domain names in a vector dataset
* adds `ogr_ds_add_field_domain()`: add a field domain in a vector dataset (Coded Values, Range or GLOB domain)
* adds `ogr_ds_delete_field_domain()`: delete a field domain in a vector dataset
* adds `ogr_field_set_domain_name()`: set a field domain on an existing field in a vector layer
* `GDALVector$getFieldDomain()`: now returns min/max for a DateTime range  as `POSIXct` DateTimes