### PR TITLE
Doc: move vector-api-overview from vignette to a web article

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -208,7 +208,7 @@ articles:
   - articles/raster-display
   - raster-attribute-tables
   - articles/gdal-block-cache
-  - vector-api-overview
+  - articles/vector-api-overview
   - articles/vector-read-benchmarks
   - gdal-config-quick-ref
   - articles/use-gdal-cli-from-r

--- a/vignettes/articles/vector-api-overview.Rmd
+++ b/vignettes/articles/vector-api-overview.Rmd
@@ -1,16 +1,5 @@
 ---
 title: "Vector API Overview"
-output:
-  rmarkdown::html_vignette:
-    toc: true
-    toc_depth: 4
-    fig_width: 7
-    fig_height: 5
-    fig_caption: true
-vignette: >
-  %\VignetteIndexEntry{Vector API Overview}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
 ---
 
 ```{r, include = FALSE}
@@ -22,8 +11,6 @@ knitr::opts_chunk$set(
 library(gdalraster)
 gdal_3_6_0_min <- (gdal_version_num() >= gdal_compute_version(3, 6, 0))
 gdal_3_7_0_min <- (gdal_version_num() >= gdal_compute_version(3, 7, 0))
-
-set_config_option("OGR2OGR_USE_ARROW_API", "NO")
 ```
 
 ## Background
@@ -244,12 +231,11 @@ Here we copy the .gpkg file from the zip archive to an in-memory file that is wr
 ```{r}
 # copy ynp_features.gpkg from the zip file to an in-memory file
 mem_gpkg <- "/vsimem/tmp/ynp_features.gpkg"
-# copyDatasetFiles() is: to, from
-copyDatasetFiles(mem_gpkg, zf_gpkg)
+ogr2ogr(zf_gpkg, mem_gpkg)
 
 vsi_read_dir("/vsimem/tmp")
 
-# confirm it is writable
+# confirm it's writable
 ogr_ds_exists(mem_gpkg, with_update = TRUE)
 
 rd_layer <- "roads"
@@ -364,9 +350,7 @@ Here we instantiate a `GDALVector` object for the park boundary layer and retrie
 
 ```{r}
 f <- system.file("extdata/ynp_features.zip", package = "gdalraster")
-# extract to a temporary writable file
-unzip(f, files = "ynp_features.gpkg", exdir = tempdir())
-ynp_dsn <- file.path(tempdir(), "ynp_features.gpkg")
+ynp_dsn <- file.path("/vsizip", f, "ynp_features.gpkg")
 
 # the park boundary layer containing a single feature
 (bnd <- new(GDALVector, ynp_dsn, "ynp_bnd"))
@@ -503,14 +487,6 @@ head(d)
 
 roads$close()
 ```
-```{r, include = FALSE}
-# clean up
-rm(bnd)
-rm(poi)
-rm(roads)
-rm(stream)
-gc()
-```
 
 ### Reproject vector layers
 
@@ -523,8 +499,8 @@ The MTBS layer uses a projected coordinate system, while layers of the "YNP feat
 f <- system.file("extdata/ynp_fires_1984_2022.gpkg", package = "gdalraster")
 
 # copy to a temporary writable file
-mtbs_dsn <- file.path(tempdir(), "ynp_fires_1984_2022.gpkg")
-file.copy(f, mtbs_dsn)
+mtbs_dsn <- "/vsimem/tmp/ynp_fires_1984_2022.gpkg"
+ogr2ogr(f, mtbs_dsn)
 
 (fires <- new(GDALVector, mtbs_dsn, "mtbs_perims"))
 
@@ -540,8 +516,7 @@ srs_mtsp <- fires$getSpatialRef()  # Montana state plane metric definition
 bnd$close()
 
 # reproject points_of_interest
-poi <- ogr_reproject(ynp_dsn, "points_of_interest", mtbs_dsn, srs_mtsp,
-                     add_cl_arg = "-skipfailures")
+poi <- ogr_reproject(ynp_dsn, "points_of_interest", mtbs_dsn, srs_mtsp)
 
 # set an attribute filter to select the Maple Fire
 fires$setAttributeFilter("incid_name = 'MAPLE'")
@@ -789,11 +764,10 @@ opt <- c("INPUT_PREFIX=layer1_",
          "PROMOTE_TO_MULTI=YES")
 
 # intersect to obtain areas re-burned since 2000
-out_file <- tempfile(fileext = ".gpkg")
 lyr_out <- ogr_proc(mode = "Intersection",
                     input_lyr = lyr1,
                     method_lyr = lyr2,
-                    out_dsn = out_file,
+                    out_dsn = mtbs_dsn,
                     out_lyr_name = "north_fork_reburned",
                     out_geom_type = "MULTIPOLYGON",
                     mode_opt = opt)
@@ -814,9 +788,6 @@ lyr_out$close()
 ```{r, include = FALSE}
 # clean up
 unlink(json_file)
-unlink(out_file)
-unlink(mtbs_dsn)
-unlink(ynp_dsn)
-
-set_config_option("OGR2OGR_USE_ARROW_API", "")
+vsi_unlink(mtbs_dsn)
+vsi_rmdir("/vsimem/tmp/")
 ```


### PR DESCRIPTION
in its original form as of the version 2.1.0 release