### PR TITLE
srs_to_projjson(): fix passing options in the API call

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2706,10 +2706,10 @@ NULL
 #' GEOGCS node of the input `srs`. Defaults to `FALSE` (see Note).
 #' @param multiline Logical value. `TRUE` for PROJJSON multiline output (the
 #' default).
-#' @param indent_width Integer value. Defaults to `2`.
-#' Only used if `multiline = TRUE` for PROJJSON output.
+#' @param indent_width Integer value. Defaults to `2`. Only used if
+#' `multiline = TRUE` for PROJJSON output.
 #' @param schema Character string containing URL to PROJJSON schema. Can be
-#' set to empty string to disable it (the default).
+#' set to empty string to disable it.
 #'
 #' @note
 #' Setting `gcs_only = TRUE` in `srs_to_wkt()` is a wrapper of
@@ -2731,7 +2731,7 @@ NULL
 #'
 #' srs_to_wkt("EPSG:5070", gcs_only = TRUE)
 #'
-#' srs_to_projjson("NAD83") |> cat("\n")
+#' srs_to_projjson("NAD83") |> writeLines()
 epsg_to_wkt <- function(epsg, pretty = FALSE) {
     .Call(`_gdalraster_epsg_to_wkt`, epsg, pretty)
 }
@@ -2742,7 +2742,7 @@ srs_to_wkt <- function(srs, pretty = FALSE, gcs_only = FALSE) {
 }
 
 #' @rdname srs_convert
-srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = "") {
+srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = NA_character_) {
     .Call(`_gdalraster_srs_to_projjson`, srs, multiline, indent_width, schema)
 }
 

--- a/man/srs_convert.Rd
+++ b/man/srs_convert.Rd
@@ -11,7 +11,12 @@ epsg_to_wkt(epsg, pretty = FALSE)
 
 srs_to_wkt(srs, pretty = FALSE, gcs_only = FALSE)
 
-srs_to_projjson(srs, multiline = TRUE, indent_width = 2L, schema = "")
+srs_to_projjson(
+  srs,
+  multiline = TRUE,
+  indent_width = 2L,
+  schema = NA_character_
+)
 }
 \arguments{
 \item{epsg}{Integer EPSG code.}
@@ -28,11 +33,11 @@ GEOGCS node of the input \code{srs}. Defaults to \code{FALSE} (see Note).}
 \item{multiline}{Logical value. \code{TRUE} for PROJJSON multiline output (the
 default).}
 
-\item{indent_width}{Integer value. Defaults to \code{2}.
-Only used if \code{multiline = TRUE} for PROJJSON output.}
+\item{indent_width}{Integer value. Defaults to \code{2}. Only used if
+\code{multiline = TRUE} for PROJJSON output.}
 
 \item{schema}{Character string containing URL to PROJJSON schema. Can be
-set to empty string to disable it (the default).}
+set to empty string to disable it.}
 }
 \value{
 Character string containing OGC WKT.
@@ -104,7 +109,7 @@ set_config_option("OSR_WKT_FORMAT", "")
 
 srs_to_wkt("EPSG:5070", gcs_only = TRUE)
 
-srs_to_projjson("NAD83") |> cat("\n")
+srs_to_projjson("NAD83") |> writeLines()
 }
 \seealso{
 \link{srs_query}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1905,7 +1905,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // srs_to_projjson
-std::string srs_to_projjson(const std::string& srs, bool multiline, int indent_width, const std::string& schema);
+std::string srs_to_projjson(const std::string& srs, bool multiline, int indent_width, const Rcpp::String& schema);
 RcppExport SEXP _gdalraster_srs_to_projjson(SEXP srsSEXP, SEXP multilineSEXP, SEXP indent_widthSEXP, SEXP schemaSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -1913,7 +1913,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
     Rcpp::traits::input_parameter< bool >::type multiline(multilineSEXP);
     Rcpp::traits::input_parameter< int >::type indent_width(indent_widthSEXP);
-    Rcpp::traits::input_parameter< const std::string& >::type schema(schemaSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::String& >::type schema(schemaSEXP);
     rcpp_result_gen = Rcpp::wrap(srs_to_projjson(srs, multiline, indent_width, schema));
     return rcpp_result_gen;
 END_RCPP

--- a/tests/testthat/test-srs_api.R
+++ b/tests/testthat/test-srs_api.R
@@ -32,6 +32,9 @@ test_that("srs functions work", {
     expect_true(srs_to_wkt("EPSG:5070", gcs_only = TRUE) |> srs_is_geographic())
 
     expect_true(srs_to_projjson("WGS84") != "")
+    expect_true(srs_to_projjson("WGS84", multiline = FALSE) != "")
+    expect_true(srs_to_projjson("WGS84", indent_width = 4) != "")
+    expect_true(srs_to_projjson("WGS84", schema = "") != "")
 
     expect_equal(srs_find_epsg("WGS84"), "EPSG:4326")
     df_matches <- srs_find_epsg("WGS84", all_matches = TRUE)


### PR DESCRIPTION
arguments `multiline`, `iindent_width` and `schema ` were not passed correctly in the call to `OSRExportToPROJJSON()`