### PR TITLE
Remove a test for datetime range domain with no min or max value in ESRI file geodatabase

### DIFF
--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -1813,18 +1813,6 @@ test_that("field domain write functions work", {
                                           fld_name = "dt_fld1",
                                           domain_name = "dt_range1"))
 
-
-    # domain with inf range
-    defn <- ogr_def_field_domain("RangeDateTime", "dt_range2",
-                                 description = "rangedatetime domain test 2",
-                                 fld_type = "OFTDateTime")
-
-    expect_true(ogr_ds_add_field_domain(dsn, defn))
-
-    expect_true(ogr_field_create(dsn, "test", "dt_fld2",
-                                 fld_type = "OFTDateTime",
-                                 domain_name = "dt_range2"))
-
     # read back
     lyr <- new(GDALVector, dsn, "test")
 


### PR DESCRIPTION
Removes a test that was missed in #741, none/infinite min or max is not supported in ESRI file geodaatbase (https://github.com/OSGeo/gdal/issues/12564)