### PR TITLE
Disable the Arrow code path for ogr2ogr and avoid virtual file systems in examples and tests for ogr_reproject() while attempting to fix #769

### DIFF
--- a/R/ogr_reproject.R
+++ b/R/ogr_reproject.R
@@ -96,6 +96,7 @@
 #' \url{https://gdal.org/en/stable/programs/ogr2ogr.html}
 #'
 #' @examples
+#' \dontshow{set_config_option("OGR2OGR_USE_ARROW_API", "NO")}
 #' # MTBS fire perimeters
 #' f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package = "gdalraster")
 #' (mtbs <- new(GDALVector, f, "mtbs_perims"))
@@ -104,7 +105,9 @@
 #'
 #' # YNP boundary
 #' f <- system.file("extdata/ynp_features.zip", package = "gdalraster")
-#' ynp_dsn <- file.path("/vsizip", f, "ynp_features.gpkg")
+#' unzip(f, files = "ynp_features.gpkg", exdir = tempdir())
+#' ynp_dsn <- file.path(tempdir(), "ynp_features.gpkg")
+#'
 #' (bnd <- new(GDALVector, ynp_dsn, "ynp_bnd"))
 #'
 #' bnd$getSpatialRef() |> srs_is_projected()  # FALSE
@@ -128,6 +131,8 @@
 #' bnd$close()
 #' bnd_mtsp$close()
 #' \dontshow{unlink(out_dsn)}
+#' \dontshow{unlink(ynp_dsn)}
+#' \dontshow{set_config_option("OGR2OGR_USE_ARROW_API", "")}
 #' @export
 ogr_reproject <- function(src_dsn, src_layer, out_dsn, out_srs,
                           out_fmt = NULL, overwrite = FALSE,

--- a/man/ogr_reproject.Rd
+++ b/man/ogr_reproject.Rd
@@ -126,6 +126,7 @@ new datasets (i.e., a database within PostgreSQL), but output layers can be
 written to an existing database.
 }
 \examples{
+\dontshow{set_config_option("OGR2OGR_USE_ARROW_API", "NO")}
 # MTBS fire perimeters
 f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package = "gdalraster")
 (mtbs <- new(GDALVector, f, "mtbs_perims"))
@@ -134,7 +135,9 @@ mtbs$getSpatialRef() |> srs_is_projected()  # TRUE
 
 # YNP boundary
 f <- system.file("extdata/ynp_features.zip", package = "gdalraster")
-ynp_dsn <- file.path("/vsizip", f, "ynp_features.gpkg")
+unzip(f, files = "ynp_features.gpkg", exdir = tempdir())
+ynp_dsn <- file.path(tempdir(), "ynp_features.gpkg")
+
 (bnd <- new(GDALVector, ynp_dsn, "ynp_bnd"))
 
 bnd$getSpatialRef() |> srs_is_projected()  # FALSE
@@ -158,6 +161,8 @@ mtbs$close()
 bnd$close()
 bnd_mtsp$close()
 \dontshow{unlink(out_dsn)}
