### PR TITLE
Field domains: support coded values field domain as a two-column data frame of (codes, values)

### DIFF
--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -329,9 +329,11 @@
 #' See [ogr_define] for details of the field and feature class definitions.
 #'
 #' \code{$getFieldDomain(domain_name)}\cr
-#' Returns a list containing specifications of the OGR field domain with the
+#' Returns a list containing the definition of the OGR field domain with the
 #' passed `domain_name`, or `NULL` if `domain_name` is not found.
-#' Some formats support the use of field domains that describe the valid values
+#' See [ogr_define] for specification of the list containing a field domain
+#' definition.
+#' Some formats support the use of field domains which describe the valid values
 #' that can be stored in a given attribute field, e.g., coded values that are
 #' present in a specified enumeration, values constrained to a specified
 #' range, or values that must match a specified pattern.

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -348,9 +348,11 @@ definitions, along with one or more geometry field definitions.
 See \link{ogr_define} for details of the field and feature class definitions.
 
 \code{$getFieldDomain(domain_name)}\cr
-Returns a list containing specifications of the OGR field domain with the
+Returns a list containing the definition of the OGR field domain with the
 passed \code{domain_name}, or \code{NULL} if \code{domain_name} is not found.
-Some formats support the use of field domains that describe the valid values
+See \link{ogr_define} for specification of the list containing a field domain
+definition.
+Some formats support the use of field domains which describe the valid values
 that can be stored in a given attribute field, e.g., coded values that are
 present in a specified enumeration, values constrained to a specified
 range, or values that must match a specified pattern.

--- a/man/ogr_define.Rd
+++ b/man/ogr_define.Rd
@@ -88,9 +88,12 @@ field domain. One of \code{"DEFAULT_VALUE"}, \code{"DUPLICATE"}, \code{"GEOMETRY
 field domain. One of \code{"DEFAULT_VALUE"}, \code{"SUM"}, \code{"GEOMETRY_WEIGHTED"}
 (supported by ESRI File Geodatabase format via OpenFileGDB driver).}
 
-\item{coded_values}{A vector of the allowed codes or \code{"CODE=VALUE"} pairs
-(the expanded "value" associated with a code is optional). Required
-if \code{domain_type = "Coded"}. Each code should appear only once, but it is the
+\item{coded_values}{Either a vector of the allowed codes, or character
+vector of \code{"CODE=VALUE"} pairs (the expanded "value" associated with a code
+is optional), or a two-column data frame with (codes, values).
+If data frame, the second column of values must be character type (i.e.,
+the descriptive text for each code). This argument is required if
+\code{domain_type = "Coded"}. Each code should appear only once, but it is the
 responsibility of the user to check it.}
 
 \item{range_min}{Minimum value in a Range or RangeDateTime field domain (can
@@ -98,16 +101,16 @@ be NULL). The data type must be consistent with with the field type given in
 the \code{fld_type} argument.}
 
 \item{min_is_inclusive}{= Logical value, whether the minimum value is
-included in the range. Defaults to \code{TRUE}. Required if \code{domain_type} is
-\code{"Range"} or \code{"RangeDateTime"}.}
+included in the range. Defaults to \code{TRUE}. Required argument if
+\code{domain_type} is \code{"Range"} or \code{"RangeDateTime"}.}
 
 \item{range_max}{Maximum value in a Range or RangeDateTime field domain (can
 be NULL). The data type must be consistent with with the field type given in
 the \code{fld_type} argument.}
 
 \item{max_is_inclusive}{= Logical value, whether the maximum value is
-included in the range. Defaults to \code{TRUE}. Required if \code{domain_type} is
-\code{"Range"} or \code{"RangeDateTime"}.}
+included in the range. Defaults to \code{TRUE}. Required argument if
+\code{domain_type} is \code{"Range"} or \code{"RangeDateTime"}.}
 
 \item{glob}{Character string containing the GLOB expression. Required if
 \code{domain_type} is \code{"GLOB"}.}
@@ -212,7 +215,7 @@ $field_type       : OGR Field Type (see attribute field definitions above)
 $field_subtype    : optional OGR Field Subtype ("OFSTBoolean", ...)
 $split_policy     : split policy of the field domain (see below)
 $merge_policy     : merge policy of the field domain (see below)
