### PR TITLE
`pixel_extract()`: support optional point IDs in the first column of an input data frame and add argument `as_data_frame`

### DIFF
--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -1680,8 +1680,9 @@ pixel_extract <- function(raster, xy, bands = NULL, interp = NULL,
     mem_dir <- ""
     f_mem <- ""
     f_in <- ds$getDescription(band = 0)
-    if (!vsi_is_local(f_in) && max_ram > 0 && nrow(xy_in) > 10 &&
-        gdal_version_num() >= gdal_compute_version(3, 6, 0)) {
+    if (max_ram > 0 && nrow(xy_in) > 10 &&
+        gdal_version_num() >= gdal_compute_version(3, 6, 0) &&
+        !vsi_is_local(f_in)) {
 
         # use MEM dataset if possible
         dm <- ds$dim()

--- a/man/pixel_extract.Rd
+++ b/man/pixel_extract.Rd
@@ -11,7 +11,8 @@ pixel_extract(
   interp = NULL,
   krnl_dim = NULL,
   xy_srs = NULL,
-  max_ram = 300
+  max_ram = 300,
+  as_data_frame = NULL
 )
 }
 \arguments{
@@ -19,22 +20,26 @@ pixel_extract(
 an object of class \code{GDALRaster} for the source dataset.}
 
 \item{xy}{A two-column numeric matrix or two-column data frame of geospatial
-(x, y) coordinates, or vector (x, y) for a single point, in the same spatial
-reference system as \code{raster}.}
+coordinates (x, y), or a vector for a single point (x, y), in the same
+spatial reference system as \code{raster}. Can also be given as a data frame with
+three or more columns, in which the first column must be a vector of point
+IDs (\code{character} or \code{numeric}), and the second and third columns must contain
+the geospatial coordinates (x, y).}
 
 \item{bands}{Optional numeric vector of band numbers. All bands in \code{raster}
-will be processed by default if not specified.}
+will be processed by default if not specified, or if \code{0} is given.}
 
 \item{interp}{Optional character string specifying an interpolation method.
 Must be one of \code{"bilinear"}, \code{"cubic"}, \code{"cubicspline"}, or \code{"nearest"} (the
 default if not specified, i.e., no interpolation).
 GDAL >= 3.10 is required for \code{"cubic"} and \code{"cubicspline"}.}
 
-\item{krnl_dim}{Optional integer value specifying the dimension of an N x N
-kernel for which all individual pixel values will be returned. Only
-supported when extracting from a single raster band. Ignored if \code{interp} is
-specified as other than \code{"nearest"} (i.e., will always use the kernel implied
-by the interpolation method).}
+\item{krnl_dim}{Optional numeric value specifying the dimension \code{N} pixels
+of an \verb{N x N} kernel for which all individual pixel values will be returned.
+Should be a positive whole number (will be coerced to integer by truncation).
+Currently only supported when extracting from a single raster band. Ignored
+if \code{interp} is specified as other than \code{"nearest"} (i.e., the kernel implied
+by the interpolation method will always be used).}
 
 \item{xy_srs}{Optional character string specifying the spatial reference
 system for \code{xy}. May be in WKT format or any of the formats supported by
@@ -44,27 +49,36 @@ system for \code{xy}. May be in WKT format or any of the formats supported by
 use for potentially copying a remote raster into memory for processing
 (see Note). Defaults to 300 MB. Set to zero to disable potential copy of
 remote files into memory.}
+
+\item{as_data_frame}{Logical value, \code{TRUE} to return output as a data frame.
+The default is to return a numeric matrix unless point IDs are present in
+the first column of \code{xy} given as a data frame. In that latter case, the
+output will always be a data frame with the point IDs in the first column.}
 }
 \value{
-A numeric matrix of pixel values with number of rows equal to the
-number of rows in \code{xy}, and number of columns equal to the number of
-\code{bands}, or if \code{krnl_dim = N} is used, number of columns equal to \code{N * N}.
-Named columns indicate the band number, e.g., \code{"b1"}. If \code{krnl_dim} is used,
-named columns indicate band number and pixel, e.g., \code{"b1_p1"}, \code{"b1_p2"},
-..., \code{"b1_p9"} if \code{krnl_dim = 3}. Pixels are in left-to-right, top-to-bottom
-order in the kernel.
+A numeric matrix or data frame of pixel values with number of rows
+equal to the number of rows in \code{xy}. The number of columns is equal to the
+number of \code{bands} (plus optional point ID column), or if \code{krnl_dim = N}
+is used, number of columns is equal to \code{N * N} (plus optional point ID
+column). Output is always a data frame if \code{xy} is given as a data frame with
+a column of point IDs (\code{as_data_frame} will be ignored in that case).
+Named columns indicate the band, e.g., \code{"b1"}. If \code{krnl_dim} is used, named
+columns indicate band and pixel, e.g., \code{"b1_p1"}, \code{"b1_p2"}, ..., \code{"b1_p9"}
+if \code{krnl_dim = 3}. Pixels are in left-to-right, top-to-bottom order in the
+kernel.
 }
 \description{
 \code{pixel_extract()} returns raster pixel values for a set of geospatial
-point locations. The coordinates are given as a two-column matrix of (x, y)
+point locations. The coordinates are given as a two-column matrix of x/y
 values in the same spatial reference system as the input raster (unless
-\code{xy_srs} is specified).
+\code{xy_srs} is specified). Coordinates can also be given in a data frame with
+an optional column of point IDs.
 Values are extracted from all bands of the raster by default, or specific
 band numbers may be given. An optional interpolation method may be specified
 for bilinear (2 x 2 kernel), cubic convolution (4 x 4 kernel, GDAL >= 3.10),
 or cubic spline (4 x 4 kernel, GDAL >= 3.10). Alternatively, an optional