+\dontshow{unlink(ynp_dsn)}
+\dontshow{set_config_option("OGR2OGR_USE_ARROW_API", "")}
 }
 \seealso{
 \code{\link[=ogr2ogr]{ogr2ogr()}}, \code{\link[=warp]{warp()}} for raster reprojection

--- a/tests/testthat/test-ogr_reproject.R
+++ b/tests/testthat/test-ogr_reproject.R
@@ -1,6 +1,16 @@
 test_that("ogr_reproject works", {
+
+    # NOTE: disabling the Arrow code path in ogr2ogr
+    # (https://gdal.org/en/release-3.10/programs/ogr2ogr.html#known-issues),
+    # and avoiding the use of any virtual file systems while attempting to fix
+    # https://github.com/USDAForestService/gdalraster/issues/769
+
     f <- system.file("extdata/ynp_features.zip", package = "gdalraster")
-    ynp_dsn <- file.path("/vsizip", f, "ynp_features.gpkg")
+    # ynp_dsn <- file.path("/vsizip", f, "ynp_features.gpkg")
+    unzip(f, files = "ynp_features.gpkg", exdir = tempdir())
+    ynp_dsn <- file.path(tempdir(), "ynp_features.gpkg")
+
+    set_config_option("OGR2OGR_USE_ARROW_API", "NO")
 
     out_gpkg <- tempfile(fileext = ".gpkg")
     on.exit(unlink(out_gpkg))
@@ -147,4 +157,6 @@ test_that("ogr_reproject works", {
                                out_gpkg, "EPSG:32100",
                                add_cl_arg = 1))
 
+
+    set_config_option("OGR2OGR_USE_ARROW_API", "")
 })

--- a/vignettes/vector-api-overview.Rmd
+++ b/vignettes/vector-api-overview.Rmd
@@ -22,6 +22,8 @@ knitr::opts_chunk$set(
 library(gdalraster)
 gdal_3_6_0_min <- (gdal_version_num() >= gdal_compute_version(3, 6, 0))
 gdal_3_7_0_min <- (gdal_version_num() >= gdal_compute_version(3, 7, 0))
+
+set_config_option("OGR2OGR_USE_ARROW_API", "NO")
 ```
 
 ## Background
@@ -361,7 +363,9 @@ Here we instantiate a `GDALVector` object for the park boundary layer and retrie
 
 ```{r}
 f <- system.file("extdata/ynp_features.zip", package = "gdalraster")
-ynp_dsn <- file.path("/vsizip", f, "ynp_features.gpkg")
+# extract to a temporary writable file
+unzip(f, files = "ynp_features.gpkg", exdir = tempdir())
+ynp_dsn <- file.path(tempdir(), "ynp_features.gpkg")
 
 # the park boundary layer containing a single feature
 (bnd <- new(GDALVector, ynp_dsn, "ynp_bnd"))
@@ -510,8 +514,8 @@ The MTBS layer uses a projected coordinate system, while layers of the "YNP feat
 f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package = "gdalraster")
 
 # copy to a temporary writable file
-mtbs_dsn <- "/vsimem/tmp/ynp_fires_1984_2022.gpkg"
-ogr2ogr(f, mtbs_dsn)
+mtbs_dsn <- file.path(tempdir(), "ynp_fires_1984_2022.gpkg")
+file.copy(f, mtbs_dsn)
 
 (fires <- new(GDALVector, mtbs_dsn, "mtbs_perims"))
 
@@ -775,10 +779,11 @@ opt <- c("INPUT_PREFIX=layer1_",
          "PROMOTE_TO_MULTI=YES")
 
 # intersect to obtain areas re-burned since 2000
+out_file <- tempfile(fileext = ".gpkg")
 lyr_out <- ogr_proc(mode = "Intersection",
                     input_lyr = lyr1,
                     method_lyr = lyr2,
-                    out_dsn = mtbs_dsn,
+                    out_dsn = out_file,
                     out_lyr_name = "north_fork_reburned",
                     out_geom_type = "MULTIPOLYGON",
                     mode_opt = opt)
@@ -799,6 +804,9 @@ lyr_out$close()
 ```{r, include = FALSE}
 # clean up
 unlink(json_file)
-vsi_unlink(mtbs_dsn)
-vsi_rmdir("/vsimem/tmp/")
+unlink(out_file)
+unlink(mtbs_dsn)
+unlink(ynp_dsn)
+
+set_config_option("OGR2OGR_USE_ARROW_API", "")
 ```


### PR DESCRIPTION
This PR only affects tests and example code involving `ogr_reproject()`. In the tests and examples, it disables the Arrow code path for ogr2ogr (cf. https://gdal.org/en/stable/programs/ogr2ogr.html#known-issues) and avoids use of virtual file systems. This is only to simplify, and eliminate possible contributing factors while attempting to resolve errors described in #769.