-$coded_values     : character vector of codes, or `"CODE=VALUE"` pairs
+$coded_values     : vector of allowed codes, or data frame of (codes, values)
 $min_value        : minimum value (data type compatible with $field_type)
 $min_is_inclusive : whether the minimum value is included in the range
 $max_value        : maximum value (data type compatible with $field_type)

--- a/src/ogr_util.cpp
+++ b/src/ogr_util.cpp
@@ -560,7 +560,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 "'$coded_values' must be a character vector or data frame");
         }
 
-        std::vector<OGRCodedValue> ogr_coded_values;
+        std::vector<OGRCodedValue> ogr_coded_values = {};
 
         // as character vector of codes, or "code=value" pairs
         if (Rcpp::is<Rcpp::CharacterVector>(fld_dom_defn["coded_values"])) {
@@ -571,6 +571,11 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 Rcpp::stop("'coded_values' is empty");
             }
 
+            if (Rcpp::any(Rcpp::is_na(coded_values))) {
+                GDALReleaseDataset(hDS);
+                Rcpp::stop("'coded_values' cannot contain NA codes");
+            }
+
             for (Rcpp::CharacterVector::iterator i = coded_values.begin();
                     i != coded_values.end(); ++i) {
 
@@ -579,6 +584,13 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
 
                 if (CSLCount(papszTokens) < 1 || CSLCount(papszTokens) > 2) {
                     GDALReleaseDataset(hDS);
+                    CSLDestroy(papszTokens);
+                    if (!ogr_coded_values.empty()) {
+                        for (auto &cv : ogr_coded_values) {
+                            VSIFree(cv.pszCode);
+                            VSIFree(cv.pszValue);
+                        }
+                    }
                     Rcpp::stop(
                         "elements of 'coded_values' must be \"CODE\" or \"CODE=VALUE\"");
                 }
@@ -618,6 +630,11 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
             Rcpp::CharacterVector codes = coded_values[0];
             Rcpp::CharacterVector values = coded_values[1];
 
+            if (Rcpp::any(Rcpp::is_na(codes))) {
+                GDALReleaseDataset(hDS);
+                Rcpp::stop("'coded_values' cannot contain NA codes");
+            }
+
             for (R_xlen_t i = 0; i < codes.size(); ++i) {
                 OGRCodedValue cv;
                 cv.pszCode = CPLStrdup(codes[i]);
@@ -654,10 +671,10 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 VSIFree(pszFailureReason);
             }
             OGR_FldDomain_Destroy(hFldDom);
-            for (auto &cv : ogr_coded_values) {
-                VSIFree(cv.pszCode);
-                VSIFree(cv.pszValue);
-            }
+        }
+        for (auto &cv : ogr_coded_values) {
+            VSIFree(cv.pszCode);
+            VSIFree(cv.pszValue);
         }
     }
 
@@ -697,7 +714,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
         // Integer and Real ranges
         if (eFieldType == OFTInteger || eFieldType == OFTReal) {
             double min_value = -99999.0;
-            double max_value = 99999.0;
+            double max_value = -99999.0;
 
             if (fld_dom_defn.containsElementNamed("min_value") &&
                 fld_dom_defn["min_value"] == R_NilValue) {
@@ -716,10 +733,16 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 Rcpp::stop("'$min_value' must be integer, double or NULL");
             }
             else {
-                min_value = Rcpp::as<double>(fld_dom_defn["min_value"]);
-                if (Rcpp::NumericVector::is_na(min_value))
+                Rcpp::NumericVector tmp = fld_dom_defn["min_value"];
+                if (tmp.size() != 1) {
+                    GDALReleaseDataset(hDS);
+                    Rcpp::stop("'$min_value' must be a single numeric value");
+                }
+                min_value = tmp[0];
+                if (Rcpp::NumericVector::is_na(min_value)) {
                     min_is_null = true;
-
+                    min_value = -99999.0;  // unused
+                }
             }
 
             if (fld_dom_defn.containsElementNamed("max_value") &&
@@ -739,9 +762,16 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 Rcpp::stop("'$max_value' must be integer, double or NULL");
             }
             else {
-                max_value = Rcpp::as<double>(fld_dom_defn["max_value"]);
-                if (Rcpp::NumericVector::is_na(max_value))
+                Rcpp::NumericVector tmp = fld_dom_defn["max_value"];
+                if (tmp.size() != 1) {
+                    GDALReleaseDataset(hDS);
+                    Rcpp::stop("'$max_value' must be a single numeric value");
+                }
+                max_value = tmp[0];
+                if (Rcpp::NumericVector::is_na(max_value)) {
                     max_is_null = true;
+                    max_value = -99999.0;  // unused
+                }
             }
 
             OGRField sMin, sMax;
@@ -804,15 +834,21 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 Rcpp::NumericVector tmp =
                     Rcpp::as<Rcpp::NumericVector>(fld_dom_defn["min_value"]);
 
+                if (tmp.size() != 1) {
+                    GDALReleaseDataset(hDS);
+                    Rcpp::stop("'$min_value' must be a single numeric value");
+                }
+
                 if (Rcpp::isInteger64(tmp)) {
                     min_value = Rcpp::fromInteger64(tmp[0]);
                     if (ISNA_INTEGER64(min_value))
                         min_is_null = true;
                 }
                 else {
-                    min_value = static_cast<int64_t>(tmp[0]);
                     if (Rcpp::NumericVector::is_na(tmp[0]))
                         min_is_null = true;
+                    else
+                        min_value = static_cast<int64_t>(tmp[0]);
                 }
             }
 