-kernel dimension may be given to extract values of the individual pixels
-within an N x N kernel centered on the pixel containing the point location.
+kernel dimension \code{N} may be given to extract values of the individual pixels
+within an \verb{N x N} kernel centered on the pixel containing the point location.
 If \code{xy_srs} is given, the function will attempt to transform the input points
 to the projection of the raster with a call to \code{transform_xy()}.
 }
@@ -73,10 +87,10 @@ Depending on the number of input points, extracting from a raster on a
 remote filesystem may require a large number of HTTP range requests which
 may be slow (i.e., URLs/remote VSI filesystems). In that case, it may be
 faster to copy the raster into memory first (either as MEM format or to a
-/vsimem filesystem).
+/vsimem/ filesystem).
 \code{pixel_extract()} will attempt to automate that process if the total size
 of file(s) that would be copied does not exceed the threshold given by
-\code{max_ram}, and \code{length(xy) > 1} (requires GDAL >= 3.6).
+\code{max_ram}, and \code{nrow(xy) > 10} (requires GDAL >= 3.6).
 
 For alternative workflows that involve copying to local storage, the data
 management functions (e.g., \code{\link[=copyDatasetFiles]{copyDatasetFiles()}}) and the VSI filesystem
@@ -91,17 +105,17 @@ print(pts)
 
 raster_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
 
-pixel_extract(raster_file, pts[-1])
+pixel_extract(raster_file, pts)
 
 # or as GDALRaster object
 ds <- new(GDALRaster, raster_file)
-pixel_extract(ds, pts[-1])
+pixel_extract(ds, pts)
 
 # interpolated values
-pixel_extract(raster_file, pts[-1], interp = "bilinear")
+pixel_extract(raster_file, pts, interp = "bilinear")
 
 # individual pixel values within a kernel
