### PR TITLE
`setGDALDatasetH_()` in classes `GDALRaster` and `GDALVector`: check shared flag of incoming GDALDatasetH and set the `m_shared` member variable

### DIFF
--- a/inst/COPYRIGHTS
+++ b/inst/COPYRIGHTS
@@ -52,33 +52,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 ===============================================================================
 
-=====file: src/gdalraster.h ===================================================
-Function: ARE_REAL_EQUAL
-This function was copied from gdal/gcore/gdal_priv.h since that header is
-otherwise not needed. We include gdal.h instead for the C API.
-
-Copyright (c) 1998, Frank Warmerdam
-Copyright (c) 2007-2014, Even Rouault <even dot rouault at spatialys.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
- *
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
- *
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-===============================================================================
-
 =====file: src/cmb_table.h ====================================================
 The struct cmbHasher{} uses the Boost method for combining hashes:
 Copyright 2005-2014 Daniel James.

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "gdal.h"
+#include "gdal_priv.h"
 #include "cpl_port.h"
 #include "cpl_conv.h"
 #include "cpl_string.h"
@@ -2190,12 +2191,17 @@ GDALDatasetH GDALRaster::getGDALDatasetH_() const {
     return m_hDataset;
 }
 
-void GDALRaster::setGDALDatasetH_(GDALDatasetH hDs, bool with_update) {
+void GDALRaster::setGDALDatasetH_(const GDALDatasetH &hDs, bool with_update) {
     m_hDataset = hDs;
     if (with_update)
         m_eAccess = GA_Update;
     else
         m_eAccess = GA_ReadOnly;
+
+    if (GDALDataset::FromHandle(m_hDataset)->GetShared() == TRUE)
+        m_shared = true;
+    else
+        m_shared = false;
 }
 
 // ****************************************************************************

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -27,21 +27,6 @@ typedef void *GDALRasterBandH;
 typedef enum {GA_ReadOnly = 0, GA_Update = 1} GDALAccess;
 #endif
 
-// The function ARE_REAL_EQUAL was copied from gcore/gdal_priv.h since we
-// do not need that header otherwise
-// Copyright (c) 1998, Frank Warmerdam
-// Copyright (c) 2007-2014, Even Rouault <even dot rouault at spatialys.com>
-// License: MIT
-//
-// Behavior is undefined if fVal1 or fVal2 are NaN (should be tested before
-// calling this function)
-template <class T> inline bool ARE_REAL_EQUAL(T fVal1, T fVal2, int ulp = 2)
-{
-    return fVal1 == fVal2 || /* Should cover infinity */
-           std::abs(fVal1 - fVal2) < std::numeric_limits<float>::epsilon() *
-                                         std::abs(fVal1 + fVal2) * ulp;
-}
-
 #ifdef GDAL_H_INCLUDED
 // Map certain GDAL enums to string names for use in R
 // GDALColorInterp (GCI)
@@ -220,7 +205,7 @@ class GDALRaster {
     bool hasInt64_() const;
     void warnInt64_() const;
     GDALDatasetH getGDALDatasetH_() const;
-    void setGDALDatasetH_(GDALDatasetH hDs, bool with_update);
+    void setGDALDatasetH_(const GDALDatasetH &hDs, bool with_update);
 
  private:
     std::string m_fname {};

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 
 #include "gdal.h"
+#include "gdal_priv.h"
 #include "cpl_port.h"
 #include "cpl_string.h"
 #include "cpl_time.h"
@@ -2542,12 +2543,17 @@ GDALDatasetH GDALVector::getGDALDatasetH_() const {
     return m_hDataset;
 }
 
-void GDALVector::setGDALDatasetH_(GDALDatasetH hDs, bool with_update) {
+void GDALVector::setGDALDatasetH_(const GDALDatasetH &hDs, bool with_update) {
     m_hDataset = hDs;
     if (with_update)
         m_eAccess = GA_Update;
     else
         m_eAccess = GA_ReadOnly;
+
+    if (GDALDataset::FromHandle(m_hDataset)->GetShared() == TRUE)
+        m_shared = true;
+    else
+        m_shared = false;
 }
 
 OGRLayerH GDALVector::getOGRLayerH_() const {
@@ -2556,7 +2562,8 @@ OGRLayerH GDALVector::getOGRLayerH_() const {
     return m_hLayer;
 }
 
-void GDALVector::setOGRLayerH_(OGRLayerH hLyr, const std::string &lyr_name) {
+void GDALVector::setOGRLayerH_(const OGRLayerH &hLyr,
+                               const std::string &lyr_name) {
     m_hLayer = hLyr;
     m_layer_name = lyr_name;
 #if __has_include("ogr_recordbatch.h")

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -165,9 +165,9 @@ class GDALVector {
 
     void setDsn_(const std::string &dsn);
     GDALDatasetH getGDALDatasetH_() const;
-    void setGDALDatasetH_(GDALDatasetH hDs, bool with_update);
+    void setGDALDatasetH_(const GDALDatasetH &hDs, bool with_update);
     OGRLayerH getOGRLayerH_() const;
-    void setOGRLayerH_(OGRLayerH hLyr, const std::string &lyr_name);
+    void setOGRLayerH_(const OGRLayerH &hLyr, const std::string &lyr_name);
     void setFieldNames_();
 
     SEXP createDF_(R_xlen_t nrow) const;
@@ -211,6 +211,7 @@ class GDALVector {
     GDALDatasetH m_hDataset {nullptr};
     GDALAccess m_eAccess {GA_ReadOnly};
     OGRLayerH m_hLayer {nullptr};
+    bool m_shared {false};
     int64_t m_last_write_fid {NA_INTEGER64};
 #if __has_include("ogr_recordbatch.h")
     struct ArrowArrayStream m_stream;


### PR DESCRIPTION
Adds `#include <gdal_priv.h>` so the copy of `ARE_REAL_EQUAL()` is also removed here.