@@ -834,15 +870,21 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 Rcpp::NumericVector tmp =
                     Rcpp::as<Rcpp::NumericVector>(fld_dom_defn["max_value"]);
 
+                if (tmp.size() != 1) {
+                    GDALReleaseDataset(hDS);
+                    Rcpp::stop("'$max_value' must be a single numeric value");
+                }
+
                 if (Rcpp::isInteger64(tmp)) {
                     max_value = Rcpp::fromInteger64(tmp[0]);
                     if (ISNA_INTEGER64(max_value))
                         max_is_null = true;
                 }
                 else {
-                    max_value = static_cast<int64_t>(tmp[0]);
                     if (Rcpp::NumericVector::is_na(tmp[0]))
                         max_is_null = true;
+                    else
+                        max_value = static_cast<int64_t>(tmp[0]);
                 }
             }
 
@@ -886,8 +928,10 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
 
     // RangeDateTime
     else if (EQUAL(domain_type.c_str(), "rangedatetime")) {
-        if (eFieldType != OFTDateTime)
+        if (eFieldType != OFTDateTime) {
+            GDALReleaseDataset(hDS);
             Rcpp::stop("'$field_type' must be OFTDateTime");
+        }
 
         double min_value = 0.0;
         double max_value = 0.0;
@@ -1024,8 +1068,10 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
 
     // GLOB
     else if (EQUAL(domain_type.c_str(), "glob")) {
-        if (eFieldType != OFTString)
+        if (eFieldType != OFTString) {
+            GDALReleaseDataset(hDS);
             Rcpp::stop("'$field_type' must be OFTString");
+        }
 
         if (!fld_dom_defn.containsElementNamed("glob") ||
             fld_dom_defn["glob"] == R_NilValue ||
@@ -1035,7 +1081,13 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
             Rcpp::stop("'$glob' must be a character string");
         }
 
-        std::string glob = Rcpp::as<std::string>(fld_dom_defn["glob"]);
+        Rcpp::CharacterVector tmp = fld_dom_defn["glob"];
+        if (tmp.size() != 1) {
+            GDALReleaseDataset(hDS);
+            Rcpp::stop("'$glob' must be a character string");
+        }
+
+        std::string glob = Rcpp::as<std::string>(tmp[0]);
 
         OGRFieldDomainH hFldDom = nullptr;
         hFldDom = OGR_GlobFldDomain_Create(domain_name.c_str(),

--- a/src/ogr_util.cpp
+++ b/src/ogr_util.cpp
@@ -708,6 +708,8 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                      (!Rcpp::is<Rcpp::NumericVector>(
                         fld_dom_defn["min_value"]) &&
                       !Rcpp::is<Rcpp::IntegerVector>(
+                        fld_dom_defn["min_value"]) &&
+                      !Rcpp::is<Rcpp::LogicalVector>(
                         fld_dom_defn["min_value"]))) {
 
                 GDALReleaseDataset(hDS);
@@ -715,6 +717,9 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
             }
             else {
                 min_value = Rcpp::as<double>(fld_dom_defn["min_value"]);
+                if (Rcpp::NumericVector::is_na(min_value))
+                    min_is_null = true;
+
             }
 
             if (fld_dom_defn.containsElementNamed("max_value") &&
@@ -726,6 +731,8 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                      (!Rcpp::is<Rcpp::NumericVector>(
                         fld_dom_defn["max_value"]) &&
                       !Rcpp::is<Rcpp::IntegerVector>(
+                        fld_dom_defn["max_value"]) &&
+                      !Rcpp::is<Rcpp::LogicalVector>(
                         fld_dom_defn["max_value"]))) {
 
                 GDALReleaseDataset(hDS);
@@ -733,6 +740,8 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
             }
             else {
                 max_value = Rcpp::as<double>(fld_dom_defn["max_value"]);
+                if (Rcpp::NumericVector::is_na(max_value))
+                    max_is_null = true;
             }
 
             OGRField sMin, sMax;
@@ -762,7 +771,8 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 OGR_FldDomain_SetSplitPolicy(hFldDom, eOFDSP);
                 OGR_FldDomain_SetMergePolicy(hFldDom, eOFDMP);
                 char *pszFailureReason = nullptr;
-                ret = GDALDatasetAddFieldDomain(hDS, hFldDom, &pszFailureReason);
+                ret = GDALDatasetAddFieldDomain(hDS, hFldDom,
+                                                &pszFailureReason);
                 if (pszFailureReason != nullptr) {
                     Rcpp::Rcout << pszFailureReason << std::endl;
                     VSIFree(pszFailureReason);
@@ -794,10 +804,16 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 Rcpp::NumericVector tmp =
                     Rcpp::as<Rcpp::NumericVector>(fld_dom_defn["min_value"]);
 
-                if (Rcpp::isInteger64(tmp))
+                if (Rcpp::isInteger64(tmp)) {
                     min_value = Rcpp::fromInteger64(tmp[0]);
-                else
+                    if (ISNA_INTEGER64(min_value))
+                        min_is_null = true;
+                }
+                else {
                     min_value = static_cast<int64_t>(tmp[0]);
+                    if (Rcpp::NumericVector::is_na(tmp[0]))
+                        min_is_null = true;
+                }
             }
 
             if (fld_dom_defn.containsElementNamed("max_value") &&
@@ -818,10 +834,16 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 Rcpp::NumericVector tmp =
                     Rcpp::as<Rcpp::NumericVector>(fld_dom_defn["max_value"]);
 
-                if (Rcpp::isInteger64(tmp))
+                if (Rcpp::isInteger64(tmp)) {
                     max_value = Rcpp::fromInteger64(tmp[0]);
-                else
+                    if (ISNA_INTEGER64(max_value))
+                        max_is_null = true;
+                }
+                else {
                     max_value = static_cast<int64_t>(tmp[0]);
+                    if (Rcpp::NumericVector::is_na(tmp[0]))
+                        max_is_null = true;
+                }
             }
 
             OGRField sMin, sMax;
@@ -841,7 +863,8 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 OGR_FldDomain_SetSplitPolicy(hFldDom, eOFDSP);
                 OGR_FldDomain_SetMergePolicy(hFldDom, eOFDMP);
                 char *pszFailureReason = nullptr;
-                ret = GDALDatasetAddFieldDomain(hDS, hFldDom, &pszFailureReason);
+                ret = GDALDatasetAddFieldDomain(hDS, hFldDom,
+                                                &pszFailureReason);
                 if (pszFailureReason != nullptr) {
                     Rcpp::Rcout << pszFailureReason << std::endl;
                     VSIFree(pszFailureReason);

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -1593,7 +1593,7 @@ test_that("field domain write functions work", {
     defn$field_type <- "OFTInteger"
     expect_error(.ogr_ds_add_field_domain(dsn, defn))
 
-    defn$field_type <- "OFTInteger"
+    defn$field_type <- "OFTString"
     defn$glob <- list(NULL)
     expect_error(.ogr_ds_add_field_domain(dsn, defn))
 


### PR DESCRIPTION
Coded values may be given as a vector of codes only, character vector of `"CODE=VALUE"`, or two-column data frame of codes, values (support for the latter added in this PR).

`GDALVector$getFieldDomain()` now returns coded values as a data frame, instead of character vector of `"CODE=VALUE"`. This is a breaking change, but the return value of `$getFieldDomain()` was not previously documented. Its return value now aligns with the specification of a field domain definition added for `ogr_def_field_domain()` in #738.