-pixel_extract(raster_file, pts[-1], krnl_dim = 3)
+pixel_extract(raster_file, pts, krnl_dim = 3)
 
 # lont/lat xy
 pts_wgs84 <- transform_xy(pts[-1], srs_from = ds$getProjection(),

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -545,8 +545,10 @@ Rcpp::NumericMatrix GDALRaster::pixel_extract(const Rcpp::RObject &xy,
     Rcpp::CharacterVector band_names = Rcpp::CharacterVector::create();
     for (auto& b : bands_in) {
         GDALRasterBandH hBand = GDALGetRasterBand(m_hDataset, b);
-        if (hBand == nullptr)
+        if (hBand == nullptr) {
+            Rcpp::Rcout << "invalid band number: " << b << std::endl;
             Rcpp::stop("failed to access the requested band");
+        }
         GDALDataType eDT = GDALGetRasterDataType(hBand);
         if (GDALDataTypeIsComplex(eDT)) {
             Rcpp::stop("complex data types currently unsupported for extract");

--- a/tests/testthat/test-gdalraster_proc.R
+++ b/tests/testthat/test-gdalraster_proc.R
@@ -627,6 +627,7 @@ test_that("pixel_extract wrapper returns correct data", {
 
     # test copy of remote raster to an in-memory dataset if not on CRAN
     skip_on_cran()
+    skip_if(gdal_version_num() < gdal_compute_version(3, 6, 0))
 
     f <- "/vsicurl/https://raw.githubusercontent.com/usdaforestservice/gdalraster/main/sample-data/lf_fbfm40_220_mt_hood_utm.tif"
     pts <- c(604450.6, 5023283,

--- a/tests/testthat/test-gdalraster_proc.R
+++ b/tests/testthat/test-gdalraster_proc.R
@@ -470,46 +470,115 @@ test_that("pixel_extract wrapper returns correct data", {
     pts <- read.csv(pt_file)
     raster_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
 
-    # single pixel extract
+    # single pixel (1x1) extract on matrix input
     extr <- pixel_extract(raster_file, pts[-1])
     colnames(extr) <- NULL
     dim(extr) <- NULL
     expected_values <- c(2648, 2865, 2717, 2560, 2916,
                          2633, 2548, 2801, 2475, 2822)
     expect_equal(extr, expected_values)
+    rm(extr)
+    # data frame input
+    extr <- pixel_extract(raster_file, pts)
+    expect_equal(extr[, 2], expected_values)
+    expect_equal(names(extr), c("id", "storml_elev"))
+    rm(extr)
+    # as_data_frame from matrix input, so no input point IDs
+    extr <- pixel_extract(raster_file, pts[-1], as_data_frame = TRUE)
+    expect_true(is.data.frame(extr))
+    expect_equal(names(extr), c("ptid", "storml_elev"))
+    expect_equal(extr[, 2], expected_values)
+    expect_equal(extr[, 1], seq_len(nrow(extr)))
+    rm(extr)
 
-    # as a GDALRaster object
+    # raster as a GDALRaster object
     ds <- new(GDALRaster, raster_file)
-    extr_ds <- pixel_extract(ds, pts[-1])
-    colnames(extr_ds) <- NULL
-    dim(extr_ds) <- NULL
-    expect_equal(extr_ds, expected_values)
+    extr_ds <- pixel_extract(ds, pts)
+    expect_equal(extr_ds[, 2], expected_values)
+    expect_equal(names(extr_ds), c("id", "storml_elev"))
     # with missing values in the input
     pts_na <- rbind(pts, c(11, NA_real_, NA_real_))
-    extr_na <- pixel_extract(ds, pts_na[-1])
-    colnames(extr_na) <- NULL
-    dim(extr_na) <- NULL
+    extr_na <- pixel_extract(ds, pts_na)
     expect_na <- c(expected_values, NA_real_)
-    expect_equal(extr_na, expect_na)
+    expect_equal(extr_na[, 2], expect_na)
     # with NaN in the input
     pts_nan <- rbind(pts, c(11, NaN, NaN))
-    extr_nan <- pixel_extract(ds, pts_na[-1])
-    colnames(extr_nan) <- NULL
-    dim(extr_nan) <- NULL
+    extr_nan <- pixel_extract(ds, pts_na)
     expect_nan <- c(expected_values, NA_real_)
-    expect_equal(extr_nan, expect_nan)
-    ds$close()
+    expect_equal(extr_nan[, 2], expect_nan)
+
+    # MEM dataset with band names
+    ds_mem <- create("MEM", "", 10, 10, 3, "Int16", return_obj = TRUE)
+    expect_true(is(ds_mem, "Rcpp_GDALRaster"))
+    ds_mem$setDescription(1, "elev")
+    ds_mem$setDescription(2, "asp")
+    ds_mem$setDescription(3, "slpp")
+    ds_mem$fillRaster(1, 1000, 0)
+    ds_mem$fillRaster(2, 100, 0)
+    ds_mem$fillRaster(3, 10, 0)
+    geo_xy <- matrix(c(5, -8, 0, -1), nrow = 2, ncol = 2, byrow = TRUE)
+    # warning for no geotransform
+    expect_warning(extr_mem <- pixel_extract(ds_mem, geo_xy,
+                                             as_data_frame = TRUE))
+    expect_true(is.data.frame(extr_mem))
+    expect_equal(names(extr_mem), c("ptid", "b1_elev", "b2_asp", "b3_slpp"))
+    expect_equal(extr_mem[, 2], c(1000, 1000))
+    expect_equal(extr_mem[, 3], c(100, 100))
+    expect_equal(extr_mem[, 4], c(10, 10))
+    rm(extr_mem)
+    # subset of bands, re-ordered
+    expect_warning(extr_mem <- pixel_extract(ds_mem, geo_xy,
+                                             bands = c(3, 2),
+                                             as_data_frame = TRUE))
+    expect_true(is.data.frame(extr_mem))
+    expect_equal(names(extr_mem), c("ptid", "b3_slpp", "b2_asp"))
+    expect_equal(extr_mem[, 2], c(10, 10))
+    expect_equal(extr_mem[, 3], c(100, 100))
+    rm(extr_mem)
+
+    # GTiff without band names
+    ds_mem$setDescription(1, "")
+    ds_mem$setDescription(2, "")
+    ds_mem$setDescription(3, "")
+    tif_file <- tempfile(fileext = ".tif")
+    ds_tif <- createCopy("GTiff", tif_file, ds_mem,
+                         return_obj = TRUE)
+    expect_true(is(ds_tif, "Rcpp_GDALRaster"))
+    expect_warning(ds_tif$setGeoTransform(ds_mem$getGeoTransform()))
+    extr_tif <- pixel_extract(ds_tif, geo_xy, as_data_frame = TRUE)
+    expect_true(is.data.frame(extr_tif))
+    ds_name <- tools::file_path_sans_ext(basename(ds_tif$getDescription(0)))
+    expected_names <- c("ptid", paste0(rep(ds_name, 3), c("_b1", "_b2", "_b3")))
+    expect_equal(names(extr_tif), expected_names)
+    expect_equal(extr_tif[, 2], c(1000, 1000))
+    expect_equal(extr_tif[, 3], c(100, 100))
+    expect_equal(extr_tif[, 4], c(10, 10))
+    rm(extr_tif)
+    # subset of bands, re-ordered
+    extr_tif <- pixel_extract(ds_tif, geo_xy,
+                              bands = c(3, 2),
+                              as_data_frame = TRUE)
+    expect_true(is.data.frame(extr_tif))
+    expected_names <- c("ptid", paste0(rep(ds_name, 2), c("_b3", "_b2")))
+    expect_equal(names(extr_tif), expected_names)
+    expect_equal(extr_tif[, 2], c(10, 10))
+    expect_equal(extr_tif[, 3], c(100, 100))
+
+    ds_mem$close()
+    ds_tif$close()
+    deleteDataset(tif_file)
 
     # interpolated values
-    extr_bilinear <- pixel_extract(raster_file, pts[-1], interp = "bilinear")
-    colnames(extr_bilinear) <- NULL
-    dim(extr_bilinear) <- NULL
+    extr_bilinear <- pixel_extract(ds, pts, interp = "bilinear")
     expected_values <- c(2649.217, 2881.799, 2716.290, 2558.797, 2920.404,
                          2629.495, 2548.250, 2810.543, 2478.609, 2819.776)
-    expect_equal(extr_bilinear, expected_values, tolerance = 1e-4)
+    expect_equal(extr_bilinear[, 2], expected_values, tolerance = 1e-4)
 
     # kernel values
-    extr_3x3 <- pixel_extract(raster_file, pts[-1], krnl_dim = 3)
+    extr_3x3 <- pixel_extract(ds, pts[-1], krnl_dim = 3)
+    expect_equal(colnames(extr_3x3), c("b1_p1", "b1_p2", "b1_p3",
+                                       "b1_p4", "b1_p5", "b1_p6",
+                                       "b1_p7", "b1_p8", "b1_p9"))
     colnames(extr_3x3) <- NULL
     dimnames(extr_3x3) <- NULL
     expected_values <- c(
@@ -528,7 +597,6 @@ test_that("pixel_extract wrapper returns correct data", {
     expect_equal(extr_3x3, expected_values)
 
     # transform the xy
-    ds$open(read_only = TRUE)
     pts_nad83 <- transform_xy(pts[-1], ds$getProjection(), "NAD83")
     extr <- pixel_extract(raster_file, pts_nad83, xy_srs = "NAD83")
     colnames(extr) <- NULL
@@ -537,6 +605,7 @@ test_that("pixel_extract wrapper returns correct data", {
                          2633, 2548, 2801, 2475, 2822)
     expect_equal(extr, expected_values)
     ds$close()
+    rm(extr)
 
 
     # input validation
@@ -544,10 +613,58 @@ test_that("pixel_extract wrapper returns correct data", {
     expect_error(pixel_extract(NULL, pts[-1]))
     expect_error(pixel_extract(raster_file))
     expect_error(pixel_extract(raster_file, as.character(pts[-1])))
-    expect_error(pixel_extract(raster_file, pts))  # more than two columns
+    expect_error(pixel_extract(raster_file, pts[, 2]))
+    expect_error(pixel_extract(raster_file, pts, bands = c(1, 2, NA)))
+    expect_no_error(pixel_extract(raster_file, pts, bands = 1.1))
+    expect_error(pixel_extract(raster_file, pts,
+                               interp = c("bilinear", "cubic")))
+    expect_error(pixel_extract(raster_file, pts, krnl_dim = c(1, 1, 1)))
+    expect_error(pixel_extract(raster_file, pts, xy_srs = 4326))
+    expect_error(pixel_extract(raster_file, pts, max_ram = "invalid"))
     pts[, 2] <- as.character(pts[, 1])
-    expect_error(pixel_extract(raster_file, pts[-1]))
-    expect_error(pixel_extract(raster_file, pts[-1], bands = "1"))
-    expect_error(pixel_extract(raster_file, pts[-1], interp = 2))
-    expect_error(pixel_extract(raster_file, pts[-1], krnl_dim = c(1, 1, 1)))
+    expect_error(pixel_extract(raster_file, pts))
+
+
+    # test copy of remote raster to an in-memory dataset if not on CRAN
+    skip_on_cran()
+
+    f <- "/vsicurl/https://raw.githubusercontent.com/usdaforestservice/gdalraster/main/sample-data/lf_fbfm40_220_mt_hood_utm.tif"
+    pts <- c(604450.6, 5023283,
+             611437.6, 5021571,
+             591824.6, 5030855,
+             613802.6, 5014220,
+             600267.6, 5035648,
+             613158.6, 5019868,
+             616192.6, 5025546,
+             597588.6, 5034797,
+             595511.6, 5024383,
+             591099.6, 5032626,
+             600548.6, 5020417,
+             598620.6, 5028004,
+             599306.6, 5034376,
+             612222.6, 5022980,
+             604734.6, 5031885,
+             601311.6, 5016818,
+             611955.6, 5015290,
+             605232.6, 5032306,
+             615538.6, 5014872,
+             600952.6, 5028567)
+    pts <- matrix(pts, nrow = 20, ncol = 2, byrow = TRUE)
+    expect_message(extr <- pixel_extract(f, pts), "copying to MEM")
+    colnames(extr) <- NULL
+    dim(extr) <- NULL
+    expected_values <- c(99, 188, 185, 185, 185, 185, 185, 185, 162, 165, 162,
+                         185, 185, 165, 185, 185, 165, 185, 165, 161)
+    expect_equal(extr, expected_values)
+    rm(extr)
+
+    # force to use /vsimem/ instead
+    expect_message(extr <- pixel_extract(f, pts, max_ram = 1),
+                   "copy completed")
+    colnames(extr) <- NULL
+    dim(extr) <- NULL
+    expected_values <- c(99, 188, 185, 185, 185, 185, 185, 185, 162, 165, 162,
+                         185, 185, 165, 185, 185, 165, 185, 165, 161)
+    expect_equal(extr, expected_values)
+    rm(extr)
 })


### PR DESCRIPTION
...

@param xy A two-column numeric matrix or two-column data frame of geospatial
coordinates (x, y), or a vector for a single point (x, y), in the same
spatial reference system as `raster`. Can also be given as a data frame with
three or more columns, in which the first column must be a vector of point
IDs (`character` or `numeric`), and the second and third columns must contain
the geospatial coordinates (x, y).

...

@param as_data_frame Logical value, `TRUE` to return output as a data frame.
The default is to return a numeric matrix unless point IDs are present in
the first column of `xy` given as a data frame. In that latter case, the
output will always be a data frame with the point IDs in the first column.

@returns A numeric matrix or data frame of pixel values with number of rows
equal to the number of rows in `xy`. The number of columns is equal to the
number of `bands` (plus optional point ID column), or if `krnl_dim = N`
is used, number of columns is equal to `N * N` (plus optional point ID
column). Output is always a data frame if `xy` is given as a data frame with
a column of point IDs (`as_data_frame` will be ignored in that case).
Named columns indicate the band, e.g., `"b1"`. If `krnl_dim` is used, named
columns indicate band and pixel, e.g., `"b1_p1"`, `"b1_p2"`, ..., `"b1_p9"`
if `krnl_dim = 3`. Pixels are in left-to-right, top-to-bottom order in the
kernel.