### PR TITLE
report no driver when driver null (fixes 759)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# gdalraster 2.1.0.9001 (dev)
+# gdalraster 2.1.0.9002 (dev)
 
 * Allow reporting of dataset that has no driver (fixes #759). 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gdalraster 2.1.0.9001 (dev)
 
+* Allow reporting of dataset that has no driver (fixes #759). 
+
 * `pixel_extract()`: add checks for potential ctrl-c user interrupt during extract for a large number of points (#757) (2025-07-20)
 
 * (internal) avoid clang warning from `-Wimplicit-const-int-float-conversion` in src/vsifile.cpp (2025-07-15)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # gdalraster 2.1.0.9002 (dev)
 
-* Allow reporting of dataset that has no driver (fixes #759). 
+* allow reporting driver name as empty string for a dataset that has no driver (fixes #759) (2025-08-01)
 
 * `pixel_extract()`: add checks for potential ctrl-c user interrupt during extract for a large number of points (#757) (2025-07-20)
 

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -290,6 +290,7 @@ std::string GDALRaster::getDriverShortName() const {
     checkAccess_(GA_ReadOnly);
 
     GDALDriverH hDriver = GDALGetDatasetDriver(m_hDataset);
+    if (!hDriver) return("");
     return GDALGetDriverShortName(hDriver);
 }
 
@@ -297,6 +298,7 @@ std::string GDALRaster::getDriverLongName() const {
     checkAccess_(GA_ReadOnly);
 
     GDALDriverH hDriver = GDALGetDatasetDriver(m_hDataset);
+    if (!hDriver) return("");
     return GDALGetDriverLongName(hDriver);
 }
 


### PR DESCRIPTION
PR to accurately report on null-driver, described as "" by GetDriverLongName and GetDriverShortName. 

Fixes #759 

(I toyed with a test for this but a bit too challenging - not sure if we can use sourceCpp to set one up? By creating a GDAL MULTDIMRASTER with OpenEx, then casting a MDArray to classic). 