### PR TITLE
Add tests in test-gdal_create.R

### DIFF
--- a/R/gdal_create.R
+++ b/R/gdal_create.R
@@ -61,11 +61,42 @@
 create <- function(format, dst_filename, xsize, ysize, nbands, dataType,
                    options = NULL, return_obj = FALSE) {
 
-    if (is.null(return_obj))
-        stop("'return_obj' must be a logical value", call. = FALSE)
+    if (missing(format) || is.null(format) || all(is.na(format)))
+        stop("'format' is required", call. = FALSE)
+    if (!(is.character(format) && length(format) == 1))
+        stop("'format' must be a character string", call. = FALSE)
+
+    if (missing(dst_filename) || is.null(dst_filename) ||
+        all(is.na(dst_filename))) {
+
+        stop("'dst_filename' is required", call. = FALSE)
+    }
+    if (!(is.character(dst_filename) && length(dst_filename) == 1))
+        stop("'dst_filename' must be a character string", call. = FALSE)
+
+    if (missing(xsize) || is.null(xsize) || all(is.na(xsize)))
+        stop("'xsize' is required", call. = FALSE)
+    if (!(is.numeric(xsize) && length(xsize) == 1))
+        stop("'xsize' must be numeric", call. = FALSE)
+
+    if (missing(ysize) || is.null(ysize) || all(is.na(ysize)))
+        stop("'ysize' is required", call. = FALSE)
+    if (!(is.numeric(ysize) && length(ysize) == 1))
+        stop("'ysize' must be numeric", call. = FALSE)
+
+    if (missing(dataType) || is.null(dataType) || all(is.na(dataType)))
+        stop("'dataType' is required", call. = FALSE)
+    if (!(is.character(dataType) && length(dataType) == 1))
+        stop("'dataType' must be a character string", call. = FALSE)
+
+    if (!is.null(options) && !is.character(options))
+        stop("'options' must be a character vector or NULL", call. = FALSE)
+
+    if (is.null(return_obj) || is.na(return_obj))
+        stop("'return_obj' must be TRUE or FALSE", call. = FALSE)
 
     if (!is.logical(return_obj) || length(return_obj) > 1)
-        stop("'return_obj' must be a logical scalar", call. = FALSE)
+        stop("'return_obj' must be a logical value", call. = FALSE)
 
     # signature for create() object factory
     ds <- new(GDALRaster, format, dst_filename, xsize, ysize, nbands, dataType,
@@ -137,6 +168,29 @@ create <- function(format, dst_filename, xsize, ysize, nbands, dataType,
 createCopy <- function(format, dst_filename, src_filename, strict = FALSE,
                        options = NULL, quiet = FALSE, return_obj = FALSE) {
 
+    if (missing(format) || is.null(format) || all(is.na(format)))
+        stop("'format' is required", call. = FALSE)
+    if (!(is.character(format) && length(format) == 1))
+        stop("'format' must be a character string", call. = FALSE)
+
+    if (missing(dst_filename) || is.null(dst_filename) ||
+        all(is.na(dst_filename))) {
+
+        stop("'dst_filename' is required", call. = FALSE)
+    }
+    if (!(is.character(dst_filename) && length(dst_filename) == 1))
+        stop("'dst_filename' must be a character string", call. = FALSE)
+
+    if (missing(src_filename) || is.null(src_filename))
+        stop("'src_filename' is required", call. = FALSE)
+    if (!(is.character(src_filename) && length(src_filename) == 1 &&
+          any(is.na(src_filename)) == FALSE) &&
+        !is(src_filename, "Rcpp_GDALRaster")) {
+
+        stop("'src_filename' must be a character string or GDALRaster object",
+             call. = FALSE)
+    }
+
     src_ds <- NULL
     if (is(src_filename, "Rcpp_GDALRaster")) {
         src_ds <- src_filename
@@ -149,11 +203,26 @@ createCopy <- function(format, dst_filename, src_filename, strict = FALSE,
              call. = FALSE)
     }
 
-    if (is.null(return_obj))
-        stop("'return_obj' must be a logical value", call. = FALSE)
+    if (is.null(strict) || is.na(strict))
+        stop("'strict' must be TRUE or FALSE", call. = FALSE)
+
+    if (!is.logical(strict) || length(strict) > 1)
+        stop("'strict' must be a logical value", call. = FALSE)
+
+    if (!is.null(options) && !is.character(options))
+        stop("'options' must be a character vector or NULL", call. = FALSE)
+
+    if (is.null(quiet) || is.na(quiet))
+        stop("'quiet' must be TRUE or FALSE", call. = FALSE)
+
+    if (!is.logical(quiet) || length(quiet) > 1)
+        stop("'quiet' must be a logical value", call. = FALSE)
+
+    if (is.null(return_obj) || is.na(return_obj))
+        stop("'return_obj' must be TRUE or FALSE", call. = FALSE)
 
     if (!is.logical(return_obj) || length(return_obj) > 1)
-        stop("'return_obj' must be a logical scalar", call. = FALSE)
+        stop("'return_obj' must be a logical value", call. = FALSE)
 
     # signature for createCopy() object factory
     ds <- new(GDALRaster, format, dst_filename, src_ds, strict, options, quiet)

--- a/tests/testthat/test-gdal_create.R
+++ b/tests/testthat/test-gdal_create.R
@@ -1,0 +1,146 @@
+# test the R interface to GDALCreate() and GDALCreateCopy() via the wrapper
+# functions in src/gdal_exp.cpp, with tests also in test-gdal_exp.R
+
+test_that("create and createCopy R public interface works", {
+
+    ## createCopy
+    f <- system.file("extdata/storml_elev.tif", package="gdalraster")
+    f2 <- paste0(tempdir(), "/", "storml_elev2.tif")
+
+    ds <- new(GDALRaster, f)
+    dm <- ds$dim()
+    chk <- ds$getChecksum(1, 0, 0, dm[1], dm[2])
+
+    expect_no_error(ds2 <- createCopy(format = "GTiff",
+                                      dst_filename = f2,
+                                      src_filename = ds,
+                                      return_obj = TRUE))
+
+    expect_true(is(ds2, "Rcpp_GDALRaster"))
+    dm2 <- ds2$dim()
+    chk2 <- ds2$getChecksum(1, 0, 0, dm2[1], dm2[2])
+
+    expect_equal(dm, dm2)
+
+    ds$close()
+    ds2$close()
+    expect_true(deleteDataset(f2))
+
+    # errors
+    expect_error(createCopy(format = NULL,
+                            dst_filename = f2,
+                            src_filename = f))
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = NULL,
+                            src_filename = f))
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = NULL))
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = f,
+                            strict = NA))
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = f,
+                            options = NA))
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = f,
+                            quiet = NULL))
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = ds),
+                 regexp = "source dataset is not open",
+                 fixed = TRUE)
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = NULL),
+                 regexp = "'src_filename' is required",
+                 fixed = TRUE)
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = f,
+                            return_obj = NULL),
+                 regexp = "'return_obj' must be TRUE or FALSE",
+                 fixed = TRUE)
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = f,
+                            return_obj = NA),
+                 regexp = "'return_obj' must be TRUE or FALSE",
+                 fixed = TRUE)
+
+    expect_error(createCopy(format = "GTiff",
+                            dst_filename = f2,
+                            src_filename = f,
+                            return_obj = "TRUE"),
+                 regexp = "'return_obj' must be a logical value",
+                 fixed = TRUE)
+
+
+    ## create
+    f3 <- tempfile(fileext = ".tif")
+    expect_no_error(ds3 <- create(format = "GTiff", dst_filename = f3,
+                                  xsize = 10, ysize = 10, nbands = 1,
+                                  dataType = "Int32", return_obj = TRUE))
+
+    ds3$close()
+    deleteDataset(f3)
+
+    # errors
+    expect_error(create(format = NULL, dst_filename = f3,
+                        xsize = 10, ysize = 10, nbands = 1,
+                        dataType = "Int32"))
+
+    expect_error(create(format = "GTiff", dst_filename = NULL,
+                        xsize = 10, ysize = 10, nbands = 1,
+                        dataType = "Int32"))
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = NULL, ysize = 10, nbands = 1,
+                        dataType = "Int32"))
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = 10, ysize = NULL, nbands = 1,
+                        dataType = "Int32"))
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = 10, ysize = 10, nbands = NULL,
+                        dataType = "Int32"))
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = 10, ysize = 10, nbands = 1,
+                        dataType = NULL))
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = 10, ysize = 10, nbands = 1,
+                        dataType = "Int32", options = NA))
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = 10, ysize = 10, nbands = 1,
+                        dataType = "Int32", return_obj = NULL),
+                 regexp = "'return_obj' must be TRUE or FALSE",
+                 fixed = TRUE)
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = 10, ysize = 10, nbands = 1,
+                        dataType = "Int32", return_obj = NA),
+                 regexp = "'return_obj' must be TRUE or FALSE",
+                 fixed = TRUE)
+
+    expect_error(create(format = "GTiff", dst_filename = f3,
+                        xsize = 10, ysize = 10, nbands = 1,
+                        dataType = "Int32", return_obj = "TRUE"),
+                 regexp = "'return_obj' must be a logical value",
+                 fixed = TRUE)
+})


### PR DESCRIPTION
Test the `create()` and `createCopy()` R public interface to the wrapper functions in src/gdal_exp.cpp (with existing tests also in test-gdal_exp.R), and improves input validation.