### PR TITLE
Try to be compatible with sf and terra in whether GDAL error level emits an R warning (but they differ)

### DIFF
--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -37,13 +37,29 @@ void gdal_error_handler_r(CPLErr err_class, int err_no, const char *msg) {
 
         case CE_Warning:
         {
-            Rcpp::Rcout << "GDAL WARNING " << err_no << ": " << msg << "\n";
+            // try to be compatible with sf, and terra default level 2
+            if (is_namespace_loaded_("sf")) {
+                std::stringstream ss_msg;
+                ss_msg << "GDAL WARNING " << err_no << ": " << msg;
+                Rcpp::warning(ss_msg.str());
+            }
+            else {
+                Rcpp::Rcout << "GDAL WARNING " << err_no << ": " << msg << "\n";
+            }
         }
         break;
 
         case CE_Failure:
         {
-            Rcpp::Rcout << "GDAL FAILURE " << err_no << ": " << msg << "\n";
+            // try to be compatible with sf, and terra default level 2
+            if (is_namespace_loaded_("sf") || is_namespace_loaded_("terra")) {
+                std::stringstream ss_msg;
+                ss_msg << "GDAL FAILURE " << err_no << ": " << msg;
+                Rcpp::warning(ss_msg.str());
+            }
+            else {
+                Rcpp::Rcout << "GDAL FAILURE " << err_no << ": " << msg << "\n";
+            }
         }
         break;
 

--- a/src/rcpp_util.cpp
+++ b/src/rcpp_util.cpp
@@ -132,3 +132,10 @@ bool contains_str_(const Rcpp::CharacterVector &v, const Rcpp::String &s) {
     else
         return true;
 }
+
+// wrapper for base R isNamespaceLoaded()
+bool is_namespace_loaded_(const Rcpp::String &pkg) {
+    Rcpp::Function f("isNamespaceLoaded");
+    Rcpp::LogicalVector res = f(pkg);
+    return Rcpp::is_true(Rcpp::all(res));
+}

--- a/src/rcpp_util.h
+++ b/src/rcpp_util.h
@@ -49,6 +49,8 @@ std::string str_tolower_(const std::string &s);
 
 bool contains_str_(const Rcpp::CharacterVector &v, const Rcpp::String &s);
 
+bool is_namespace_loaded_(const Rcpp::String &pkg);
+
 // case-insensitive comparator for std::map
 // https://stackoverflow.com/questions/1801892/how-can-i-make-the-mapfind-operation-case-insensitive
 struct _ci_less {


### PR DESCRIPTION
Detect loaded namespaces and try to be compatible.