### PR TITLE
Multiple updates for the gdal CLI bindings

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2218,6 +2218,11 @@ vsi_is_local <- function(filename) {
 }
 
 #' @noRd
+.gdal_global_reg_names <- function() {
+    .Call(`_gdalraster_gdal_global_reg_names`)
+}
+
+#' @noRd
 NULL
 
 #' @noRd

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -144,12 +144,12 @@ dt_find_for_value <- function(value, is_complex = FALSE) {
 #'
 #' @returns
 #' `gdal_version()` returns a character vector of length four containing:
-#'   * "–version" - one line version message, e.g., “GDAL 3.6.3, released
-#'   2023/03/12”
-#'   * "GDAL_VERSION_NUM" - formatted as a string, e.g., “3060300” for
+#'   * "-version" - one line version message, e.g., "GDAL 3.6.3, released
+#'   2023/03/12"
+#'   * "GDAL_VERSION_NUM" - formatted as a string, e.g., "3060300" for
 #'   GDAL 3.6.3.0
-#'   * "GDAL_RELEASE_DATE" - formatted as a string, e.g., “20230312”
-#'   * "GDAL_RELEASE_NAME" - e.g., “3.6.3”
+#'   * "GDAL_RELEASE_DATE" - formatted as a string, e.g., "20230312"
+#'   * "GDAL_RELEASE_NAME" - e.g., "3.6.3"
 #'
 #' `gdal_version_num()` returns `as.integer(gdal_version()[2])`
 #' @examples

--- a/R/cmb_table.R
+++ b/R/cmb_table.R
@@ -25,7 +25,7 @@
 #' hash table are described in Details.
 #'
 #' @section Usage (see Details):
-#' \preformatted{
+#' ```
 #' ## Constructors
 #' cmb <- new(CmbTable, keyLen)
 #' # or, giving the variable names:
@@ -37,7 +37,7 @@
 #' cmb$updateFromMatrixByRow(int_cmbs, incr)
 #' cmb$asDataFrame()
 #' cmb$asMatrix()
-#' }
+#' ```
 #'
 #' @section Details:
 #' ## Constructors

--- a/R/gdal_cli.R
+++ b/R/gdal_cli.R
@@ -3,7 +3,7 @@
 # see R/gdalalg.R and src/gdalalg.h
 # Chris Toney <jctoney at gmail.com>
 
-#' Convenience functions for using \dQuote{gdal} CLI algorithms
+#' Convenience functions for using GDAL CLI algorithms
 #'
 #' @name gdal_cli
 #' @description
@@ -12,7 +12,7 @@
 #'
 #' **Requires GDAL >= `r .GDALALG_MIN_GDAL_STR`**
 #'
-#' **Experimental** (see "Development status")
+#' **Experimental** (see \dQuote{Development status})
 #'
 #' @details
 #' These functions are convenient for accessing and running GDAL CLI algorithms
@@ -26,7 +26,7 @@
 #' with vector inputs.
 #'
 #' `gdal_usage()` prints a help message to the console for a given command, or
-#' for the root `"gdal"` entry point if called with no argument. No return
+#' for the root \dQuote{gdal} entry point if called with no argument. No return
 #' value, called for that side effect only.
 #'
 #' `gdal_run()` executes a GDAL CLI algorithm and returns it as an object of
@@ -53,7 +53,7 @@
 #' commands, e.g., `gdal_commands("vector")`.
 #' @param recurse Logical value, `TRUE` to include all subcommands recursively
 #' (the default). Set to `FALSE` to include only the top-level \dQuote{gdal}
-#' commands (i.e., "raster", "vector", etc.)
+#' commands (i.e., \dQuote{raster}, \dQuote{vector}, etc.)
 #' @param cout Logical value, `TRUE` to print a list of commands along with
 #' their descriptions and help URLS to the console (the default).
 #' @param cmd A character string or character vector containing the path to the
@@ -81,7 +81,7 @@
 #' input(s) first, output last. Positional arguments can also be specified as
 #' named arguments, if preferred to avoid any ambiguity.
 #' * Named arguments have:
-#'   * at least one "long" name, preceded by two dash characters when specified
+#'   * at least one long name, preceded by two dash characters when specified
 #'   on the command line,
 #'   * optionally, auxiliary long names (i.e., aliases),
 #'   * and optionally a one-letter short name, preceded by a single dash
@@ -143,8 +143,8 @@
 #' Using \dQuote{gdal} CLI algorithms from R:\cr
 #' \url{https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html}
 #'
-#' @examplesIf gdal_version_num() >= gdalraster:::.GDALALG_MIN_GDAL
-#' ## top-level gdal commands
+#' @examplesIf gdal_version_num() >= gdal_compute_version(3, 11, 3)
+#' ## top-level commands
 #' gdal_commands(recurse = FALSE)
 #'
 #' ## convert storml_elev.tif to GeoPackage raster

--- a/R/gdal_cli.R
+++ b/R/gdal_cli.R
@@ -7,10 +7,10 @@
 #'
 #' @name gdal_cli
 #' @description
-#' This set of functions can be used to access and run GDAL utilities as
-#' \dQuote{gdal} command line interface (CLI) algorithms.
+#' This set of functions can be used to access and run GDAL utilities as `gdal`
+#' command line interface (CLI) algorithms.
 #'
-#' **Requires GDAL >= `r .GDALALG_MIN_GDAL_STR`**
+#' **Requires GDAL >= 3.11.3**
 #'
 #' **Experimental** (see the section `Development Status` below)
 #'
@@ -20,14 +20,14 @@
 #' documentation for additional information (`?GDALAlg`).
 #'
 #' `gdal_commands()` prints a list of commands and their descriptions to the
-#' console, and returns (invisibly) a data frame with columns named `command`,
-#' `description` and `URL`. The `contains` argument can be used to filter the
+#' console, and returns (invisibly) a data frame with columns `command`,
+#' `description`, `URL`. The `contains` argument can be used to filter the
 #' output, e.g., `gdal_commands("vector")` to return only commands for working
 #' with vector inputs.
 #'
 #' `gdal_usage()` prints a help message to the console for a given command, or
-#' for the root \dQuote{gdal} entry point if called with no argument. No return
-#' value, called for that side effect only.
+#' for the root `gdal` entry point if called with no argument. No return value,
+#' called for that side effect only.
 #'
 #' `gdal_run()` executes a GDAL CLI algorithm and returns it as an object of
 #' class [`GDALAlg`][GDALAlg]. A list containing algorithm output(s) can be
@@ -60,8 +60,8 @@
 #' @param contains Optional character string for filtering output to certain
 #' commands, e.g., `gdal_commands("vector")`.
 #' @param recurse Logical value, `TRUE` to include all subcommands recursively
-#' (the default). Set to `FALSE` to include only the top-level \dQuote{gdal}
-#' commands (i.e., \dQuote{raster}, \dQuote{vector}, etc.)
+#' (the default). Set to `FALSE` to include only the top-level `gdal` commands
+#' (i.e., `raster`, `vector`, etc.)
 #' @param cout Logical value, `TRUE` to print a list of commands along with
 #' their descriptions and help URLS to the console (the default).
 #' @param cmd A character string or character vector containing the path to the
@@ -83,50 +83,47 @@
 #' formats. Programmatic usage also allows passing and receiving datasets as
 #' objects (i.e., `GDALRaster` or `GDALVector`), in addition to dataset names
 #' (e.g., filename, URL, database connection string).
-#'
 #' * Commands accept one or several positional arguments, typically for dataset
 #' names (or, in \R, as `GDALRaster` or `GDALVector` datasets). The order is
 #' input(s) first, output last. Positional arguments can also be specified as
 #' named arguments, if preferred to avoid any ambiguity.
 #' * Named arguments have:
-#'   * at least one \dQuote{long} name, preceded by two dash characters when
-#'   specified on the command line,
+#'   * at least one "long" name, preceded by two dash characters
 #'   * optionally, auxiliary long names (i.e., aliases),
 #'   * and optionally a one-letter short name, preceded by a single dash
-#'   character on the command line, e.g., `-f, --of, --format, --output-format
-#'   <OUTPUT-FORMAT>`
-#' * Boolean arguments are specified by just specifying the argument name. In
-#' \R `list` format, the named element must be assigned a value of logical
-#' `TRUE`.
+#'   character, e.g., \code{-f, --of, --format, --output-format <OUTPUT-FORMAT>}
+#' * Boolean arguments are specified by just specifying the argument name in
+#' character vector format. In \R `list` format, the named element must be
+#' assigned a value of logical `TRUE`.
 #' * Arguments that require a value are specified like:
-#'   * `-f VALUE` for one-letter short names
-#'   * `--format VALUE` or `--format=VALUE` for long names
-#'   * in a named list, this might look like: `args$format <- VALUE`
+#'   * \code{-f VALUE} for one-letter short names
+#'   * \code{--format VALUE} or \code{--format=VALUE} for long names
+#'   * in a named list, this might look like: \code{args$format <- VALUE}
 #' * Some arguments can be multi-valued. Some of them require all values to be
 #' packed together and separated with comma. This is, e.g., the case of:\cr
-#' `--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax`\cr
-#' e.g., `--bbox=2.1,49.1,2.9,49.9`.
+#' \code{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax} \cr
+#' e.g., \code{--bbox=2.1,49.1,2.9,49.9}
 #' * Others accept each value to be preceded by a new mention of the argument
-#' name, e.g., `--co COMPRESS=LZW --co TILED=YES`. For that one, if the value
-#' of the argument does not contain commas, the packed form is also accepted:
-#' `--co COMPRESS=LZW,TILED=YES`. Note that repeated mentions of an argument
-#' are possible in the character vector format for argument input, whereas
-#' arguments given in named list format must used argument long names as the
-#' list element names, and the packed format for the values (which can be a
-#' character vector or numeric vector of values).
+#' name, e.g., \code{c("--co", "COMPRESS=LZW", "--co", "TILED=YES")}. For that
+#' one, if the value of the argument does not contain commas, the packed form
+#' is also accepted: \code{--co COMPRESS=LZW,TILED=YES}. Note that repeated
+#' mentions of an argument are possible in the character vector format for
+#' argument input, whereas arguments given in named list format must use
+#' argument long names as the list element names, and the packed format for the
+#' values (which can be a character vector or numeric vector of values).
 #' * Named arguments can be placed before or after positional arguments.
 #'
 #' @section Development Status:
 #' The GDAL Command Line Interface Modernization was first introduced in the
 #' [GDAL 3.11.0 release](https://github.com/OSGeo/gdal/releases/tag/v3.11.0)
-#' (2025-05-09). The GDAL project provides warning that the new CLI \dQuote{is
+#' (2025-05-09). The GDAL project provides warning that the new CLI "is
 #' provisionally provided as an alternative interface to GDAL and OGR command
 #' line utilities. The project reserves the right to modify, rename,
 #' reorganize, and change the behavior until it is officially frozen via PSC
 #' vote in a future major GDAL release. The utility needs time to mature,
 #' benefit from incremental feedback, and explore enhancements without carrying
 #' the burden of full backward compatibility. Your usage of it should have no
-#' expectation of compatibility until that time.}
+#' expectation of compatibility until that time."
 #' (\url{https://gdal.org/en/latest/programs/#gdal-application})
 #'
 #' Initial bindings to enable programmatic use of the CLI algorithms from \R
@@ -143,16 +140,16 @@
 #' When using argument names as the element names of a list, the underscore
 #' character can be substituted for the dash characters that are used in some
 #' names. This avoids having to surround names in backticks when they are used
-#' to access list elements in the form `args$arg_name` (the form
-#' `args[["arg-name"]]` also works).
+#' to access list elements in the form \code{args$arg_name} (the form
+#' \code{args[["arg-name"]]} also works).
 #'
 #' @seealso
 #' [`GDALAlg-class`][GDALAlg]
 #'
-#' \dQuote{gdal} Command Line Interface (CLI):\cr
+#' `gdal` Command Line Interface (CLI) \cr
 #' \url{https://gdal.org/en/stable/programs/index.html}
 #'
-#' Using \dQuote{gdal} CLI algorithms from R:\cr
+#' Using `gdal` CLI algorithms from \R \cr
 #' \url{https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html}
 #'
 #' @examplesIf length(gdal_global_reg_names()) > 0
@@ -237,7 +234,7 @@
 #' ds$close()
 #' deleteDataset(f_out)
 #'
-#' ## "pipeline" syntax
+#' ## pipeline syntax
 #' # "raster pipeline" example 2 from:
 #' # https://gdal.org/en/latest/programs/gdal_raster_pipeline.html
 #' # serialize the command to reproject a GTiff file into GDALG format, and
@@ -268,9 +265,8 @@
 #' unlink(f_out)
 #' @export
 gdal_commands <- function(contains = NULL, recurse = TRUE, cout = TRUE) {
-    if (gdal_version_num() < .GDALALG_MIN_GDAL) {
-        stop("gdal_commands() requires GDAL >= ", .GDALALG_MIN_GDAL_STR,
-             call. = FALSE)
+    if (gdal_version_num() < gdal_compute_version(3, 11, 3)) {
+        stop("gdal_commands() requires GDAL >= 3.11.3", call. = FALSE)
     }
 
     if (missing(contains) || is.null(contains) || all(is.na(contains)))
@@ -296,9 +292,8 @@ gdal_commands <- function(contains = NULL, recurse = TRUE, cout = TRUE) {
 #' @name gdal_cli
 #' @export
 gdal_usage <- function(cmd = NULL) {
-    if (gdal_version_num() < .GDALALG_MIN_GDAL) {
-        stop("gdal_usage() requires GDAL >= ", .GDALALG_MIN_GDAL_STR,
-             call. = FALSE)
+    if (gdal_version_num() < gdal_compute_version(3, 11, 3)) {
+        stop("gdal_usage() requires GDAL >= 3.11.3", call. = FALSE)
     }
 
     alg <- gdal_alg(cmd)
@@ -309,9 +304,8 @@ gdal_usage <- function(cmd = NULL) {
 #' @name gdal_cli
 #' @export
 gdal_run <- function(cmd, args) {
-    if (gdal_version_num() < .GDALALG_MIN_GDAL) {
-        stop("gdal_run() requires GDAL >= ", .GDALALG_MIN_GDAL_STR,
-             call. = FALSE)
+    if (gdal_version_num() < gdal_compute_version(3, 11, 3)) {
+        stop("gdal_run() requires GDAL >= 3.11.3", call. = FALSE)
     }
 
     if (missing(cmd) || is.null(cmd) || all(is.na(cmd)))
@@ -344,9 +338,8 @@ gdal_run <- function(cmd, args) {
 #' @name gdal_cli
 #' @export
 gdal_alg <- function(cmd = NULL, args = NULL, parse = TRUE) {
-    if (gdal_version_num() < .GDALALG_MIN_GDAL) {
-        stop("gdal_alg() requires GDAL >= ", .GDALALG_MIN_GDAL_STR,
-             call. = FALSE)
+    if (gdal_version_num() < gdal_compute_version(3, 11, 3)) {
+        stop("gdal_alg() requires GDAL >= 3.11.3", call. = FALSE)
     }
 
     if (missing(cmd) || is.null(cmd) || all(is.na(cmd)))
@@ -389,9 +382,10 @@ gdal_global_reg_names <- function() {
     return(.gdal_global_reg_names())
 }
 
-#' helper function to print usage to the console
-#' called from GDALAlg::usage() in src/gdalalg.cpp
+# helper function to print usage to the console
+# called from GDALAlg::usage() in src/gdalalg.cpp
 #' @noRd
+#' @export
 .print_alg_usage <- function(cmd) {
     alg <- new(GDALAlg, cmd)
     alginfo <- alg$info()

--- a/R/gdal_cli.R
+++ b/R/gdal_cli.R
@@ -12,7 +12,7 @@
 #'
 #' **Requires GDAL >= `r .GDALALG_MIN_GDAL_STR`**
 #'
-#' **Experimental** (see \dQuote{Development status})
+#' **Experimental** (see the section `Development Status` below)
 #'
 #' @details
 #' These functions are convenient for accessing and running GDAL CLI algorithms
@@ -31,7 +31,7 @@
 #'
 #' `gdal_run()` executes a GDAL CLI algorithm and returns it as an object of
 #' class [`GDALAlg`][GDALAlg]. A list containing algorithm output(s) can be
-#' accessed by calling the \code{$outputs()} (plural) method on the returned
+#' accessed by calling the \code{$outputs()} method (plural) on the returned
 #' object, or, more conveniently in most cases, by calling \code{$output()}
 #' (singular) to return the the single output value when there is only one.
 #' After assigning the output, or otherwise completing work with the `GDALAlg`
@@ -49,6 +49,14 @@
 #' for class `GDALAlg`. Executing the returned algorithm is optional by calling
 #' the object's \code{$run()} method (assuming argument values were given).
 #'
+#' `gdal_global_reg_names()` returns a character vector containing the names of
+#' the algorithms in the GDAL global algorithm registry. These are the
+#' top-level nodes (`raster`, `vector`, etc.) known to GDAL. Potentially code
+#' external to GDAL could register a new command available for CLI use in a
+#' GDAL plugin. This function may be useful in certain troubleshooting
+#' scenarios. It will return a vector of length zero if no names are returned
+#' from the global registry.
+#'
 #' @param contains Optional character string for filtering output to certain
 #' commands, e.g., `gdal_commands("vector")`.
 #' @param recurse Logical value, `TRUE` to include all subcommands recursively
@@ -60,14 +68,14 @@
 #' algorithm, e.g., `"raster reproject"` or `c("raster", "reproject")`.
 #' Defaults to `"gdal"`, the main entry point to CLI commands.
 #' @param args Either a character vector or a named list containing input
-#' arguments of the algorithm (see section \dQuote{Algorithm argument syntax}).
+#' arguments of the algorithm (see section `Algorithm Argument Syntax` below).
 #' @param parse Logical value, `TRUE` to attempt parsing `args` if they are
 #' given in `gdal_alg()` (the default). Set to `FALSE` to instantiate the
 #' algorithm without parsing arguments. The \code{$parseCommandLineArgs()}
 #' method on the returned object can be called to parse arguments and obtain
 #' the result of that, with potentially useful error messages.
 #'
-#' @section Algorithm argument syntax:
+#' @section Algorithm Argument Syntax:
 #' Arguments are given in \R as a character vector or named list, but
 #' otherwise syntax basically matches the GDAL specification for arguments as
 #' they are given on the command line. Those specifications are listed here
@@ -81,23 +89,23 @@
 #' input(s) first, output last. Positional arguments can also be specified as
 #' named arguments, if preferred to avoid any ambiguity.
 #' * Named arguments have:
-#'   * at least one long name, preceded by two dash characters when specified
-#'   on the command line,
+#'   * at least one \dQuote{long} name, preceded by two dash characters when
+#'   specified on the command line,
 #'   * optionally, auxiliary long names (i.e., aliases),
 #'   * and optionally a one-letter short name, preceded by a single dash
 #'   character on the command line, e.g., `-f, --of, --format, --output-format
 #'   <OUTPUT-FORMAT>`
 #' * Boolean arguments are specified by just specifying the argument name. In
-#' \R list format, the named element must be assigned a value of logical `TRUE`.
+#' \R `list` format, the named element must be assigned a value of logical
+#' `TRUE`.
 #' * Arguments that require a value are specified like:
-#'   * `-f VALUE` for one-letter short names.
-#'   * `--format VALUE` or `--format=VALUE` for long names.
-#'   * in a named list, this would look like:\cr
-#'   `arg_list$format <- VALUE`
+#'   * `-f VALUE` for one-letter short names
+#'   * `--format VALUE` or `--format=VALUE` for long names
+#'   * in a named list, this might look like: `args$format <- VALUE`
 #' * Some arguments can be multi-valued. Some of them require all values to be
-#' packed together and separated with comma. This is, e.g., the case of:
-#' `--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax`, e.g.,
-#' `--bbox=2.1,49.1,2.9,49.9`.
+#' packed together and separated with comma. This is, e.g., the case of:\cr
+#' `--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax`\cr
+#' e.g., `--bbox=2.1,49.1,2.9,49.9`.
 #' * Others accept each value to be preceded by a new mention of the argument
 #' name, e.g., `--co COMPRESS=LZW --co TILED=YES`. For that one, if the value
 #' of the argument does not contain commas, the packed form is also accepted:
@@ -108,30 +116,34 @@
 #' character vector or numeric vector of values).
 #' * Named arguments can be placed before or after positional arguments.
 #'
-#' @section Development status:
+#' @section Development Status:
 #' The GDAL Command Line Interface Modernization was first introduced in the
 #' [GDAL 3.11.0 release](https://github.com/OSGeo/gdal/releases/tag/v3.11.0)
-#' (2025-05-09). The GDAL project states that the new CLI \dQuote{is
+#' (2025-05-09). The GDAL project provides warning that the new CLI \dQuote{is
 #' provisionally provided as an alternative interface to GDAL and OGR command
 #' line utilities. The project reserves the right to modify, rename,
 #' reorganize, and change the behavior until it is officially frozen via PSC
-#' vote in a future major GDAL release.... Your usage of it should have no
+#' vote in a future major GDAL release. The utility needs time to mature,
+#' benefit from incremental feedback, and explore enhancements without carrying
+#' the burden of full backward compatibility. Your usage of it should have no
 #' expectation of compatibility until that time.}
 #' (\url{https://gdal.org/en/latest/programs/#gdal-application})
 #'
-#' Initial bindings to enable programmatic use of the new CLI algorithms from \R
+#' Initial bindings to enable programmatic use of the CLI algorithms from \R
 #' were added in \pkg{gdalraster} 2.2.0, and will evolve over future releases.
-#' The bindings are considered experimental until the upstream API is declared
-#' stable. Breaking changes in minor version releases are possible until then.
+#' *The bindings are considered experimental until the upstream API is declared
+#' stable*. Breaking changes in minor version releases are possible until then.
+#' Please use with those cautions in mind. Bug reports may be filed at:
+#' \url{https://github.com/USDAForestService/gdalraster/issues}.
 #'
 #' @note
 #' Commands do not require the leading `"gdal"` root node. They may begin
 #' with a top-level command (e.g., `"raster"`, `"vector"`, etc.).
 #'
 #' When using argument names as the element names of a list, the underscore
-#' character can be optionally substituted for the dash characters that are
-#' used in some names. This avoids having to surround names in backticks when
-#' they are used to access list elements in the form `args$arg_name` (the form
+#' character can be substituted for the dash characters that are used in some
+#' names. This avoids having to surround names in backticks when they are used
+#' to access list elements in the form `args$arg_name` (the form
 #' `args[["arg-name"]]` also works).
 #'
 #' @seealso
@@ -143,7 +155,7 @@
 #' Using \dQuote{gdal} CLI algorithms from R:\cr
 #' \url{https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html}
 #'
-#' @examplesIf gdal_version_num() >= gdal_compute_version(3, 11, 3)
+#' @examplesIf length(gdal_global_reg_names()) > 0
 #' ## top-level commands
 #' gdal_commands(recurse = FALSE)
 #'
@@ -255,7 +267,7 @@
 #' ds$close()
 #' unlink(f_out)
 #' @export
-gdal_commands <- function(contains = "", recurse = TRUE, cout = TRUE) {
+gdal_commands <- function(contains = NULL, recurse = TRUE, cout = TRUE) {
     if (gdal_version_num() < .GDALALG_MIN_GDAL) {
         stop("gdal_commands() requires GDAL >= ", .GDALALG_MIN_GDAL_STR,
              call. = FALSE)
@@ -369,6 +381,12 @@ gdal_alg <- function(cmd = NULL, args = NULL, parse = TRUE) {
     }
 
     return(alg)
+}
+
+#' @name gdal_cli
+#' @export
+gdal_global_reg_names <- function() {
+    return(.gdal_global_reg_names())
 }
 
 #' helper function to print usage to the console

--- a/R/gdal_cli.R
+++ b/R/gdal_cli.R
@@ -84,7 +84,7 @@
 #' objects (i.e., `GDALRaster` or `GDALVector`), in addition to dataset names
 #' (e.g., filename, URL, database connection string).
 #' * Commands accept one or several positional arguments, typically for dataset
-#' names (or, in \R, as `GDALRaster` or `GDALVector` datasets). The order is
+#' names (or in \R as `GDALRaster` or `GDALVector` datasets). The order is
 #' input(s) first, output last. Positional arguments can also be specified as
 #' named arguments, if preferred to avoid any ambiguity.
 #' * Named arguments have:

--- a/R/gdalalg.R
+++ b/R/gdalalg.R
@@ -1,10 +1,7 @@
-#' @noRd
-#' @export
 .GDALALG_MIN_GDAL <- gdal_compute_version(3, 11, 3)
-
-#' @noRd
-#' @export
 .GDALALG_MIN_GDAL_STR <- "3.11.3"
+# NOTE: also update the min GDAL version in @examplesIf in this file and in
+#       R/gdal_cli.R, and in the details section of man/gdalraster-package.Rd
 
 #' @name GDALAlg-class
 #'
@@ -22,7 +19,7 @@
 #'
 #' **Requires GDAL >= `r .GDALALG_MIN_GDAL_STR`**.
 #'
-#' **Experimental** (see "Development status")
+#' **Experimental** (see \dQuote{Development status})
 #'
 #' `GDALAlg` is a C++ class exposed directly to \R (via `RCPP_EXPOSED_CLASS`).
 #' Fields and methods of the class are accessed using the `$` operator. Note
@@ -243,7 +240,7 @@
 #'
 #' [Using \dQuote{gdal} CLI algorithms from R](https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html)
 #'
-#' @examplesIf gdal_version_num() >= gdalraster:::.GDALALG_MIN_GDAL
+#' @examplesIf gdal_version_num() >= gdal_compute_version(3, 11, 3)
 #' f <- system.file("extdata/storml_elev.tif", package="gdalraster")
 #'
 #' ## raster info

--- a/R/gdalalg.R
+++ b/R/gdalalg.R
@@ -1,8 +1,3 @@
-.GDALALG_MIN_GDAL <- gdal_compute_version(3, 11, 3)
-.GDALALG_MIN_GDAL_STR <- "3.11.3"
-# NOTE: also update the minimum GDAL version in the details section of
-#       man/gdalraster-package.Rd
-
 #' @name GDALAlg-class
 #'
 #' @aliases
@@ -12,12 +7,12 @@
 #'
 #' @description
 #' `GDALAlg` provides bindings to `GDALAlgorithm` and related classes
-#' that implement the \dQuote{gdal} command line interface (CLI) in the GDAL
+#' that implement the `gdal` command line interface (CLI) in the GDAL
 #' API. An object of class `GDALAlg` represents an instance of a CLI algorithm
 #' with methods to obtain algorithm information and argument information, run
 #' the algorithm, and access its output.
 #'
-#' **Requires GDAL >= `r .GDALALG_MIN_GDAL_STR`**.
+#' **Requires GDAL >= 3.11.3**.
 #'
 #' **Experimental** (see the section `Development Status` below)
 #'
@@ -32,15 +27,14 @@
 #' arguments of the algorithm (see section `Algorithm Argument Syntax` below).
 #' @returns An object of class `GDALAlg`, which contains a pointer to the
 #' algorithm instance. Class methods are described in Details, along with a set
-#' of writable fields for per-object settings. Values may be set on the class
-#' fields by regular assignment with \code{<-} or \code{=}.
+#' of writable fields for per-object settings.
 #'
 #' @inheritSection gdal_cli Algorithm Argument Syntax
 #'
 #' @inheritSection gdal_cli Development Status
 #'
 #' @section Usage (see Details):
-#' \preformatted{
+#' ```
 #' ## Constructors
 #' alg <- new(GDALAlg, cmd)
 #' # or, with arguments
@@ -64,7 +58,7 @@
 #'
 #' alg$close()
 #' alg$release()
-#' }
+#' ```
 #' @section Details:
 #' ## Constructors
 #'
@@ -232,14 +226,6 @@
 #' Release memory associated with the algorithm, potentially after attempting
 #' to finalize. No return value, called for side-effects.
 #'
-#' @seealso
-#' [gdal_alg()], [gdal_commands()], [gdal_run()], [gdal_usage()]
-#'
-#' GDAL RFC 104: Adding a \dQuote{gdal} front-end command line interface:\cr
-#' [Implementation details](https://gdal.org/en/stable/development/rfc/rfc104_gdal_cli.html#implementation-details)
-#'
-#' [Using \dQuote{gdal} CLI algorithms from R](https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html)
-#'
 #' @examplesIf length(gdal_global_reg_names()) > 0
 #' f <- system.file("extdata/storml_elev.tif", package="gdalraster")
 #'
@@ -342,7 +328,6 @@
 #' alg$argInfo("resampling")
 #'
 #' alg$release()
-
 NULL
 
 Rcpp::loadModule("mod_GDALAlg", TRUE)

--- a/R/gdalalg.R
+++ b/R/gdalalg.R
@@ -1,7 +1,7 @@
 .GDALALG_MIN_GDAL <- gdal_compute_version(3, 11, 3)
 .GDALALG_MIN_GDAL_STR <- "3.11.3"
-# NOTE: also update the min GDAL version in @examplesIf in this file and in
-#       R/gdal_cli.R, and in the details section of man/gdalraster-package.Rd
+# NOTE: also update the minimum GDAL version in the details section of
+#       man/gdalraster-package.Rd
 
 #' @name GDALAlg-class
 #'
@@ -12,32 +12,32 @@
 #'
 #' @description
 #' `GDALAlg` provides bindings to `GDALAlgorithm` and related classes
-#' that implement the "gdal" command line interface (CLI) in the GDAL API.
-#' An object of class `GDALAlg` represents an instance of a CLI algorithm with
-#' methods to obtain algorithm information and argument information, run the
-#' algorithm, and access its output.
+#' that implement the \dQuote{gdal} command line interface (CLI) in the GDAL
+#' API. An object of class `GDALAlg` represents an instance of a CLI algorithm
+#' with methods to obtain algorithm information and argument information, run
+#' the algorithm, and access its output.
 #'
 #' **Requires GDAL >= `r .GDALALG_MIN_GDAL_STR`**.
 #'
-#' **Experimental** (see \dQuote{Development status})
+#' **Experimental** (see the section `Development Status` below)
 #'
 #' `GDALAlg` is a C++ class exposed directly to \R (via `RCPP_EXPOSED_CLASS`).
-#' Fields and methods of the class are accessed using the `$` operator. Note
-#' that all arguments to class methods are required and must be given in the
-#' order documented (naming optional).
+#' Fields and methods of the class are accessed using the `$` operator.
+#' Arguments to class constructors and class methods must be given in the order
+#' documented (naming optional).
 #'
 #' @param cmd A character string or character vector containing the path to the
 #' algorithm, e.g., `"raster reproject"` or `c("raster", "reproject")`.
 #' @param args Either a character vector or a named list containing input
-#' arguments of the algorithm (see section \dQuote{Algorithm argument syntax}).
+#' arguments of the algorithm (see section `Algorithm Argument Syntax` below).
 #' @returns An object of class `GDALAlg`, which contains a pointer to the
 #' algorithm instance. Class methods are described in Details, along with a set
-#' of writable fields for per-object settings. Values may be assigned to the
-#' class fields by regular \code{<-} or \code{=} assignment.
+#' of writable fields for per-object settings. Values may be set on the class
+#' fields by regular assignment with \code{<-} or \code{=}.
 #'
-#' @inheritSection gdal_cli Algorithm argument syntax
+#' @inheritSection gdal_cli Algorithm Argument Syntax
 #'
-#' @inheritSection gdal_cli Development status
+#' @inheritSection gdal_cli Development Status
 #'
 #' @section Usage (see Details):
 #' \preformatted{
@@ -73,7 +73,7 @@
 #'
 #' \code{new(GDALAlg, cmd, args)}\cr
 #' Instantiate an algorithm giving input arguments as a character vector or
-#' named list. See section \dQuote{Algorithm argument syntax} for details.
+#' named list. See the section `Algorithm Argument Syntax` for details.
 #'
 #' ## Read/write fields (per-object settings)
 #'
@@ -240,7 +240,7 @@
 #'
 #' [Using \dQuote{gdal} CLI algorithms from R](https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html)
 #'
-#' @examplesIf gdal_version_num() >= gdal_compute_version(3, 11, 3)
+#' @examplesIf length(gdal_global_reg_names()) > 0
 #' f <- system.file("extdata/storml_elev.tif", package="gdalraster")
 #'
 #' ## raster info

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -583,7 +583,7 @@
 #'
 #' \code{force}:
 #'   * `TRUE`: The raster will be scanned to compute statistics. Once computed,
-#'   statistics will generally be “set” back on the raster band if the format
+#'   statistics will generally be "set" back on the raster band if the format
 #'   supports caching statistics.
 #'   (Note: `ComputeStatistics()` in the GDAL API is called automatically here.
 #'   This is a change in the behavior of `GetStatistics()` in the API, to a

--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -38,7 +38,7 @@
 #' (i.e., by regular \code{<-} or \code{=} assignment).
 #'
 #' @section Usage (see Details):
-#' \preformatted{
+#' ```
 #' ## Constructors
 #' # read-only by default:
 #' ds <- new(GDALRaster, filename)
@@ -137,7 +137,7 @@
 #' ds$getChecksum(band, xoff, yoff, xsize, ysize)
 #'
 #' ds$close()
-#' }
+#' ```
 #' @section Details:
 #' ## Constructors
 #'
@@ -336,7 +336,7 @@
 #' Helper method returning a numeric matrix with named columns: `xblockoff`,
 #' `yblockoff`, `xoff`, `yoff`, `xsize`, `ysize`, `xmin`, `xmax`, `ymin`,
 #' `ymax`. For the meanings of these names, refer to the following class
-#' methods below: \code{$getBlockSize()}, \code{$getActualBlockSize} and
+#' methods below: \code{$getBlockSize()}, \code{$getActualBlockSize()} and
 #' \code{$read()}.
 #' All offsets are zero-based. The columns `xmin`, `xmax`, `ymin` and
 #' `ymax` give the extent of each block in geospatial coordinates.

--- a/R/gdalvector.R
+++ b/R/gdalvector.R
@@ -53,7 +53,7 @@
 #' \code{=} assignment).
 #'
 #' @section Usage (see Details):
-#' \preformatted{
+#' ```
 #' ## Constructors
 #' # for single-layer file formats such as shapefile
 #' lyr <- new(GDALVector, dsn)
@@ -134,7 +134,7 @@
 #' lyr$getMetadataItem(mdi_name)
 #'
 #' lyr$close()
-#' }
+#' ```
 #' @section Details:
 #' ## Constructors
 #'

--- a/R/running_stats.R
+++ b/R/running_stats.R
@@ -39,7 +39,7 @@
 #' computes statistics for a whole raster band.
 #'
 #' @section Usage (see Details):
-#' \preformatted{
+#' ```
 #' ## Constructor
 #' rs <- new(RunningStats, na_rm)
 #'
@@ -53,7 +53,7 @@
 #' rs$get_var()
 #' rs$get_sd()
 #' rs$reset()
-#' }
+#' ```
 #'
 #' @section Details:
 #' ## Constructor

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -52,7 +52,7 @@ SEEK_END <- "SEEK_END"
 #' Details.
 #'
 #' @section Usage (see Details):
-#' \preformatted{
+#' ```
 #' ## Constructors
 #' vf <- new(VSIFile, filename)
 #' # specifying access:
@@ -76,7 +76,7 @@ SEEK_END <- "SEEK_END"
 #' vf$get_filename()
 #' vf$get_access()
 #' vf$set_access(access)
-#' }
+#' ```
 #' @section Details:
 #' ## Constructors
 #'

--- a/man/CmbTable-class.Rd
+++ b/man/CmbTable-class.Rd
@@ -31,8 +31,8 @@ for readability.
 }
 \section{Usage (see Details)}{
 
-\preformatted{
-## Constructors
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## Constructors
 cmb <- new(CmbTable, keyLen)
 # or, giving the variable names:
 cmb <- new(CmbTable, keyLen, varNames)
@@ -43,7 +43,7 @@ cmb$updateFromMatrix(int_cmbs, incr)
 cmb$updateFromMatrixByRow(int_cmbs, incr)
 cmb$asDataFrame()
 cmb$asMatrix()
-}
+}\if{html}{\out{</div>}}
 }
 
 \section{Details}{

--- a/man/GDALAlg-class.Rd
+++ b/man/GDALAlg-class.Rd
@@ -11,29 +11,29 @@
 algorithm, e.g., \code{"raster reproject"} or \code{c("raster", "reproject")}.}
 
 \item{args}{Either a character vector or a named list containing input
-arguments of the algorithm (see section \dQuote{Algorithm argument syntax}).}
+arguments of the algorithm (see section \verb{Algorithm Argument Syntax} below).}
 }
 \value{
 An object of class \code{GDALAlg}, which contains a pointer to the
 algorithm instance. Class methods are described in Details, along with a set
-of writable fields for per-object settings. Values may be assigned to the
-class fields by regular \code{<-} or \code{=} assignment.
+of writable fields for per-object settings. Values may be set on the class
+fields by regular assignment with \code{<-} or \code{=}.
 }
 \description{
 \code{GDALAlg} provides bindings to \code{GDALAlgorithm} and related classes
-that implement the "gdal" command line interface (CLI) in the GDAL API.
-An object of class \code{GDALAlg} represents an instance of a CLI algorithm with
-methods to obtain algorithm information and argument information, run the
-algorithm, and access its output.
+that implement the \dQuote{gdal} command line interface (CLI) in the GDAL
+API. An object of class \code{GDALAlg} represents an instance of a CLI algorithm
+with methods to obtain algorithm information and argument information, run
+the algorithm, and access its output.
 
 \strong{Requires GDAL >= 3.11.3}.
 
-\strong{Experimental} (see \dQuote{Development status})
+\strong{Experimental} (see the section \verb{Development Status} below)
 
 \code{GDALAlg} is a C++ class exposed directly to \R (via \code{RCPP_EXPOSED_CLASS}).
-Fields and methods of the class are accessed using the \code{$} operator. Note
-that all arguments to class methods are required and must be given in the
-order documented (naming optional).
+Fields and methods of the class are accessed using the \code{$} operator.
+Arguments to class constructors and class methods must be given in the order
+documented (naming optional).
 }
 \section{Usage (see Details)}{
 
@@ -73,7 +73,7 @@ Instantiate an algorithm without specifying input arguments.
 
 \code{new(GDALAlg, cmd, args)}\cr
 Instantiate an algorithm giving input arguments as a character vector or
-named list. See section \dQuote{Algorithm argument syntax} for details.
+named list. See the section \verb{Algorithm Argument Syntax} for details.
 }
 
 \subsection{Read/write fields (per-object settings)}{
@@ -242,7 +242,7 @@ to finalize. No return value, called for side-effects.
 }
 }
 
-\section{Algorithm argument syntax}{
+\section{Algorithm Argument Syntax}{
 
 Arguments are given in \R as a character vector or named list, but
 otherwise syntax basically matches the GDAL specification for arguments as
@@ -258,25 +258,25 @@ input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:
 \itemize{
-\item at least one long name, preceded by two dash characters when specified
-on the command line,
+\item at least one \dQuote{long} name, preceded by two dash characters when
+specified on the command line,
 \item optionally, auxiliary long names (i.e., aliases),
 \item and optionally a one-letter short name, preceded by a single dash
 character on the command line, e.g., \verb{-f, --of, --format, --output-format <OUTPUT-FORMAT>}
 }
 \item Boolean arguments are specified by just specifying the argument name. In
-\R list format, the named element must be assigned a value of logical \code{TRUE}.
+\R \code{list} format, the named element must be assigned a value of logical
+\code{TRUE}.
 \item Arguments that require a value are specified like:
 \itemize{
-\item \verb{-f VALUE} for one-letter short names.
-\item \verb{--format VALUE} or \code{--format=VALUE} for long names.
-\item in a named list, this would look like:\cr
-\code{arg_list$format <- VALUE}
+\item \verb{-f VALUE} for one-letter short names
+\item \verb{--format VALUE} or \code{--format=VALUE} for long names
+\item in a named list, this might look like: \code{args$format <- VALUE}
 }
 \item Some arguments can be multi-valued. Some of them require all values to be
-packed together and separated with comma. This is, e.g., the case of:
-\verb{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax}, e.g.,
-\verb{--bbox=2.1,49.1,2.9,49.9}.
+packed together and separated with comma. This is, e.g., the case of:\cr
+\verb{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax}\cr
+e.g., \verb{--bbox=2.1,49.1,2.9,49.9}.
 \item Others accept each value to be preceded by a new mention of the argument
 name, e.g., \verb{--co COMPRESS=LZW --co TILED=YES}. For that one, if the value
 of the argument does not contain commas, the packed form is also accepted:
@@ -289,26 +289,30 @@ character vector or numeric vector of values).
 }
 }
 
-\section{Development status}{
+\section{Development Status}{
 
 The GDAL Command Line Interface Modernization was first introduced in the
 \href{https://github.com/OSGeo/gdal/releases/tag/v3.11.0}{GDAL 3.11.0 release}
-(2025-05-09). The GDAL project states that the new CLI \dQuote{is
+(2025-05-09). The GDAL project provides warning that the new CLI \dQuote{is
 provisionally provided as an alternative interface to GDAL and OGR command
 line utilities. The project reserves the right to modify, rename,
 reorganize, and change the behavior until it is officially frozen via PSC
-vote in a future major GDAL release.... Your usage of it should have no
+vote in a future major GDAL release. The utility needs time to mature,
+benefit from incremental feedback, and explore enhancements without carrying
+the burden of full backward compatibility. Your usage of it should have no
 expectation of compatibility until that time.}
 (\url{https://gdal.org/en/latest/programs/#gdal-application})
 
-Initial bindings to enable programmatic use of the new CLI algorithms from \R
+Initial bindings to enable programmatic use of the CLI algorithms from \R
 were added in \pkg{gdalraster} 2.2.0, and will evolve over future releases.
-The bindings are considered experimental until the upstream API is declared
-stable. Breaking changes in minor version releases are possible until then.
+\emph{The bindings are considered experimental until the upstream API is declared
+stable}. Breaking changes in minor version releases are possible until then.
+Please use with those cautions in mind. Bug reports may be filed at:
+\url{https://github.com/USDAForestService/gdalraster/issues}.
 }
 
 \examples{
-\dontshow{if (gdal_version_num() >= gdal_compute_version(3, 11, 3)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (length(gdal_global_reg_names()) > 0) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 f <- system.file("extdata/storml_elev.tif", package="gdalraster")
 
 ## raster info

--- a/man/GDALAlg-class.Rd
+++ b/man/GDALAlg-class.Rd
@@ -16,12 +16,11 @@ arguments of the algorithm (see section \verb{Algorithm Argument Syntax} below).
 \value{
 An object of class \code{GDALAlg}, which contains a pointer to the
 algorithm instance. Class methods are described in Details, along with a set
-of writable fields for per-object settings. Values may be set on the class
-fields by regular assignment with \code{<-} or \code{=}.
+of writable fields for per-object settings.
 }
 \description{
 \code{GDALAlg} provides bindings to \code{GDALAlgorithm} and related classes
-that implement the \dQuote{gdal} command line interface (CLI) in the GDAL
+that implement the \code{gdal} command line interface (CLI) in the GDAL
 API. An object of class \code{GDALAlg} represents an instance of a CLI algorithm
 with methods to obtain algorithm information and argument information, run
 the algorithm, and access its output.
@@ -37,8 +36,8 @@ documented (naming optional).
 }
 \section{Usage (see Details)}{
 
-\preformatted{
-## Constructors
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## Constructors
 alg <- new(GDALAlg, cmd)
 # or, with arguments
 alg <- new(GDALAlg, cmd, args)
@@ -61,7 +60,7 @@ alg$outputs()
 
 alg$close()
 alg$release()
-}
+}\if{html}{\out{</div>}}
 }
 
 \section{Details}{
@@ -258,33 +257,32 @@ input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:
 \itemize{
-\item at least one \dQuote{long} name, preceded by two dash characters when
-specified on the command line,
+\item at least one "long" name, preceded by two dash characters
 \item optionally, auxiliary long names (i.e., aliases),
 \item and optionally a one-letter short name, preceded by a single dash
-character on the command line, e.g., \verb{-f, --of, --format, --output-format <OUTPUT-FORMAT>}
+character, e.g., \code{-f, --of, --format, --output-format <OUTPUT-FORMAT>}
 }
-\item Boolean arguments are specified by just specifying the argument name. In
-\R \code{list} format, the named element must be assigned a value of logical
-\code{TRUE}.
+\item Boolean arguments are specified by just specifying the argument name in
+character vector format. In \R \code{list} format, the named element must be
+assigned a value of logical \code{TRUE}.
 \item Arguments that require a value are specified like:
 \itemize{
-\item \verb{-f VALUE} for one-letter short names
-\item \verb{--format VALUE} or \code{--format=VALUE} for long names
+\item \code{-f VALUE} for one-letter short names
+\item \code{--format VALUE} or \code{--format=VALUE} for long names
 \item in a named list, this might look like: \code{args$format <- VALUE}
 }
 \item Some arguments can be multi-valued. Some of them require all values to be
 packed together and separated with comma. This is, e.g., the case of:\cr
-\verb{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax}\cr
-e.g., \verb{--bbox=2.1,49.1,2.9,49.9}.
+\code{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax} \cr
+e.g., \code{--bbox=2.1,49.1,2.9,49.9}
 \item Others accept each value to be preceded by a new mention of the argument
-name, e.g., \verb{--co COMPRESS=LZW --co TILED=YES}. For that one, if the value
-of the argument does not contain commas, the packed form is also accepted:
-\verb{--co COMPRESS=LZW,TILED=YES}. Note that repeated mentions of an argument
-are possible in the character vector format for argument input, whereas
-arguments given in named list format must used argument long names as the
-list element names, and the packed format for the values (which can be a
-character vector or numeric vector of values).
+name, e.g., \code{c("--co", "COMPRESS=LZW", "--co", "TILED=YES")}. For that
+one, if the value of the argument does not contain commas, the packed form
+is also accepted: \code{--co COMPRESS=LZW,TILED=YES}. Note that repeated
+mentions of an argument are possible in the character vector format for
+argument input, whereas arguments given in named list format must use
+argument long names as the list element names, and the packed format for the
+values (which can be a character vector or numeric vector of values).
 \item Named arguments can be placed before or after positional arguments.
 }
 }
@@ -293,14 +291,14 @@ character vector or numeric vector of values).
 
 The GDAL Command Line Interface Modernization was first introduced in the
 \href{https://github.com/OSGeo/gdal/releases/tag/v3.11.0}{GDAL 3.11.0 release}
-(2025-05-09). The GDAL project provides warning that the new CLI \dQuote{is
+(2025-05-09). The GDAL project provides warning that the new CLI "is
 provisionally provided as an alternative interface to GDAL and OGR command
 line utilities. The project reserves the right to modify, rename,
 reorganize, and change the behavior until it is officially frozen via PSC
 vote in a future major GDAL release. The utility needs time to mature,
 benefit from incremental feedback, and explore enhancements without carrying
 the burden of full backward compatibility. Your usage of it should have no
-expectation of compatibility until that time.}
+expectation of compatibility until that time."
 (\url{https://gdal.org/en/latest/programs/#gdal-application})
 
 Initial bindings to enable programmatic use of the CLI algorithms from \R
@@ -415,12 +413,4 @@ alg$argInfo("resampling")
 
 alg$release()
 \dontshow{\}) # examplesIf}
-}
-\seealso{
-\code{\link[=gdal_alg]{gdal_alg()}}, \code{\link[=gdal_commands]{gdal_commands()}}, \code{\link[=gdal_run]{gdal_run()}}, \code{\link[=gdal_usage]{gdal_usage()}}
-
-GDAL RFC 104: Adding a \dQuote{gdal} front-end command line interface:\cr
-\href{https://gdal.org/en/stable/development/rfc/rfc104_gdal_cli.html#implementation-details}{Implementation details}
-
-\href{https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html}{Using \dQuote{gdal} CLI algorithms from R}
 }

--- a/man/GDALAlg-class.Rd
+++ b/man/GDALAlg-class.Rd
@@ -28,7 +28,7 @@ algorithm, and access its output.
 
 \strong{Requires GDAL >= 3.11.3}.
 
-\strong{Experimental} (see "Development status")
+\strong{Experimental} (see \dQuote{Development status})
 
 \code{GDALAlg} is a C++ class exposed directly to \R (via \code{RCPP_EXPOSED_CLASS}).
 Fields and methods of the class are accessed using the \code{$} operator. Note
@@ -258,7 +258,7 @@ input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:
 \itemize{
-\item at least one "long" name, preceded by two dash characters when specified
+\item at least one long name, preceded by two dash characters when specified
 on the command line,
 \item optionally, auxiliary long names (i.e., aliases),
 \item and optionally a one-letter short name, preceded by a single dash
@@ -308,7 +308,7 @@ stable. Breaking changes in minor version releases are possible until then.
 }
 
 \examples{
-\dontshow{if (gdal_version_num() >= gdalraster:::.GDALALG_MIN_GDAL) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (gdal_version_num() >= gdal_compute_version(3, 11, 3)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 f <- system.file("extdata/storml_elev.tif", package="gdalraster")
 
 ## raster info

--- a/man/GDALAlg-class.Rd
+++ b/man/GDALAlg-class.Rd
@@ -252,7 +252,7 @@ objects (i.e., \code{GDALRaster} or \code{GDALVector}), in addition to dataset n
 (e.g., filename, URL, database connection string).
 \itemize{
 \item Commands accept one or several positional arguments, typically for dataset
-names (or, in \R, as \code{GDALRaster} or \code{GDALVector} datasets). The order is
+names (or in \R as \code{GDALRaster} or \code{GDALVector} datasets). The order is
 input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -68,8 +68,8 @@ override the default resampling to one of \code{BILINEAR}, \code{CUBIC},
 }
 \section{Usage (see Details)}{
 
-\preformatted{
-## Constructors
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## Constructors
 # read-only by default:
 ds <- new(GDALRaster, filename)
 # for update access:
@@ -167,7 +167,7 @@ ds$flushCache()
 ds$getChecksum(band, xoff, yoff, xsize, ysize)
 
 ds$close()
-}
+}\if{html}{\out{</div>}}
 }
 
 \section{Details}{
@@ -371,7 +371,7 @@ info and examples.
 Helper method returning a numeric matrix with named columns: \code{xblockoff},
 \code{yblockoff}, \code{xoff}, \code{yoff}, \code{xsize}, \code{ysize}, \code{xmin}, \code{xmax}, \code{ymin},
 \code{ymax}. For the meanings of these names, refer to the following class
-methods below: \code{$getBlockSize()}, \code{$getActualBlockSize} and
+methods below: \code{$getBlockSize()}, \code{$getActualBlockSize()} and
 \code{$read()}.
 All offsets are zero-based. The columns \code{xmin}, \code{xmax}, \code{ymin} and
 \code{ymax} give the extent of each block in geospatial coordinates.

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -622,7 +622,7 @@ computation is forced).
 \code{force}:
 \itemize{
 \item \code{TRUE}: The raster will be scanned to compute statistics. Once computed,
-statistics will generally be “set” back on the raster band if the format
+statistics will generally be "set" back on the raster band if the format
 supports caching statistics.
 (Note: \code{ComputeStatistics()} in the GDAL API is called automatically here.
 This is a change in the behavior of \code{GetStatistics()} in the API, to a

--- a/man/GDALVector-class.Rd
+++ b/man/GDALVector-class.Rd
@@ -65,8 +65,8 @@ Naming the arguments is optional but may be preferred for readability.
 }
 \section{Usage (see Details)}{
 
-\preformatted{
-## Constructors
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## Constructors
 # for single-layer file formats such as shapefile
 lyr <- new(GDALVector, dsn)
 # specifying the layer name, or SQL statement defining the layer
@@ -146,7 +146,7 @@ lyr$setMetadata(metadata)
 lyr$getMetadataItem(mdi_name)
 
 lyr$close()
-}
+}\if{html}{\out{</div>}}
 }
 
 \section{Details}{

--- a/man/RunningStats-class.Rd
+++ b/man/RunningStats-class.Rd
@@ -44,8 +44,8 @@ computes statistics for a whole raster band.
 }
 \section{Usage (see Details)}{
 
-\preformatted{
-## Constructor
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## Constructor
 rs <- new(RunningStats, na_rm)
 
 ## Methods
@@ -58,7 +58,7 @@ rs$get_sum()
 rs$get_var()
 rs$get_sd()
 rs$reset()
-}
+}\if{html}{\out{</div>}}
 }
 
 \section{Details}{

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -66,8 +66,8 @@ allow sequential write only.
 }
 \section{Usage (see Details)}{
 
-\preformatted{
-## Constructors
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## Constructors
 vf <- new(VSIFile, filename)
 # specifying access:
 vf <- new(VSIFile, filename, access)
@@ -90,7 +90,7 @@ vf$open()
 vf$get_filename()
 vf$get_access()
 vf$set_access(access)
-}
+}\if{html}{\out{</div>}}
 }
 
 \section{Details}{

--- a/man/gdal_cli.Rd
+++ b/man/gdal_cli.Rd
@@ -24,8 +24,8 @@ gdal_global_reg_names()
 commands, e.g., \code{gdal_commands("vector")}.}
 
 \item{recurse}{Logical value, \code{TRUE} to include all subcommands recursively
-(the default). Set to \code{FALSE} to include only the top-level \dQuote{gdal}
-commands (i.e., \dQuote{raster}, \dQuote{vector}, etc.)}
+(the default). Set to \code{FALSE} to include only the top-level \code{gdal} commands
+(i.e., \code{raster}, \code{vector}, etc.)}
 
 \item{cout}{Logical value, \code{TRUE} to print a list of commands along with
 their descriptions and help URLS to the console (the default).}
@@ -44,8 +44,8 @@ method on the returned object can be called to parse arguments and obtain
 the result of that, with potentially useful error messages.}
 }
 \description{
-This set of functions can be used to access and run GDAL utilities as
-\dQuote{gdal} command line interface (CLI) algorithms.
+This set of functions can be used to access and run GDAL utilities as \code{gdal}
+command line interface (CLI) algorithms.
 
 \strong{Requires GDAL >= 3.11.3}
 
@@ -57,14 +57,14 @@ by way of the C++ exposed class \code{\link{GDALAlg}}. See the class
 documentation for additional information (\code{?GDALAlg}).
 
 \code{gdal_commands()} prints a list of commands and their descriptions to the
-console, and returns (invisibly) a data frame with columns named \code{command},
-\code{description} and \code{URL}. The \code{contains} argument can be used to filter the
+console, and returns (invisibly) a data frame with columns \code{command},
+\code{description}, \code{URL}. The \code{contains} argument can be used to filter the
 output, e.g., \code{gdal_commands("vector")} to return only commands for working
 with vector inputs.
 
 \code{gdal_usage()} prints a help message to the console for a given command, or
-for the root \dQuote{gdal} entry point if called with no argument. No return
-value, called for that side effect only.
+for the root \code{gdal} entry point if called with no argument. No return value,
+called for that side effect only.
 
 \code{gdal_run()} executes a GDAL CLI algorithm and returns it as an object of
 class \code{\link{GDALAlg}}. A list containing algorithm output(s) can be
@@ -120,33 +120,32 @@ input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:
 \itemize{
-\item at least one \dQuote{long} name, preceded by two dash characters when
-specified on the command line,
+\item at least one "long" name, preceded by two dash characters
 \item optionally, auxiliary long names (i.e., aliases),
 \item and optionally a one-letter short name, preceded by a single dash
-character on the command line, e.g., \verb{-f, --of, --format, --output-format <OUTPUT-FORMAT>}
+character, e.g., \code{-f, --of, --format, --output-format <OUTPUT-FORMAT>}
 }
-\item Boolean arguments are specified by just specifying the argument name. In
-\R \code{list} format, the named element must be assigned a value of logical
-\code{TRUE}.
+\item Boolean arguments are specified by just specifying the argument name in
+character vector format. In \R \code{list} format, the named element must be
+assigned a value of logical \code{TRUE}.
 \item Arguments that require a value are specified like:
 \itemize{
-\item \verb{-f VALUE} for one-letter short names
-\item \verb{--format VALUE} or \code{--format=VALUE} for long names
+\item \code{-f VALUE} for one-letter short names
+\item \code{--format VALUE} or \code{--format=VALUE} for long names
 \item in a named list, this might look like: \code{args$format <- VALUE}
 }
 \item Some arguments can be multi-valued. Some of them require all values to be
 packed together and separated with comma. This is, e.g., the case of:\cr
-\verb{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax}\cr
-e.g., \verb{--bbox=2.1,49.1,2.9,49.9}.
+\code{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax} \cr
+e.g., \code{--bbox=2.1,49.1,2.9,49.9}
 \item Others accept each value to be preceded by a new mention of the argument
-name, e.g., \verb{--co COMPRESS=LZW --co TILED=YES}. For that one, if the value
-of the argument does not contain commas, the packed form is also accepted:
-\verb{--co COMPRESS=LZW,TILED=YES}. Note that repeated mentions of an argument
-are possible in the character vector format for argument input, whereas
-arguments given in named list format must used argument long names as the
-list element names, and the packed format for the values (which can be a
-character vector or numeric vector of values).
+name, e.g., \code{c("--co", "COMPRESS=LZW", "--co", "TILED=YES")}. For that
+one, if the value of the argument does not contain commas, the packed form
+is also accepted: \code{--co COMPRESS=LZW,TILED=YES}. Note that repeated
+mentions of an argument are possible in the character vector format for
+argument input, whereas arguments given in named list format must use
+argument long names as the list element names, and the packed format for the
+values (which can be a character vector or numeric vector of values).
 \item Named arguments can be placed before or after positional arguments.
 }
 }
@@ -155,14 +154,14 @@ character vector or numeric vector of values).
 
 The GDAL Command Line Interface Modernization was first introduced in the
 \href{https://github.com/OSGeo/gdal/releases/tag/v3.11.0}{GDAL 3.11.0 release}
-(2025-05-09). The GDAL project provides warning that the new CLI \dQuote{is
+(2025-05-09). The GDAL project provides warning that the new CLI "is
 provisionally provided as an alternative interface to GDAL and OGR command
 line utilities. The project reserves the right to modify, rename,
 reorganize, and change the behavior until it is officially frozen via PSC
 vote in a future major GDAL release. The utility needs time to mature,
 benefit from incremental feedback, and explore enhancements without carrying
 the burden of full backward compatibility. Your usage of it should have no
-expectation of compatibility until that time.}
+expectation of compatibility until that time."
 (\url{https://gdal.org/en/latest/programs/#gdal-application})
 
 Initial bindings to enable programmatic use of the CLI algorithms from \R
@@ -256,7 +255,7 @@ plot_raster(ds, legend = TRUE, col_map_fn = ramp, na_col = "#d9d9d9",
 ds$close()
 deleteDataset(f_out)
 
-## "pipeline" syntax
+## pipeline syntax
 # "raster pipeline" example 2 from:
 # https://gdal.org/en/latest/programs/gdal_raster_pipeline.html
 # serialize the command to reproject a GTiff file into GDALG format, and
@@ -290,9 +289,9 @@ unlink(f_out)
 \seealso{
 \code{\link[=GDALAlg]{GDALAlg-class}}
 
-\dQuote{gdal} Command Line Interface (CLI):\cr
+\code{gdal} Command Line Interface (CLI) \cr
 \url{https://gdal.org/en/stable/programs/index.html}
 
-Using \dQuote{gdal} CLI algorithms from R:\cr
+Using \code{gdal} CLI algorithms from \R \cr
 \url{https://usdaforestservice.github.io/gdalraster/articles/use-gdal-cli-from-r.html}
 }

--- a/man/gdal_cli.Rd
+++ b/man/gdal_cli.Rd
@@ -6,15 +6,18 @@
 \alias{gdal_usage}
 \alias{gdal_run}
 \alias{gdal_alg}
+\alias{gdal_global_reg_names}
 \title{Convenience functions for using GDAL CLI algorithms}
 \usage{
-gdal_commands(contains = "", recurse = TRUE, cout = TRUE)
+gdal_commands(contains = NULL, recurse = TRUE, cout = TRUE)
 
 gdal_usage(cmd = NULL)
 
 gdal_run(cmd, args)
 
 gdal_alg(cmd = NULL, args = NULL, parse = TRUE)
+
+gdal_global_reg_names()
 }
 \arguments{
 \item{contains}{Optional character string for filtering output to certain
@@ -32,7 +35,7 @@ algorithm, e.g., \code{"raster reproject"} or \code{c("raster", "reproject")}.
 Defaults to \code{"gdal"}, the main entry point to CLI commands.}
 
 \item{args}{Either a character vector or a named list containing input
-arguments of the algorithm (see section \dQuote{Algorithm argument syntax}).}
+arguments of the algorithm (see section \verb{Algorithm Argument Syntax} below).}
 
 \item{parse}{Logical value, \code{TRUE} to attempt parsing \code{args} if they are
 given in \code{gdal_alg()} (the default). Set to \code{FALSE} to instantiate the
@@ -46,7 +49,7 @@ This set of functions can be used to access and run GDAL utilities as
 
 \strong{Requires GDAL >= 3.11.3}
 
-\strong{Experimental} (see \dQuote{Development status})
+\strong{Experimental} (see the section \verb{Development Status} below)
 }
 \details{
 These functions are convenient for accessing and running GDAL CLI algorithms
@@ -65,7 +68,7 @@ value, called for that side effect only.
 
 \code{gdal_run()} executes a GDAL CLI algorithm and returns it as an object of
 class \code{\link{GDALAlg}}. A list containing algorithm output(s) can be
-accessed by calling the \code{$outputs()} (plural) method on the returned
+accessed by calling the \code{$outputs()} method (plural) on the returned
 object, or, more conveniently in most cases, by calling \code{$output()}
 (singular) to return the the single output value when there is only one.
 After assigning the output, or otherwise completing work with the \code{GDALAlg}
@@ -82,18 +85,26 @@ JSON-formatted string (\code{$usageAsJSON()}).
 This function is simply an alternative to calling the \code{new()} constructor
 for class \code{GDALAlg}. Executing the returned algorithm is optional by calling
 the object's \code{$run()} method (assuming argument values were given).
+
+\code{gdal_global_reg_names()} returns a character vector containing the names of
+the algorithms in the GDAL global algorithm registry. These are the
+top-level nodes (\code{raster}, \code{vector}, etc.) known to GDAL. Potentially code
+external to GDAL could register a new command available for CLI use in a
+GDAL plugin. This function may be useful in certain troubleshooting
+scenarios. It will return a vector of length zero if no names are returned
+from the global registry.
 }
 \note{
 Commands do not require the leading \code{"gdal"} root node. They may begin
 with a top-level command (e.g., \code{"raster"}, \code{"vector"}, etc.).
 
 When using argument names as the element names of a list, the underscore
-character can be optionally substituted for the dash characters that are
-used in some names. This avoids having to surround names in backticks when
-they are used to access list elements in the form \code{args$arg_name} (the form
+character can be substituted for the dash characters that are used in some
+names. This avoids having to surround names in backticks when they are used
+to access list elements in the form \code{args$arg_name} (the form
 \code{args[["arg-name"]]} also works).
 }
-\section{Algorithm argument syntax}{
+\section{Algorithm Argument Syntax}{
 
 Arguments are given in \R as a character vector or named list, but
 otherwise syntax basically matches the GDAL specification for arguments as
@@ -109,25 +120,25 @@ input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:
 \itemize{
-\item at least one long name, preceded by two dash characters when specified
-on the command line,
+\item at least one \dQuote{long} name, preceded by two dash characters when
+specified on the command line,
 \item optionally, auxiliary long names (i.e., aliases),
 \item and optionally a one-letter short name, preceded by a single dash
 character on the command line, e.g., \verb{-f, --of, --format, --output-format <OUTPUT-FORMAT>}
 }
 \item Boolean arguments are specified by just specifying the argument name. In
-\R list format, the named element must be assigned a value of logical \code{TRUE}.
+\R \code{list} format, the named element must be assigned a value of logical
+\code{TRUE}.
 \item Arguments that require a value are specified like:
 \itemize{
-\item \verb{-f VALUE} for one-letter short names.
-\item \verb{--format VALUE} or \code{--format=VALUE} for long names.
-\item in a named list, this would look like:\cr
-\code{arg_list$format <- VALUE}
+\item \verb{-f VALUE} for one-letter short names
+\item \verb{--format VALUE} or \code{--format=VALUE} for long names
+\item in a named list, this might look like: \code{args$format <- VALUE}
 }
 \item Some arguments can be multi-valued. Some of them require all values to be
-packed together and separated with comma. This is, e.g., the case of:
-\verb{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax}, e.g.,
-\verb{--bbox=2.1,49.1,2.9,49.9}.
+packed together and separated with comma. This is, e.g., the case of:\cr
+\verb{--bbox <BBOX> Clipping bounding box as xmin,ymin,xmax,ymax}\cr
+e.g., \verb{--bbox=2.1,49.1,2.9,49.9}.
 \item Others accept each value to be preceded by a new mention of the argument
 name, e.g., \verb{--co COMPRESS=LZW --co TILED=YES}. For that one, if the value
 of the argument does not contain commas, the packed form is also accepted:
@@ -140,26 +151,30 @@ character vector or numeric vector of values).
 }
 }
 
-\section{Development status}{
+\section{Development Status}{
 
 The GDAL Command Line Interface Modernization was first introduced in the
 \href{https://github.com/OSGeo/gdal/releases/tag/v3.11.0}{GDAL 3.11.0 release}
-(2025-05-09). The GDAL project states that the new CLI \dQuote{is
+(2025-05-09). The GDAL project provides warning that the new CLI \dQuote{is
 provisionally provided as an alternative interface to GDAL and OGR command
 line utilities. The project reserves the right to modify, rename,
 reorganize, and change the behavior until it is officially frozen via PSC
-vote in a future major GDAL release.... Your usage of it should have no
+vote in a future major GDAL release. The utility needs time to mature,
+benefit from incremental feedback, and explore enhancements without carrying
+the burden of full backward compatibility. Your usage of it should have no
 expectation of compatibility until that time.}
 (\url{https://gdal.org/en/latest/programs/#gdal-application})
 
-Initial bindings to enable programmatic use of the new CLI algorithms from \R
+Initial bindings to enable programmatic use of the CLI algorithms from \R
 were added in \pkg{gdalraster} 2.2.0, and will evolve over future releases.
-The bindings are considered experimental until the upstream API is declared
-stable. Breaking changes in minor version releases are possible until then.
+\emph{The bindings are considered experimental until the upstream API is declared
+stable}. Breaking changes in minor version releases are possible until then.
+Please use with those cautions in mind. Bug reports may be filed at:
+\url{https://github.com/USDAForestService/gdalraster/issues}.
 }
 
 \examples{
-\dontshow{if (gdal_version_num() >= gdal_compute_version(3, 11, 3)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (length(gdal_global_reg_names()) > 0) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 ## top-level commands
 gdal_commands(recurse = FALSE)
 

--- a/man/gdal_cli.Rd
+++ b/man/gdal_cli.Rd
@@ -115,7 +115,7 @@ objects (i.e., \code{GDALRaster} or \code{GDALVector}), in addition to dataset n
 (e.g., filename, URL, database connection string).
 \itemize{
 \item Commands accept one or several positional arguments, typically for dataset
-names (or, in \R, as \code{GDALRaster} or \code{GDALVector} datasets). The order is
+names (or in \R as \code{GDALRaster} or \code{GDALVector} datasets). The order is
 input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:

--- a/man/gdal_cli.Rd
+++ b/man/gdal_cli.Rd
@@ -6,7 +6,7 @@
 \alias{gdal_usage}
 \alias{gdal_run}
 \alias{gdal_alg}
-\title{Convenience functions for using \dQuote{gdal} CLI algorithms}
+\title{Convenience functions for using GDAL CLI algorithms}
 \usage{
 gdal_commands(contains = "", recurse = TRUE, cout = TRUE)
 
@@ -22,7 +22,7 @@ commands, e.g., \code{gdal_commands("vector")}.}
 
 \item{recurse}{Logical value, \code{TRUE} to include all subcommands recursively
 (the default). Set to \code{FALSE} to include only the top-level \dQuote{gdal}
-commands (i.e., "raster", "vector", etc.)}
+commands (i.e., \dQuote{raster}, \dQuote{vector}, etc.)}
 
 \item{cout}{Logical value, \code{TRUE} to print a list of commands along with
 their descriptions and help URLS to the console (the default).}
@@ -46,7 +46,7 @@ This set of functions can be used to access and run GDAL utilities as
 
 \strong{Requires GDAL >= 3.11.3}
 
-\strong{Experimental} (see "Development status")
+\strong{Experimental} (see \dQuote{Development status})
 }
 \details{
 These functions are convenient for accessing and running GDAL CLI algorithms
@@ -60,7 +60,7 @@ output, e.g., \code{gdal_commands("vector")} to return only commands for working
 with vector inputs.
 
 \code{gdal_usage()} prints a help message to the console for a given command, or
-for the root \code{"gdal"} entry point if called with no argument. No return
+for the root \dQuote{gdal} entry point if called with no argument. No return
 value, called for that side effect only.
 
 \code{gdal_run()} executes a GDAL CLI algorithm and returns it as an object of
@@ -109,7 +109,7 @@ input(s) first, output last. Positional arguments can also be specified as
 named arguments, if preferred to avoid any ambiguity.
 \item Named arguments have:
 \itemize{
-\item at least one "long" name, preceded by two dash characters when specified
+\item at least one long name, preceded by two dash characters when specified
 on the command line,
 \item optionally, auxiliary long names (i.e., aliases),
 \item and optionally a one-letter short name, preceded by a single dash
@@ -159,8 +159,8 @@ stable. Breaking changes in minor version releases are possible until then.
 }
 
 \examples{
-\dontshow{if (gdal_version_num() >= gdalraster:::.GDALALG_MIN_GDAL) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-## top-level gdal commands
+\dontshow{if (gdal_version_num() >= gdal_compute_version(3, 11, 3)) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+## top-level commands
 gdal_commands(recurse = FALSE)
 
 ## convert storml_elev.tif to GeoPackage raster

--- a/man/gdal_version.Rd
+++ b/man/gdal_version.Rd
@@ -12,12 +12,12 @@ gdal_version_num()
 \value{
 \code{gdal_version()} returns a character vector of length four containing:
 \itemize{
-\item "–version" - one line version message, e.g., “GDAL 3.6.3, released
-2023/03/12”
-\item "GDAL_VERSION_NUM" - formatted as a string, e.g., “3060300” for
+\item "-version" - one line version message, e.g., "GDAL 3.6.3, released
+2023/03/12"
+\item "GDAL_VERSION_NUM" - formatted as a string, e.g., "3060300" for
 GDAL 3.6.3.0
-\item "GDAL_RELEASE_DATE" - formatted as a string, e.g., “20230312”
-\item "GDAL_RELEASE_NAME" - e.g., “3.6.3”
+\item "GDAL_RELEASE_DATE" - formatted as a string, e.g., "20230312"
+\item "GDAL_RELEASE_NAME" - e.g., "3.6.3"
 }
 
 \code{gdal_version_num()} returns \code{as.integer(gdal_version()[2])}

--- a/man/gdalraster-package.Rd
+++ b/man/gdalraster-package.Rd
@@ -14,9 +14,9 @@
   See \url{https://gdal.org/en/stable/api/} for details of the GDAL API.
 }
 \details{
-  Initial experimental bindings to the modernized \dQuote{gdal} Command Line
-  Interface (CLI) are implemented in \code{\link{GDALAlg-class}} and related
-  convenience functions: \code{\link[=gdal_commands]{gdal_commands()}},
+  Experimental bindings to the modernized \code{gdal} Command Line Interface
+  (CLI) are implemented in \code{\link{GDALAlg-class}} and related convenience
+  functions: \code{\link[=gdal_commands]{gdal_commands()}},
   \code{\link[=gdal_usage]{gdal_usage()}}, \code{\link[=gdal_run]{gdal_run()}},
   \code{\link[=gdal_alg]{gdal_alg()}} (\emph{Requires GDAL >= 3.11.3})
 
@@ -265,7 +265,7 @@
   working directory.
 
   Temporary files are created in some examples which have cleanup code wrapped
-  in \code{dontshow{}}. While the cleanup code is not shown in the
+  in \code{dontshow}. While the cleanup code is not shown in the
   documentation, note that this code runs by default if examples are run with
   \code{example()}.
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1016,6 +1016,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// gdal_global_reg_names
+Rcpp::CharacterVector gdal_global_reg_names();
+RcppExport SEXP _gdalraster_gdal_global_reg_names() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(gdal_global_reg_names());
+    return rcpp_result_gen;
+END_RCPP
+}
 // getGEOSVersion
 std::vector<int> getGEOSVersion();
 RcppExport SEXP _gdalraster_getGEOSVersion() {
@@ -2293,6 +2303,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_vsi_get_signed_url", (DL_FUNC) &_gdalraster_vsi_get_signed_url, 2},
     {"_gdalraster_vsi_is_local", (DL_FUNC) &_gdalraster_vsi_is_local, 1},
     {"_gdalraster_gdal_commands", (DL_FUNC) &_gdalraster_gdal_commands, 3},
+    {"_gdalraster_gdal_global_reg_names", (DL_FUNC) &_gdalraster_gdal_global_reg_names, 0},
     {"_gdalraster_getGEOSVersion", (DL_FUNC) &_gdalraster_getGEOSVersion, 0},
     {"_gdalraster_has_geos", (DL_FUNC) &_gdalraster_has_geos, 0},
     {"_gdalraster_g_wkb2wkt", (DL_FUNC) &_gdalraster_g_wkb2wkt, 2},

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -36,12 +36,12 @@
 //'
 //' @returns
 //' `gdal_version()` returns a character vector of length four containing:
-//'   * "–version" - one line version message, e.g., “GDAL 3.6.3, released
-//'   2023/03/12”
-//'   * "GDAL_VERSION_NUM" - formatted as a string, e.g., “3060300” for
+//'   * "-version" - one line version message, e.g., "GDAL 3.6.3, released
+//'   2023/03/12"
+//'   * "GDAL_VERSION_NUM" - formatted as a string, e.g., "3060300" for
 //'   GDAL 3.6.3.0
-//'   * "GDAL_RELEASE_DATE" - formatted as a string, e.g., “20230312”
-//'   * "GDAL_RELEASE_NAME" - e.g., “3.6.3”
+//'   * "GDAL_RELEASE_DATE" - formatted as a string, e.g., "20230312"
+//'   * "GDAL_RELEASE_NAME" - e.g., "3.6.3"
 //'
 //' `gdal_version_num()` returns `as.integer(gdal_version()[2])`
 //' @examples

--- a/src/gdalalg.cpp
+++ b/src/gdalalg.cpp
@@ -24,8 +24,8 @@ constexpr char GDALALG_MIN_GDAL_MSG_[] =
 constexpr R_xlen_t CMD_TOKENS_MAX_ = 5;
 
     #if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3, 12, 0)
-// cf. https://lists.osgeo.org/pipermail/gdal-dev/2025-August/060818.html
-// cf. https://github.com/OSGeo/gdal/pull/12853 for GDAL >= 3.12
+// see https://lists.osgeo.org/pipermail/gdal-dev/2025-August/060818.html
+// see https://github.com/OSGeo/gdal/pull/12853 for GDAL >= 3.12
 struct GDALAlgorithmArgHS
 {
     GDALAlgorithmArg *ptr = nullptr;
@@ -38,6 +38,8 @@ struct GDALAlgorithmArgHS
 #endif  // GDALALG_MIN_GDAL_
 
 #if GDAL_VERSION_NUM >= GDALALG_MIN_GDAL_
+// internal helper to get subalgorithm names, descriptions and URLs,
+// potentially filtering on 'contains'
 void append_subalg_names_desc_(const GDALAlgorithmH alg,
                                const std::string &cmd_str,
                                std::vector<std::string> *names,
@@ -46,9 +48,6 @@ void append_subalg_names_desc_(const GDALAlgorithmH alg,
                                const std::string &contains,
                                bool cout) {
 
-// internal helper to get subalgorithm names, descriptions and URLs,
-// potentially filtering on 'contains'
-
     char **subnames = nullptr;
     subnames = GDALAlgorithmGetSubAlgorithmNames(alg);
     int num_subnames = CSLCount(subnames);
@@ -56,9 +55,9 @@ void append_subalg_names_desc_(const GDALAlgorithmH alg,
     for (int i = 0; i < num_subnames; ++i) {
         GDALAlgorithmH subalg = nullptr;
         subalg = GDALAlgorithmInstantiateSubAlgorithm(alg, subnames[i]);
-        if (subalg == nullptr) {
+        if (!subalg) {
             Rcpp::Rcout << "failed to instantiate alg name: " << subnames[i] <<
-                std::endl;
+                "\n";
             continue;
         }
 
@@ -76,11 +75,11 @@ void append_subalg_names_desc_(const GDALAlgorithmH alg,
         }
 
         if (cout && cout_this) {
-            Rcpp::Rcout << this_cmd_str.c_str() << ":" << std::endl;
-            Rcpp::Rcout << GDALAlgorithmGetDescription(subalg) << std::endl;
+            Rcpp::Rcout << this_cmd_str.c_str() << ":\n";
+            Rcpp::Rcout << GDALAlgorithmGetDescription(subalg) << "\n";
             if (!EQUAL(GDALAlgorithmGetHelpFullURL(subalg), ""))
-                Rcpp::Rcout << GDALAlgorithmGetHelpFullURL(subalg) << std::endl;
-            Rcpp::Rcout << std::endl;
+                Rcpp::Rcout << GDALAlgorithmGetHelpFullURL(subalg) << "\n";
+            Rcpp::Rcout << "\n";
         }
 
         if (GDALAlgorithmHasSubAlgorithms(subalg)) {
@@ -95,6 +94,7 @@ void append_subalg_names_desc_(const GDALAlgorithmH alg,
 }
 #endif  // GDALALG_MIN_GDAL_
 
+//  public R wrapper in R/gdal_cli.R
 //' @noRd
 // [[Rcpp::export(name = ".gdal_commands")]]
 Rcpp::DataFrame gdal_commands(const std::string &contains, bool recurse,
@@ -106,15 +106,14 @@ Rcpp::DataFrame gdal_commands(const std::string &contains, bool recurse,
 #else
     GDALAlgorithmRegistryH reg = nullptr;
     reg = GDALGetGlobalAlgorithmRegistry();
-    if (reg == nullptr) {
+    if (!reg)
         Rcpp::stop("failed to obtain global algorithm registry");
-    }
 
     GDALAlgorithmH gdal_alg = nullptr;
     gdal_alg = GDALAlgorithmRegistryInstantiateAlg(reg,
         GDALGlobalAlgorithmRegistry::ROOT_ALG_NAME);
 
-    if (gdal_alg == nullptr) {
+    if (!gdal_alg) {
         GDALAlgorithmRegistryRelease(reg);
         Rcpp::stop("failed to instantiate \"gdal\" entry point");
     }
@@ -136,9 +135,9 @@ Rcpp::DataFrame gdal_commands(const std::string &contains, bool recurse,
     for (int i = 0; i < num_names; ++i) {
         GDALAlgorithmH alg = nullptr;
         alg = GDALAlgorithmRegistryInstantiateAlg(reg, names[i]);
-        if (alg == nullptr) {
+        if (!alg) {
             Rcpp::Rcout << "failed to instantiate alg name: " << names[i] <<
-                std::endl;
+                "\n";
             continue;
         }
 
@@ -155,11 +154,11 @@ Rcpp::DataFrame gdal_commands(const std::string &contains, bool recurse,
         }
 
         if (cout && cout_this) {
-            Rcpp::Rcout << names[i] << ":" << std::endl;
-            Rcpp::Rcout << GDALAlgorithmGetDescription(alg) << std::endl;
+            Rcpp::Rcout << names[i] << ":\n";
+            Rcpp::Rcout << GDALAlgorithmGetDescription(alg) << "\n";
             if (!EQUAL(GDALAlgorithmGetHelpFullURL(alg), ""))
-                Rcpp::Rcout << GDALAlgorithmGetHelpFullURL(alg) << std::endl;
-            Rcpp::Rcout << std::endl;
+                Rcpp::Rcout << GDALAlgorithmGetHelpFullURL(alg) << "\n";
+            Rcpp::Rcout << "\n";
         }
 
         if (recurse && GDALAlgorithmHasSubAlgorithms(alg)) {
@@ -184,6 +183,7 @@ Rcpp::DataFrame gdal_commands(const std::string &contains, bool recurse,
 #endif  // GDALALG_MIN_GDAL_
 }
 
+//  public R wrapper in R/gdal_cli.R
 //' @noRd
 // [[Rcpp::export(name = ".gdal_global_reg_names")]]
 Rcpp::CharacterVector gdal_global_reg_names() {
@@ -191,15 +191,14 @@ Rcpp::CharacterVector gdal_global_reg_names() {
     Rcpp::CharacterVector out = Rcpp::CharacterVector::create();
 
 #if GDAL_VERSION_NUM < GDALALG_MIN_GDAL_
-    Rcpp::Rcout << GDALALG_MIN_GDAL_MSG_ << std::endl;
+    Rcpp::Rcout << GDALALG_MIN_GDAL_MSG_ << "\n";
     return out;
 
 #else
     GDALAlgorithmRegistryH reg = nullptr;
     reg = GDALGetGlobalAlgorithmRegistry();
-    if (reg == nullptr) {
-        Rcpp::Rcout << "failed to obtain global algorithm registry" <<
-            std::endl;
+    if (!reg) {
+        Rcpp::Rcout << "failed to obtain global algorithm registry\n";
         return out;
     }
 
@@ -218,7 +217,8 @@ Rcpp::CharacterVector gdal_global_reg_names() {
 
 // ****************************************************************************
 //  Implementation of exposed class GDALAlg, which wraps GDALAlgorithm and
-//  its related classes GDALAlgorithmArg and GDALArgDatasetValue
+//  its related classes GDALAlgorithmArg and GDALArgDatasetValue.
+//  Documented in R/gdalalg.R.
 // ****************************************************************************
 
 GDALAlg::GDALAlg() :
@@ -246,10 +246,11 @@ GDALAlg::GDALAlg(const Rcpp::CharacterVector &cmd, const Rcpp::RObject &args) {
         Rcpp::stop("number of elements in 'cmd' is out of range");
     }
 
+    Rcpp::CharacterVector cmd_in = enc_to_utf8_(cmd);
     m_cmd_str = "";
-    for (R_xlen_t i = 0; i < cmd.size(); ++i) {
-        m_cmd_str += Rcpp::as<std::string>(cmd[i]);
-        if (i < cmd.size() - 1) {
+    for (R_xlen_t i = 0; i < cmd_in.size(); ++i) {
+        m_cmd_str += Rcpp::as<std::string>(cmd_in[i]);
+        if (i < cmd_in.size() - 1) {
             m_cmd_str += " ";
         }
     }
@@ -271,12 +272,13 @@ GDALAlg::GDALAlg(const Rcpp::CharacterVector &cmd, const Rcpp::RObject &args) {
         }
     }
     else {
-        m_cmd = Rcpp::clone(cmd);
+        m_cmd = cmd_in;
     }
 
     if (!args.isNULL()) {
         if (Rcpp::is<Rcpp::CharacterVector>(args)) {
-            m_args = Rcpp::clone(args);
+            Rcpp::CharacterVector args_in(args);
+            m_args = enc_to_utf8_(args_in);
         }
         else if (Rcpp::is<Rcpp::List>(args)) {
             m_args = parseListArgs_(Rcpp::as<Rcpp::List>(args));
@@ -295,15 +297,15 @@ GDALAlg::GDALAlg(const Rcpp::CharacterVector &cmd, const Rcpp::RObject &args) {
 
 GDALAlg::~GDALAlg() {
 #if GDAL_VERSION_NUM >= GDALALG_MIN_GDAL_
-    if (m_hActualAlg != nullptr) {
+    if (m_hActualAlg) {
         if (m_hasRun && !m_hasFinalized)
             GDALAlgorithmFinalize(m_hActualAlg);
         GDALAlgorithmRelease(m_hActualAlg);
     }
 
-    if (m_hAlg != nullptr) {
+    if (m_hAlg)
         GDALAlgorithmRelease(m_hAlg);
-    }
+
 #endif  // GDALALG_MIN_GDAL_
 }
 
@@ -312,7 +314,7 @@ Rcpp::List GDALAlg::info() const {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
     Rcpp::List alg_info = Rcpp::List::create();
@@ -352,11 +354,11 @@ Rcpp::List GDALAlg::info() const {
         std::vector<std::string> names(papszArgNames, papszArgNames + nCount);
 
 #if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3, 12, 0)
-        // cf. https://lists.osgeo.org/pipermail/gdal-dev/2025-August/060825.html
+        // see https://lists.osgeo.org/pipermail/gdal-dev/2025-August/060825.html
         names.erase(std::remove(names.begin(), names.end(), "help-doc"),
                     names.end());
 #else
-        // cf. https://github.com/OSGeo/gdal/pull/12890
+        // see https://github.com/OSGeo/gdal/pull/12890
         std::vector<std::string> hidden_args = {};
         for (const std::string &nm : names) {
             auto hArg = GDALAlgorithmGetArg(alg, nm.c_str());
@@ -391,7 +393,7 @@ Rcpp::List GDALAlg::argInfo(const Rcpp::String &arg_name) const {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
     if (arg_name == "" || arg_name == NA_STRING)
@@ -403,7 +405,7 @@ Rcpp::List GDALAlg::argInfo(const Rcpp::String &arg_name) const {
     hArg = GDALAlgorithmGetArg(m_hActualAlg ? m_hActualAlg : m_hAlg,
                                arg_name.get_cstring());
 
-    if (hArg == nullptr)
+    if (!hArg)
         Rcpp::stop("failed to obtain GDALAlgorithmArg object for 'arg_name'");
 
     arg_info.push_back(GDALAlgorithmArgGetName(hArg), "name");
@@ -462,8 +464,8 @@ Rcpp::List GDALAlg::argInfo(const Rcpp::String &arg_name) const {
                        "has_default_value");
 
     if (GDALAlgorithmArgHasDefaultValue(hArg)) {
-    // cf. https://lists.osgeo.org/pipermail/gdal-dev/2025-August/060818.html
-    // cf. https://github.com/OSGeo/gdal/pull/12853 for GDAL >= 3.12
+    // see https://lists.osgeo.org/pipermail/gdal-dev/2025-August/060818.html
+    // see https://github.com/OSGeo/gdal/pull/12853 for GDAL >= 3.12
 
         if (eType == GAAT_STRING) {
     #if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3, 12, 0)
@@ -579,7 +581,7 @@ Rcpp::List GDALAlg::argInfo(const Rcpp::String &arg_name) const {
                        "is_hidden_for_cli");
     // GDALAlgorithmArgIsOnlyForCLI() is deprecated at GDAL 3.12
     // renamed to GDALAlgorithmArgIsHiddenForAPI()
-    // cf. https://github.com/OSGeo/gdal/pull/12890
+    // see https://github.com/OSGeo/gdal/pull/12890
     arg_info.push_back(GDALAlgorithmArgIsHiddenForAPI(hArg),
                        "is_only_for_cli");
     #endif
@@ -653,7 +655,7 @@ Rcpp::String GDALAlg::usageAsJSON() const {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
     char *pszUsage = nullptr;
@@ -676,7 +678,7 @@ bool GDALAlg::parseCommandLineArgs() {
 
     // parses cl args which sets the values, and also instantiates m_hActualAlg
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
     if (m_haveParsedCmdLineArgs) {
@@ -700,7 +702,7 @@ bool GDALAlg::parseCommandLineArgs() {
                     if (it->second.size() > 1) {
                         Rcpp::Rcout << it->first.c_str() << ": " <<
                             "dataset list given where single dataset expected"
-                            << std::endl;
+                            << "\n";
 
                         res = false;
                     } else {
@@ -759,7 +761,7 @@ bool GDALAlg::parseCommandLineArgs() {
                     contains_str_(m_args, "--if")) {
 
                     if (!quiet) {
-                        Rcpp::Rcout << "argument: " << pszArgName << std::endl;
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
                         Rcpp::warning(warning_msg);
                     }
                 }
@@ -783,7 +785,7 @@ bool GDALAlg::parseCommandLineArgs() {
                     contains_str_(m_args, "-l")) {
 
                     if (!quiet) {
-                        Rcpp::Rcout << "argument: " << pszArgName << std::endl;
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
                         Rcpp::warning(warning_msg);
                     }
                 }
@@ -799,10 +801,8 @@ bool GDALAlg::parseCommandLineArgs() {
                         res = false;
                     }
                     if (!res) {
-                        Rcpp::Rcout << "argument: " << pszArgName << std::endl;
-                        Rcpp::Rcout << "  failed to set from object"
-                            << std::endl;
-
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
+                        Rcpp::Rcout << "  failed to set from object\n";
                         break;
                     }
                 }
@@ -813,8 +813,7 @@ bool GDALAlg::parseCommandLineArgs() {
 
                 if (contains_str_(m_args, "--sql")) {
                     if (!quiet) {
-                        Rcpp::Rcout << "argument: " << pszArgName <<
-                            std::endl;
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
                         Rcpp::warning(warning_msg);
                     }
                 }
@@ -832,8 +831,8 @@ bool GDALAlg::parseCommandLineArgs() {
                     }
                 }
                 if (!res) {
-                    Rcpp::Rcout << "argument: " << pszArgName << std::endl;
-                    Rcpp::Rcout << "  failed to set from object" << std::endl;
+                    Rcpp::Rcout << "argument: " << pszArgName << "\n";
+                    Rcpp::Rcout << "  failed to set from object\n";
 
                     break;
                 }
@@ -844,8 +843,7 @@ bool GDALAlg::parseCommandLineArgs() {
 
                 if (contains_str_(m_args, "--dialect")) {
                     if (!quiet) {
-                        Rcpp::Rcout << "argument: " << pszArgName <<
-                            std::endl;
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
                         Rcpp::warning(warning_msg);
                     }
                 }
@@ -866,8 +864,8 @@ bool GDALAlg::parseCommandLineArgs() {
                     }
                 }
                 if (!res) {
-                    Rcpp::Rcout << "argument: " << pszArgName << std::endl;
-                    Rcpp::Rcout << "  failed to set from object" << std::endl;
+                    Rcpp::Rcout << "argument: " << pszArgName << "\n";
+                    Rcpp::Rcout << "  failed to set from object\n";
 
                     break;
                 }
@@ -878,8 +876,7 @@ bool GDALAlg::parseCommandLineArgs() {
 
                 if (contains_str_(m_args, "--like-sql")) {
                     if (!quiet) {
-                        Rcpp::Rcout << "argument: " << pszArgName <<
-                            std::endl;
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
                         Rcpp::warning(warning_msg);
                     }
                 }
@@ -899,8 +896,8 @@ bool GDALAlg::parseCommandLineArgs() {
                     }
                 }
                 if (!res) {
-                    Rcpp::Rcout << "argument: " << pszArgName << std::endl;
-                    Rcpp::Rcout << "  failed to set from object" << std::endl;
+                    Rcpp::Rcout << "argument: " << pszArgName << "\n";
+                    Rcpp::Rcout << "  failed to set from object\n";
 
                     break;
                 }
@@ -911,7 +908,7 @@ bool GDALAlg::parseCommandLineArgs() {
 
                 if (contains_str_(m_args, "--like-layer")) {
                     if (!quiet) {
-                        Rcpp::Rcout << "argument: " << pszArgName << std::endl;
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
                         Rcpp::warning(warning_msg);
                     }
                 }
@@ -927,10 +924,8 @@ bool GDALAlg::parseCommandLineArgs() {
                         res = false;
                     }
                     if (!res) {
-                        Rcpp::Rcout << "argument: " << pszArgName << std::endl;
-                        Rcpp::Rcout << "  failed to set from object"
-                            << std::endl;
-
+                        Rcpp::Rcout << "argument: " << pszArgName << "\n";
+                        Rcpp::Rcout << "  failed to set from object\n";
                         break;
                     }
                 }
@@ -968,7 +963,7 @@ bool GDALAlg::run() {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
     if (m_hasRun)
@@ -976,18 +971,15 @@ bool GDALAlg::run() {
 
     if (!m_haveParsedCmdLineArgs) {
         if (!parseCommandLineArgs()) {
-            if (!quiet) {
-                Rcpp::Rcout << "parse command line arguments failed" <<
-                    std::endl;
-            }
+            if (!quiet)
+                Rcpp::Rcout << "parse command line arguments failed\n";
             return false;
         }
     }
 
-    if (m_hActualAlg == nullptr) {
-        if (!quiet) {
-            Rcpp::Rcout << "actual algorithm handle is nullptr" << std::endl;
-        }
+    if (!m_hActualAlg) {
+        if (!quiet)
+            Rcpp::Rcout << "actual algorithm handle is NULL\n";
         return false;
     }
 
@@ -1007,10 +999,10 @@ SEXP GDALAlg::output() const {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
-    if (!m_hasRun || m_hActualAlg == nullptr)
+    if (!m_hasRun || !m_hActualAlg)
         Rcpp::stop("algorithm has not run");
 
     std::vector<std::string> out_arg_names = getOutputArgNames_();
@@ -1035,10 +1027,10 @@ Rcpp::List GDALAlg::outputs() const {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
-    if (!m_hasRun || m_hActualAlg == nullptr)
+    if (!m_hasRun || !m_hActualAlg)
         Rcpp::stop("algorithm has not run");
 
     std::vector<std::string> out_arg_names = getOutputArgNames_();
@@ -1050,10 +1042,10 @@ Rcpp::List GDALAlg::outputs() const {
     for (std::string arg_name : out_arg_names) {
         GDALAlgorithmArgH hArg = nullptr;
         hArg = GDALAlgorithmGetArg(m_hActualAlg, arg_name.c_str());
-        if (hArg == nullptr) {
+        if (!hArg) {
             if (!quiet) {
-                Rcpp::Rcout << "got nullptr for arg: " << arg_name.c_str()
-                    << std::endl;
+                Rcpp::Rcout << "got NULL for arg: " << arg_name.c_str()
+                    << "\n";
             }
             continue;
         }
@@ -1076,27 +1068,27 @@ bool GDALAlg::close() {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hAlg == nullptr)
+    if (!m_hAlg)
         Rcpp::stop("algorithm not instantiated");
 
     if (!m_hasRun) {
         if (!quiet)
-            Rcpp::Rcout << "algorithm has not run" << std::endl;
+            Rcpp::Rcout << "algorithm has not run\n";
         return false;
     }
 
     if (m_hasFinalized) {
         if (!quiet)
-            Rcpp::Rcout << "algorithm has already been finalized" << std::endl;
+            Rcpp::Rcout << "algorithm has already been finalized\n";
         return false;
     }
 
-    if (m_hActualAlg != nullptr) {
+    if (m_hActualAlg) {
         return GDALAlgorithmFinalize(m_hActualAlg);
     }
     else {
         if (!quiet)
-            Rcpp::Rcout << "actual algorithm is nullptr" << std::endl;
+            Rcpp::Rcout << "actual algorithm is nullptr\n";
         return false;
     }
 #endif  // GDALALG_MIN_GDAL_
@@ -1107,14 +1099,14 @@ void GDALAlg::release() {
     Rcpp::stop(GDALALG_MIN_GDAL_MSG_);
 #else
 
-    if (m_hActualAlg != nullptr) {
+    if (m_hActualAlg) {
         if (m_hasRun && !m_hasFinalized)
             GDALAlgorithmFinalize(m_hActualAlg);
         GDALAlgorithmRelease(m_hActualAlg);
         m_hActualAlg = nullptr;
     }
 
-    if (m_hAlg != nullptr) {
+    if (m_hAlg) {
         GDALAlgorithmRelease(m_hAlg);
         m_hAlg = nullptr;
     }
@@ -1124,23 +1116,22 @@ void GDALAlg::release() {
 
 void GDALAlg::show() const {
 #if GDAL_VERSION_NUM < GDALALG_MIN_GDAL_
-    Rcpp::Rcout << GDALALG_MIN_GDAL_MSG_ << std::endl;
+    Rcpp::Rcout << GDALALG_MIN_GDAL_MSG_ << "\n";
 #else
 
-    Rcpp::Rcout << "C++ object of class GDALAlg" << std::endl;
+    Rcpp::Rcout << "C++ object of class GDALAlg\n";
 
-    if (m_hAlg == nullptr) {
-        Rcpp::Rcout << " algorithm not instantiated" << std::endl;
+    if (!m_hAlg) {
+        Rcpp::Rcout << " algorithm not instantiated\n";
     }
     else {
         const GDALAlgorithmH &alg = m_hActualAlg ? m_hActualAlg : m_hAlg;
 
-        Rcpp::Rcout << " Name        : " << GDALAlgorithmGetName(alg) <<
-            std::endl;
+        Rcpp::Rcout << " Name        : " << GDALAlgorithmGetName(alg) << "\n";
         Rcpp::Rcout << " Description : " << GDALAlgorithmGetDescription(alg) <<
-            std::endl;
+            "\n";
         Rcpp::Rcout << " Help URL    : " << GDALAlgorithmGetHelpFullURL(alg) <<
-            std::endl;
+            "\n";
     }
 #endif  // GDALALG_MIN_GDAL_
 }
@@ -1150,7 +1141,7 @@ void GDALAlg::show() const {
 // ****************************************************************************
 
 Rcpp::CharacterVector GDALAlg::parseListArgs_(
-        const Rcpp::List &list_args) {
+                                const Rcpp::List &list_args) {
 
     // convert arguments in a named list to character vector form and return it
     // arguments in list form must use arg long names
@@ -1164,7 +1155,7 @@ Rcpp::CharacterVector GDALAlg::parseListArgs_(
     else
         num_args = list_args.size();
 
-    Rcpp::CharacterVector arg_names = list_args.names();
+    Rcpp::CharacterVector arg_names = enc_to_utf8_(list_args.names());
     if (arg_names.size() == 0 || arg_names.size() != num_args)
         Rcpp::stop("arg list must have named elements");
 
@@ -1172,13 +1163,19 @@ Rcpp::CharacterVector GDALAlg::parseListArgs_(
         if (list_args[i] == R_NilValue)
             continue;
 
-        Rcpp::String nm = arg_names[i];
+        Rcpp::String nm(arg_names[i]);
         if (nm == NA_STRING || nm == "")
             continue;
 
         nm.replace_all("--", "");
         nm.replace_all("_", "-");
-        std::string nm_no_dashes(nm.get_cstring());
+        if (STARTS_WITH(nm.get_cstring(), "-") &&
+            CPLStrlenUTF8(nm.get_cstring()) < 3) {
+
+            Rcpp::Rcout << "argument: " << arg_names[i] << "\n";
+            Rcpp::stop("arguments in list format must use \"long\" names");
+        }
+        std::string nm_no_lead_dashes(nm.get_cstring());
         nm.push_front("--");
 
         // boolean
@@ -1198,14 +1195,14 @@ Rcpp::CharacterVector GDALAlg::parseListArgs_(
                 const GDALRaster* const &ds = list_args[i];
                 std::vector<GDALDatasetH> ds_list = {};
                 ds_list.push_back(ds->getGDALDatasetH_());
-                m_map_input_hDS[nm_no_dashes] = ds_list;
+                m_map_input_hDS[nm_no_lead_dashes] = ds_list;
                 continue;
             }
             if (cls == "Rcpp_GDALVector") {
                 GDALVector* const &ds = list_args[i];
                 std::vector<GDALDatasetH> ds_list = {};
                 ds_list.push_back(ds->getGDALDatasetH_());
-                m_map_input_hDS[nm_no_dashes] = ds_list;
+                m_map_input_hDS[nm_no_lead_dashes] = ds_list;
                 if (EQUAL(nm.get_cstring(), "--input"))
                     m_input_GDALVector = ds;
                 else if (EQUAL(nm.get_cstring(), "--like"))
@@ -1232,7 +1229,7 @@ Rcpp::CharacterVector GDALAlg::parseListArgs_(
                         GDALVector* const &ds = list_tmp[j];
                         ds_list.push_back(ds->getGDALDatasetH_());
                         if (EQUAL(nm.get_cstring(), "--input") &&
-                            m_input_GDALVector == nullptr) {
+                            !m_input_GDALVector) {
 
                             m_input_GDALVector = ds;
                         }
@@ -1241,7 +1238,7 @@ Rcpp::CharacterVector GDALAlg::parseListArgs_(
             }
 
             if (!ds_list.empty()) {
-                m_map_input_hDS[nm_no_dashes] = ds_list;
+                m_map_input_hDS[nm_no_lead_dashes] = ds_list;
             }
             continue;
         }
@@ -1277,26 +1274,24 @@ void GDALAlg::instantiateAlg_() {
 #else
     // instantiate m_hAlg
 
-    if (m_hAlg != nullptr || m_hActualAlg != nullptr) {
+    if (m_hAlg || m_hActualAlg) {
         Rcpp::stop(
-            "instantiateAlg_(): algorithm object appears already instantiated");
+            "instantiateAlg_(): algorithm object already instantiated");
     }
 
     GDALAlgorithmRegistryH reg = nullptr;
     reg = GDALGetGlobalAlgorithmRegistry();
-    if (reg == nullptr) {
+    if (!reg)
         Rcpp::stop("failed to obtain global algorithm registry");
-    }
 
     if (m_cmd.size() == 1) {
         Rcpp::String cmd(m_cmd[0]);
 
         m_hAlg = GDALAlgorithmRegistryInstantiateAlg(reg, cmd.get_cstring());
 
-        if (m_hAlg == nullptr) {
+        if (!m_hAlg) {
             GDALAlgorithmRegistryRelease(reg);
-            Rcpp::Rcout << "top-level command: " << cmd.get_cstring() <<
-                std::endl;
+            Rcpp::Rcout << "top-level command: " << cmd.get_cstring() << "\n";
             Rcpp::stop("failed to instantiate CLI algorithm");
         }
     }
@@ -1307,10 +1302,9 @@ void GDALAlg::instantiateAlg_() {
         alg_tmp.push_back(
             GDALAlgorithmRegistryInstantiateAlg(reg, cmd.get_cstring()));
 
-        if (alg_tmp[0] == nullptr) {
+        if (!alg_tmp[0]) {
             GDALAlgorithmRegistryRelease(reg);
-            Rcpp::Rcout << "top-level command: " << cmd.get_cstring() <<
-                std::endl;
+            Rcpp::Rcout << "top-level command: " << cmd.get_cstring() << "\n";
             Rcpp::stop("failed to instantiate CLI algorithm");
         }
         for (R_xlen_t i = 1; i < m_cmd.size(); ++i) {
@@ -1322,14 +1316,14 @@ void GDALAlg::instantiateAlg_() {
                     GDALAlgorithmInstantiateSubAlgorithm(alg_tmp[i - 1],
                                                          sub_cmd.get_cstring());
 
-                if (m_hAlg == nullptr) {
+                if (!m_hAlg) {
                     for (GDALAlgorithmH alg : alg_tmp) {
                         if (alg)
                             GDALAlgorithmRelease(alg);
                     }
                     GDALAlgorithmRegistryRelease(reg);
                     Rcpp::Rcout << "subcommand: " << sub_cmd.get_cstring() <<
-                        std::endl;
+                        "\n";
                     Rcpp::stop("failed to instantiate CLI algorithm");
                 }
             }
@@ -1347,7 +1341,7 @@ void GDALAlg::instantiateAlg_() {
                     }
                     GDALAlgorithmRegistryRelease(reg);
                     Rcpp::Rcout << "subcommand: " << sub_cmd.get_cstring() <<
-                        std::endl;
+                        "\n";
                     Rcpp::stop("failed to instantiate CLI algorithm");
                 }
             }
@@ -1368,16 +1362,13 @@ std::vector<std::string> GDALAlg::getOutputArgNames_() const {
 #if GDAL_VERSION_NUM < GDALALG_MIN_GDAL_
     return names_out;
 #else
-
     char **papszArgNames = nullptr;
     if (m_hActualAlg) {
         papszArgNames = GDALAlgorithmGetArgNames(m_hActualAlg);
     }
     else {
-        if (!quiet) {
-            Rcpp::Rcout << "actual algorithm object not instantiated" <<
-                std::endl;
-        }
+        if (!quiet)
+            Rcpp::Rcout << "actual algorithm object not instantiated\n";
         return names_out;
     }
 
@@ -1387,10 +1378,10 @@ std::vector<std::string> GDALAlg::getOutputArgNames_() const {
         for (std::string arg_name : names) {
             GDALAlgorithmArgH hArg = nullptr;
             hArg = GDALAlgorithmGetArg(m_hActualAlg, arg_name.c_str());
-            if (hArg == nullptr) {
+            if (!hArg) {
                 if (!quiet) {
                     Rcpp::Rcout << "got nullptr for arg: " << arg_name.c_str()
-                        << std::endl;
+                        << "\n";
                 }
                 continue;
             }
@@ -1408,7 +1399,7 @@ std::vector<std::string> GDALAlg::getOutputArgNames_() const {
 
 #if GDAL_VERSION_NUM >= GDALALG_MIN_GDAL_
 SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
-    if (hArg == nullptr)
+    if (!hArg)
         Rcpp::stop("got nullptr for GDALAlgorithmArgH hArg");
 
     SEXP out = R_NilValue;
@@ -1502,12 +1493,9 @@ SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
         {
             GDALArgDatasetValueH hArgDSValue = nullptr;
             hArgDSValue = GDALAlgorithmArgGetAsDatasetValue(hArg);
-
-            if (hArgDSValue == nullptr) {
-                if (!quiet) {
-                    Rcpp::Rcout << "output dataset value is NULL" <<
-                        std::endl;
-                }
+            if (!hArgDSValue) {
+                if (!quiet)
+                    Rcpp::Rcout << "output dataset value is NULL\n";
                 return R_NilValue;
             }
 
@@ -1518,7 +1506,7 @@ SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
 
             GDALDatasetH hDS = nullptr;
             hDS = GDALArgDatasetValueGetDatasetIncreaseRefCount(hArgDSValue);
-            if (hDS == nullptr) {
+            if (!hDS) {
                 GDALArgDatasetValueRelease(hArgDSValue);
                 Rcpp::stop("GDAL dataset object is NULL");
             }
@@ -1526,7 +1514,6 @@ SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
             // raster
             if (ds_type & GDAL_OF_RASTER) {
                 std::string ds_name(GDALArgDatasetValueGetName(hArgDSValue));
-
                 GDALRaster *ds = new GDALRaster();
                 ds->setFilename(ds_name);
                 ds->setGDALDatasetH_(hDS, with_update);
@@ -1536,7 +1523,6 @@ SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
             // vector
             else if (ds_type & GDAL_OF_VECTOR) {
                 std::string ds_name(GDALArgDatasetValueGetName(hArgDSValue));
-
                 OGRLayerH hLayer = nullptr;
                 std::string layer_name = "";
                 if (this->outputLayerNameForOpen == "" ||
@@ -1548,10 +1534,9 @@ SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
                     layer_name = this->outputLayerNameForOpen;
                     hLayer = GDALDatasetGetLayerByName(hDS, layer_name.c_str());
                 }
-
                 if (layer_name == "") {
                     // default layer first by index was opened
-                    if (hLayer != nullptr)
+                    if (hLayer)
                         layer_name = OGR_L_GetName(hLayer);
                 }
 
@@ -1559,15 +1544,13 @@ SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
                 lyr->setDsn_(ds_name);
                 lyr->setGDALDatasetH_(hDS, true);
                 lyr->setOGRLayerH_(hLayer, layer_name);
-                if (hLayer != nullptr)
+                if (hLayer)
                     lyr->setFieldNames_();
-
                 const GDALVector &lyr_ref = *lyr;
                 out = Rcpp::wrap(lyr_ref);
             }
             // multidim raster - currently only as dataset name
             else if (ds_type & GDAL_OF_MULTIDIM_RASTER) {
-
                 out = Rcpp::wrap(GDALArgDatasetValueGetName(hArgDSValue));
             }
             // unrecognized dataset type - should not occur
@@ -1586,14 +1569,13 @@ SEXP GDALAlg::getOutputArgValue_(const GDALAlgorithmArgH &hArg) const {
             Rcpp::warning(
                 "unhandled output of type DATASET_LIST (returned NULL)");
             out = R_NilValue;
-
         }
         break;
 
         default:
         {
             Rcpp::Rcout << "GDALAlgorithmArgType: " <<
-                GDALAlgorithmArgGetType(hArg) << std::endl;
+                GDALAlgorithmArgGetType(hArg) << "\n";
 
             out = Rcpp::wrap("unhandled arg type");
         }

--- a/src/gdalalg.h
+++ b/src/gdalalg.h
@@ -23,6 +23,8 @@
 Rcpp::DataFrame gdal_commands(const std::string starts_with, bool recurse,
                               bool cout);
 
+Rcpp::CharacterVector gdal_global_reg_names();
+
 class GDALAlg {
  public:
     GDALAlg();

--- a/tests/testthat/test-GDALAlg-class.R
+++ b/tests/testthat/test-GDALAlg-class.R
@@ -1,7 +1,7 @@
 # Tests for src/gdalalg.cpp
 # skip on CRAN while dev status of CLI bindings is "experimental"
 skip_on_cran()
-skip_if(gdal_version_num() < .GDALALG_MIN_GDAL)
+skip_if(gdal_version_num() < gdal_compute_version(3, 11, 3))
 
 test_that("class constructors work", {
     # default constructor

--- a/tests/testthat/test-gdal_cli.R
+++ b/tests/testthat/test-gdal_cli.R
@@ -1,6 +1,6 @@
 # skip on CRAN while dev status of CLI bindings is "experimental"
 skip_on_cran()
-skip_if(gdal_version_num() < .GDALALG_MIN_GDAL)
+skip_if(gdal_version_num() < gdal_compute_version(3, 11, 3))
 
 test_that("gdal_commands works", {
     expect_output(cmds <- gdal_commands(), "info:")

--- a/tests/testthat/test-gdal_cli.R
+++ b/tests/testthat/test-gdal_cli.R
@@ -149,3 +149,7 @@ test_that("gdal_usage works", {
     expect_output(gdal_usage(cmd), "Advanced options:")
     expect_output(gdal_usage(cmd), "For more details:")
 })
+
+test_that("gdal_global_reg_names returns a character vector", {
+    expect_vector(gdal_global_reg_names(), character())
+})

--- a/vignettes/articles/use-gdal-cli-from-r.Rmd
+++ b/vignettes/articles/use-gdal-cli-from-r.Rmd
@@ -24,9 +24,9 @@ GDAL 3.11 added a framework for a unified command line interface (CLI) with a co
 
 The GDAL project states that the new CLI framework
 
-> "is provisionally provided as an alternative interface to GDAL and OGR command line utilities. The project reserves the right to modify, rename, reorganize, and change the behavior until it is officially frozen via PSC vote in a future major GDAL release.... Your usage of it should have no expectation of compatibility until that time." (<https://gdal.org/en/latest/programs/#gdal-application>)
+> "is provisionally provided as an alternative interface to GDAL and OGR command line utilities. The project reserves the right to modify, rename, reorganize, and change the behavior until it is officially frozen via PSC vote in a future major GDAL release. The utility needs time to mature, benefit from incremental feedback, and explore enhancements without carrying the burden of full backward compatibility. Your usage of it should have no expectation of compatibility until that time." (<https://gdal.org/en/latest/programs/#gdal-application>)
 
-The initial bindings in **gdalraster** 2.2.0 are expected to evolve over future releases. The bindings are considered experimental until the upstream API is declared stable. Breaking changes in minor version releases are possible until then.
+The initial bindings in **gdalraster** 2.2.0 will evolve over future releases. *The bindings are considered experimental until the upstream API is declared stable*. Breaking changes in minor version releases are possible until then. Please use with those cautions in mind. Bug reports may be filed at: <https://github.com/USDAForestService/gdalraster/issues>.
 
 ## Command discovery and usage info
 


### PR DESCRIPTION
Includes code fixes and improvements, minor new functionality, and documentation updates. Some documentation changes related to formatting in .Rd files are applied throughout the package for consistency, but code changes in this PR affect only the CLI bindings:
* ensure algorithm names originating in `Rcpp::CharacterVector` are always passed explicitly in GDAL C API calls as `const char *`, via `get_cstring()` method of `Rcpp::String`
* fix clang compiler warning from `-Wunused-const-variable`
* improve input validation in class `GDALAlg`
* add `gdal_global_reg_names()`: return a character vector containing the names of the algorithms in the GDAL global algorithm registry
* allow example code in the documentation to execute in checks only if names are returned from the global algorithm registry, for now until the upstream API is declared stable
* update text in the `Development Status` section describing the experimental bindings
* remove some non-ASCII characters found in .Rd files and other miscellaneous improvements in .Rd formatting, attempting to avoid the warning for LaTex errors seen only on CRAN `r-release-macos-x86_64`, but not on the other platforms including `r-release-macos-arm64` or `r-oldrel-macos-x86_64`: 

```
checking PDF version of manual ... [11s/17s] WARNING
LaTeX errors when creating PDF version.
This typically indicates Rd problems.
LaTeX errors found:
checking PDF version of manual without index ... OK
```