### PR TITLE
Lint: various C++ code linting

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2217,8 +2217,8 @@ vsi_is_local <- function(filename) {
 }
 
 #' @noRd
-.gdal_commands <- function(contains, recurse, cout) {
-    .Call(`_gdalraster_gdal_commands`, contains, recurse, cout)
+.gdal_commands <- function(contains, recurse, console_out) {
+    .Call(`_gdalraster_gdal_commands`, contains, recurse, console_out)
 }
 
 #' @noRd

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1004,15 +1004,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // gdal_commands
-Rcpp::DataFrame gdal_commands(const std::string& contains, bool recurse, bool cout);
-RcppExport SEXP _gdalraster_gdal_commands(SEXP containsSEXP, SEXP recurseSEXP, SEXP coutSEXP) {
+Rcpp::DataFrame gdal_commands(const std::string& contains, bool recurse, bool console_out);
+RcppExport SEXP _gdalraster_gdal_commands(SEXP containsSEXP, SEXP recurseSEXP, SEXP console_outSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type contains(containsSEXP);
     Rcpp::traits::input_parameter< bool >::type recurse(recurseSEXP);
-    Rcpp::traits::input_parameter< bool >::type cout(coutSEXP);
-    rcpp_result_gen = Rcpp::wrap(gdal_commands(contains, recurse, cout));
+    Rcpp::traits::input_parameter< bool >::type console_out(console_outSEXP);
+    rcpp_result_gen = Rcpp::wrap(gdal_commands(contains, recurse, console_out));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/cmb_table.cpp
+++ b/src/cmb_table.cpp
@@ -3,6 +3,10 @@ Chris Toney <chris.toney at usda.gov> */
 
 #include "cmb_table.h"
 
+#include <string>
+#include <vector>
+
+
 CmbTable::CmbTable() {}
 
 CmbTable::CmbTable(unsigned int keyLen) :
@@ -135,8 +139,8 @@ void CmbTable::show() const {
         out += (" " + s);
     }
 
-    Rcpp::Rcout << "C++ object of class CmbTable" << std::endl;
-    Rcpp::Rcout << " Columns: " << out << std::endl;
+    Rcpp::Rcout << "C++ object of class CmbTable\n";
+    Rcpp::Rcout << " Columns: " << out << "\n";
 }
 
 RCPP_MODULE(mod_cmb_table) {

--- a/src/cmb_table.h
+++ b/src/cmb_table.h
@@ -1,13 +1,11 @@
 /* Hash table class for counting unique combinations of integers
 Chris Toney <chris.toney at usda.gov> */
 
-#ifndef SRC_CMB_TABLE_H_
-#define SRC_CMB_TABLE_H_
+#ifndef CMB_TABLE_H_
+#define CMB_TABLE_H_
 
 #include <Rcpp.h>
 
-#include <string>
-#include <vector>
 #include <unordered_map>
 
 struct cmbKey {
@@ -69,4 +67,4 @@ class CmbTable {
 // cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(CmbTable)
 
-#endif  // SRC_CMB_TABLE_H_
+#endif  // CMB_TABLE_H_

--- a/src/gdal_dt.cpp
+++ b/src/gdal_dt.cpp
@@ -7,7 +7,9 @@
 
 #include "gdal_dt.h"
 
-#include "gdal.h"
+#include <gdal.h>
+
+#include <string>
 
 
 //' Helper functions for GDAL raster data types

--- a/src/gdal_dt.h
+++ b/src/gdal_dt.h
@@ -5,12 +5,13 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_GDAL_DT_H_
-#define SRC_GDAL_DT_H_
+#ifndef GDAL_DT_H_
+#define GDAL_DT_H_
+
+#include <Rcpp.h>
 
 #include <string>
 
-#include <Rcpp.h>
 
 int dt_size(const std::string &dt, bool as_bytes);
 bool dt_is_complex(const std::string &dt);
@@ -27,4 +28,4 @@ std::string dt_find(int bits, bool is_signed, bool is_floating,
 
 std::string dt_find_for_value(double value, bool is_complex);
 
-#endif  // SRC_GDAL_DT_H_
+#endif  // GDAL_DT_H_

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -3,15 +3,20 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#include <algorithm>
+#include "gdal_vsi.h"
 
-#include "gdal.h"
-#include "cpl_port.h"
-#include "cpl_string.h"
-#include "cpl_vsi.h"
+#include <RcppInt64>
+
+#include <gdal.h>
+#include <cpl_port.h>
+#include <cpl_string.h>
+#include <cpl_vsi.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
 
 #include "gdalraster.h"
-#include "gdal_vsi.h"
 
 
 //' Copy a source file to a target filename

--- a/src/gdal_vsi.h
+++ b/src/gdal_vsi.h
@@ -3,11 +3,12 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_GDAL_VSI_H_
-#define SRC_GDAL_VSI_H_
+#ifndef GDAL_VSI_H_
+#define GDAL_VSI_H_
+
+#include <Rcpp.h>
 
 #include <string>
-#include <Rcpp.h>
 
 int vsi_copy_file(const Rcpp::CharacterVector &src_file,
                   const Rcpp::CharacterVector &target_file,
@@ -56,4 +57,4 @@ SEXP vsi_get_signed_url(const Rcpp::CharacterVector &filename,
 bool vsi_is_local(const Rcpp::CharacterVector &filename);
 
 
-#endif  // SRC_GDAL_VSI_H_
+#endif  // GDAL_VSI_H_

--- a/src/gdalalg.h
+++ b/src/gdalalg.h
@@ -4,15 +4,15 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_GDALALG_H_
-#define SRC_GDALALG_H_
-
-#include "rcpp_util.h"
+#ifndef GDALALG_H_
+#define GDALALG_H_
 
 #if __has_include(<gdalalgorithm.h>)
     #include <gdalalgorithm.h>
 #endif
 #include <gdal.h>
+
+#include <Rcpp.h>
 
 #include <map>
 #include <string>
@@ -20,8 +20,8 @@
 
 #include "gdalvector.h"
 
-Rcpp::DataFrame gdal_commands(const std::string starts_with, bool recurse,
-                              bool cout);
+Rcpp::DataFrame gdal_commands(const std::string &contains, bool recurse,
+                              bool console_out);
 
 Rcpp::CharacterVector gdal_global_reg_names();
 
@@ -88,4 +88,4 @@ class GDALAlg {
 // cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(GDALAlg)
 
-#endif  // SRC_GDALALG_H_
+#endif  // GDALALG_H_

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -5,25 +5,28 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#include <errno.h>
+#include <gdal.h>
+#include <gdal_priv.h>
+#include <cpl_port.h>
+#include <cpl_conv.h>
+#include <cpl_string.h>
+#include <cpl_vsi.h>
+#include <gdal_alg.h>
+#include <gdal_utils.h>
+
 #include <algorithm>
 #include <cmath>
 #include <complex>
+#include <cstdint>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
-#include "gdal.h"
-#include "gdal_priv.h"
-#include "cpl_port.h"
-#include "cpl_conv.h"
-#include "cpl_string.h"
-#include "cpl_vsi.h"
-#include "gdal_alg.h"
-#include "gdal_utils.h"
-
-#include "gdal_vsi.h"
-#include "transform.h"
 #include "gdalraster.h"
+#include "gdal_vsi.h"
+#include "rcpp_util.h"
+#include "transform.h"
 
 void gdal_error_handler_r(CPLErr err_class, int err_no, const char *msg) {
     switch (err_class) {
@@ -610,7 +613,7 @@ Rcpp::NumericMatrix GDALRaster::pixel_extract(const Rcpp::RObject &xy,
     for (auto& b : bands_in) {
         GDALRasterBandH hBand = GDALGetRasterBand(m_hDataset, b);
         if (hBand == nullptr) {
-            Rcpp::Rcout << "invalid band number: " << b << std::endl;
+            Rcpp::Rcout << "invalid band number: " << b << "\n";
             Rcpp::stop("failed to access the requested band");
         }
         GDALDataType eDT = GDALGetRasterDataType(hBand);
@@ -2162,21 +2165,21 @@ void GDALRaster::show() const {
     Rcpp::Function fn = pkg[".get_crs_name"];
     std::string crs_name = Rcpp::as<std::string>(fn(getProjection()));
 
-    Rcpp::Rcout << "C++ object of class GDALRaster" << std::endl;
+    Rcpp::Rcout << "C++ object of class GDALRaster\n";
     Rcpp::Rcout << " Driver : " << getDriverLongName() << " (" <<
-                                   getDriverShortName() << ")" << std::endl;
-    Rcpp::Rcout << " DSN    : " << getDescription(0) << std::endl;
+                                   getDriverShortName() << ")\n";
+    Rcpp::Rcout << " DSN    : " << getDescription(0) << "\n";
     Rcpp::Rcout << " Dim    : " << std::to_string(xsize) << ", " <<
                                    std::to_string(ysize) << ", " <<
                                    std::to_string(getRasterCount()) <<
-                                   std::endl;
-    Rcpp::Rcout << " CRS    : " << crs_name << std::endl;
+                                   "\n";
+    Rcpp::Rcout << " CRS    : " << crs_name << "\n";
     Rcpp::Rcout << " Res    : " << std::to_string(res()[0]) << ", " <<
-                                   std::to_string(res()[1]) << std::endl;
+                                   std::to_string(res()[1]) << "\n";
     Rcpp::Rcout << " Bbox   : " << std::to_string(bbox()[0]) << ", " <<
                                    std::to_string(bbox()[1]) << ", " <<
                                    std::to_string(bbox()[2]) << ", " <<
-                                   std::to_string(bbox()[3]) << std::endl;
+                                   std::to_string(bbox()[3]) << "\n";
 }
 
 // ****************************************************************************

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -5,17 +5,12 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_GDALRASTER_H_
-#define SRC_GDALRASTER_H_
+#ifndef GDALRASTER_H_
+#define GDALRASTER_H_
 
-#include <limits>
-#include <map>
-#include <string>
-#include <vector>
+#include <Rcpp.h>
 
-#include "rcpp_util.h"
-
-#ifndef SRC_GDALRASTER_TYPES_H_
+#ifndef GDALRASTER_TYPES_H_
 #include <cpl_port.h>
 #include <cpl_error.h>
 int CPL_STDCALL GDALTermProgressR(double, CPL_UNUSED const char *,
@@ -23,6 +18,10 @@ int CPL_STDCALL GDALTermProgressR(double, CPL_UNUSED const char *,
 void gdal_error_handler_r(CPLErr err_class, int err_no, const char *msg);
 void gdal_silent_errors_r(CPLErr err_class, int err_no, const char *msg);
 #endif
+
+#include <map>
+#include <string>
+#include <vector>
 
 // Predeclare some GDAL types until the public header is included
 #ifndef GDAL_H_INCLUDED
@@ -367,7 +366,7 @@ Rcpp::String ogrinfo(const Rcpp::CharacterVector &dsn,
                      const Rcpp::Nullable<Rcpp::CharacterVector> &cl_arg,
                      const Rcpp::Nullable<Rcpp::CharacterVector> &open_options,
                      bool read_only,
-                     bool cout);
+                     bool console_out);
 
 bool polygonize(const Rcpp::CharacterVector &src_filename, int src_band,
                 const Rcpp::CharacterVector &out_dsn,
@@ -404,4 +403,4 @@ Rcpp::IntegerMatrix createColorRamp(int start_index,
                                     const Rcpp::IntegerVector &end_color,
                                     const std::string &palette_interp);
 
-#endif  // SRC_GDALRASTER_H_
+#endif  // GDALRASTER_H_

--- a/src/gdalraster_types.h
+++ b/src/gdalraster_types.h
@@ -1,7 +1,7 @@
-#ifndef SRC_GDALRASTER_TYPES_H_
-#define SRC_GDALRASTER_TYPES_H_
+#ifndef GDALRASTER_TYPES_H_
+#define GDALRASTER_TYPES_H_
 
 #include "gdalraster.h"
 #include "gdalvector.h"
 
-#endif  // SRC_GDALRASTER_TYPES_H_
+#endif  // GDALRASTER_TYPES_H_

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -5,22 +5,24 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_GDALVECTOR_H_
-#define SRC_GDALVECTOR_H_
+#ifndef GDALVECTOR_H_
+#define GDALVECTOR_H_
+
+#include <Rcpp.h>
 
 #include <map>
 #include <string>
 #include <vector>
 
-#include "rcpp_util.h"
-
-#if __has_include("ogr_recordbatch.h")  // for Arrow structs (GDAL >= 3.6)
-    #include "ogr_recordbatch.h"
+#if __has_include(<ogr_recordbatch.h>)  // for Arrow structs (GDAL >= 3.6)
+    #include <ogr_recordbatch.h>
 #endif
+
+#include "rcpp_util.h"
 
 // Predeclare some GDAL types until the public header is included
 #ifndef GDAL_H_INCLUDED
-    #ifndef SRC_GDALRASTER_H_
+    #ifndef GDALRASTER_H_
         typedef void *GDALDatasetH;
         typedef enum {GA_ReadOnly = 0, GA_Update = 1} GDALAccess;
     #endif
@@ -185,7 +187,7 @@ class GDALVector {
             const std::map<R_xlen_t, int> &map_flds,
             const std::map<R_xlen_t, int> &map_geom_flds) const;
 
-#if __has_include("ogr_recordbatch.h")
+#if __has_include(<ogr_recordbatch.h>)
     int arrow_get_schema(struct ArrowSchema* out);
     int arrow_get_next(struct ArrowArray* out);
     const char* arrow_get_last_error();
@@ -213,7 +215,7 @@ class GDALVector {
     OGRLayerH m_hLayer {nullptr};
     bool m_shared {false};
     int64_t m_last_write_fid {NA_INTEGER64};
-#if __has_include("ogr_recordbatch.h")
+#if __has_include(<ogr_recordbatch.h>)
     struct ArrowArrayStream m_stream;
     std::vector<SEXP> m_stream_xptrs {};
 #endif
@@ -222,4 +224,4 @@ class GDALVector {
 // cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(GDALVector)
 
-#endif  // SRC_GDALVECTOR_H_
+#endif  // GDALVECTOR_H_

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -6,16 +6,15 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_GEOM_API_H_
-#define SRC_GEOM_API_H_
-
-#include <string>
-#include <vector>
+#ifndef GEOM_API_H_
+#define GEOM_API_H_
 
 #include <Rcpp.h>
 
-#include "ogr_geometry.h"
+#include <ogr_geometry.h>
 
+#include <string>
+#include <vector>
 
 std::vector<int> getGEOSVersion();
 bool has_geos();  // GDAL built against GEOS is required at gdalraster 1.10
@@ -161,4 +160,4 @@ OGRwkbGeometryType getTargetGeomType(OGRwkbGeometryType geom_type,
                                      bool convert_to_linear,
                                      bool promote_to_multi);
 
-#endif  // SRC_GEOM_API_H_
+#endif  // GEOM_API_H_

--- a/src/ogr_util.cpp
+++ b/src/ogr_util.cpp
@@ -3,18 +3,18 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
+#include <cpl_port.h>
+#include <cpl_error.h>
+#include <cpl_string.h>
+#include <cpl_time.h>
+#include <ogr_srs_api.h>
+
 #include <cstdint>
+#include <string>
 #include <vector>
 
-#include "gdal.h"
-#include "cpl_port.h"
-#include "cpl_error.h"
-#include "cpl_string.h"
-#include "cpl_time.h"
-#include "ogr_srs_api.h"
-
-#include "gdalraster.h"
 #include "ogr_util.h"
+#include "gdalraster.h"
 
 
 OGRwkbGeometryType getWkbGeomType_(const std::string &geom_type) {
@@ -667,7 +667,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
             char *pszFailureReason = nullptr;
             ret = GDALDatasetAddFieldDomain(hDS, hFldDom, &pszFailureReason);
             if (pszFailureReason != nullptr) {
-                Rcpp::Rcout << pszFailureReason << std::endl;
+                Rcpp::Rcout << pszFailureReason << "\n";
                 VSIFree(pszFailureReason);
             }
             OGR_FldDomain_Destroy(hFldDom);
@@ -804,7 +804,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 ret = GDALDatasetAddFieldDomain(hDS, hFldDom,
                                                 &pszFailureReason);
                 if (pszFailureReason != nullptr) {
-                    Rcpp::Rcout << pszFailureReason << std::endl;
+                    Rcpp::Rcout << pszFailureReason << "\n";
                     VSIFree(pszFailureReason);
                 }
                 OGR_FldDomain_Destroy(hFldDom);
@@ -908,7 +908,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
                 ret = GDALDatasetAddFieldDomain(hDS, hFldDom,
                                                 &pszFailureReason);
                 if (pszFailureReason != nullptr) {
-                    Rcpp::Rcout << pszFailureReason << std::endl;
+                    Rcpp::Rcout << pszFailureReason << "\n";
                     VSIFree(pszFailureReason);
                 }
                 OGR_FldDomain_Destroy(hFldDom);
@@ -918,8 +918,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
         else {
             GDALReleaseDataset(hDS);
             if (eFieldType == OFTDateTime) {
-                Rcpp::Rcout << "use '$type' RangeDateTime for OFTDateTime"
-                    << std::endl;
+                Rcpp::Rcout << "use '$type' RangeDateTime for OFTDateTime\n";
             }
             Rcpp::stop(
                 "'$field_type' must be OFTInteger, OFTInteger64 or OFTReal");
@@ -1059,7 +1058,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
             char *pszFailureReason = nullptr;
             ret = GDALDatasetAddFieldDomain(hDS, hFldDom, &pszFailureReason);
             if (pszFailureReason != nullptr) {
-                Rcpp::Rcout << pszFailureReason << std::endl;
+                Rcpp::Rcout << pszFailureReason << "\n";
                 VSIFree(pszFailureReason);
             }
             OGR_FldDomain_Destroy(hFldDom);
@@ -1101,7 +1100,7 @@ bool ogr_ds_add_field_domain(const std::string &dsn,
             char *pszFailureReason = nullptr;
             ret = GDALDatasetAddFieldDomain(hDS, hFldDom, &pszFailureReason);
             if (pszFailureReason != nullptr) {
-                Rcpp::Rcout << pszFailureReason << std::endl;
+                Rcpp::Rcout << pszFailureReason << "\n";
                 VSIFree(pszFailureReason);
             }
             OGR_FldDomain_Destroy(hFldDom);
@@ -1244,7 +1243,7 @@ OGRLayerH CreateLayer_(GDALDatasetH hDS, const std::string &layer,
             }
         }
         if (!has_geom_fld_defn)
-            Rcpp::stop("'layer_defn' does not have a geometry field definition");
+            Rcpp::stop("'layer_defn' does not have a geom field definition");
     }
 
     OGRwkbGeometryType eGeomType = getWkbGeomType_(geom_type_in);

--- a/src/ogr_util.h
+++ b/src/ogr_util.h
@@ -3,14 +3,18 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_OGR_UTIL_H_
-#define SRC_OGR_UTIL_H_
+#ifndef OGR_UTIL_H_
+#define OGR_UTIL_H_
+
+#include <gdal.h>
+
+#include <Rcpp.h>
 
 #include <map>
 #include <string>
-#include "rcpp_util.h"
 
 #include "gdalvector.h"
+#include "rcpp_util.h"
 
 #ifdef GDAL_H_INCLUDED
 // map OGRwkbGeometryType enum to string names for use in R
@@ -241,4 +245,4 @@ SEXP ogr_execute_sql(const std::string &dsn, const std::string &sql,
                      const std::string &spatial_filter,
                      const std::string &dialect);
 
-#endif  // SRC_OGR_UTIL_H_
+#endif  // OGR_UTIL_H_

--- a/src/progress_r.cpp
+++ b/src/progress_r.cpp
@@ -25,6 +25,7 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#include <algorithm>
 #include <cmath>
 #include "gdalraster.h"
 

--- a/src/rcpp_util.cpp
+++ b/src/rcpp_util.cpp
@@ -5,6 +5,9 @@
 
 #include "rcpp_util.h"
 
+#include <algorithm>
+#include <string>
+
 // convert data frame to numeric matrix in Rcpp
 Rcpp::NumericMatrix df_to_matrix_(const Rcpp::DataFrame &df) {
     Rcpp::NumericMatrix m = Rcpp::no_init(df.nrows(), df.size());

--- a/src/rcpp_util.h
+++ b/src/rcpp_util.h
@@ -3,26 +3,30 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_RCPP_UTIL_H_
-#define SRC_RCPP_UTIL_H_
-
-#include <limits.h>
+#ifndef RCPP_UTIL_H_
+#define RCPP_UTIL_H_
 
 #include <Rcpp.h>
 #include <RcppInt64>
 
 #include <algorithm>
-#include <cctype>
 #include <cstdint>
+#include <limits>
 #include <string>
 
-constexpr int64_t MAX_INT_AS_R_NUMERIC = 9007199254740991;
+constexpr int64_t MAX_INT_AS_R_NUMERIC_ = 9007199254740991;
 
-// as defined in the bit64 package src/integer64.h
-#define NA_INTEGER64 LLONG_MIN
-#define ISNA_INTEGER64(X)((X) == NA_INTEGER64)
-#define MIN_INTEGER64 LLONG_MIN+1
-#define MAX_INTEGER64 LLONG_MAX
+// as defined in the bit64 package src/integer64.h:
+// #define NA_INTEGER64 LLONG_MIN
+// #define ISNA_INTEGER64(X)((X) == NA_INTEGER64)
+// #define MIN_INTEGER64 LLONG_MIN+1
+// #define MAX_INTEGER64 LLONG_MAX
+// replaced here with:
+constexpr int64_t NA_INTEGER64 = std::numeric_limits<int64_t>::min();
+constexpr bool ISNA_INTEGER64(int64_t x) {return (x == NA_INTEGER64);}
+constexpr int64_t MIN_INTEGER64 = std::numeric_limits<int64_t>::min() + 1;
+constexpr int64_t MAX_INTEGER64 = std::numeric_limits<int64_t>::max();
+
 
 Rcpp::NumericMatrix df_to_matrix_(const Rcpp::DataFrame &df);
 Rcpp::IntegerMatrix df_to_int_matrix_(const Rcpp::DataFrame &df);
@@ -67,4 +71,4 @@ struct _ci_less {
     }
 };
 
-#endif  // SRC_RCPP_UTIL_H_
+#endif  // RCPP_UTIL_H_

--- a/src/running_stats.cpp
+++ b/src/running_stats.cpp
@@ -97,8 +97,8 @@ double RunningStats::get_sd() const {
 }
 
 void RunningStats::show() const {
-    Rcpp::Rcout << "C++ object of class RunningStats" << std::endl;
-    Rcpp::Rcout << " Number of values: " << get_count() << std::endl;
+    Rcpp::Rcout << "C++ object of class RunningStats\n";
+    Rcpp::Rcout << " Number of values: " << get_count() << "\n";
 }
 
 RCPP_MODULE(mod_running_stats) {

--- a/src/running_stats.h
+++ b/src/running_stats.h
@@ -4,11 +4,12 @@
    Also tracks the min, max, sum and count.
    Chris Toney <chris.toney at usda.gov> */
 
-#ifndef SRC_RUNNING_STATS_H_
-#define SRC_RUNNING_STATS_H_
+#ifndef RUNNING_STATS_H_
+#define RUNNING_STATS_H_
+
+#include <Rcpp.h>
 
 #include <cstdint>
-#include <Rcpp.h>
 
 class RunningStats {
  public:
@@ -39,4 +40,4 @@ class RunningStats {
 // cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(RunningStats)
 
-#endif  // SRC_RUNNING_STATS_H_
+#endif  // RUNNING_STATS_H_

--- a/src/srs_api.cpp
+++ b/src/srs_api.cpp
@@ -5,17 +5,17 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#include "srs_api.h"
+#include <cpl_port.h>
+#include <cpl_conv.h>
+#include <ogr_srs_api.h>
+#include <ogr_spatialref.h>
+#include <ogrsf_frmts.h>
 
+#include <string>
 #include <vector>
 
+#include "srs_api.h"
 #include "transform.h"
-
-#include "cpl_port.h"
-#include "cpl_conv.h"
-#include "ogr_srs_api.h"
-#include "ogr_spatialref.h"
-#include "ogrsf_frmts.h"
 
 
 //' Convert spatial reference definitions to OGC WKT or PROJJSON
@@ -477,7 +477,7 @@ SEXP srs_find_epsg(const std::string &srs, bool all_matches = false) {
         if (!all_matches) {
             if (panConfidence[i] != 100) {
                 Rcpp::Rcout << "confidence in this match: " <<
-                        panConfidence[i] << "%" << std::endl;
+                    panConfidence[i] << "%" << "\n";
             }
             if (pszAuthorityName && pszAuthorityCode) {
                 identified_code = pszAuthorityName;

--- a/src/srs_api.h
+++ b/src/srs_api.h
@@ -5,8 +5,8 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_SRS_API_H_
-#define SRC_SRS_API_H_
+#ifndef SRS_API_H_
+#define SRS_API_H_
 
 #include <Rcpp.h>
 #include <string>
@@ -36,4 +36,4 @@ double srs_get_coord_epoch(const std::string &srs);
 int srs_get_utm_zone(const std::string &srs);
 std::string srs_get_axis_mapping_strategy(const std::string &srs);
 
-#endif  // SRC_SRS_API_H_
+#endif  // SRS_API_H_

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -5,9 +5,12 @@
 
 #include "transform.h"
 
-#include "ogr_core.h"
-#include "ogr_srs_api.h"
-#include "ogr_spatialref.h"
+#include <ogr_core.h>
+#include <ogr_srs_api.h>
+#include <ogr_spatialref.h>
+
+#include <string>
+#include <vector>
 
 #include "gdalraster.h"
 #include "srs_api.h"

--- a/src/transform.h
+++ b/src/transform.h
@@ -3,8 +3,10 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
-#ifndef SRC_TRANSFORM_H_
-#define SRC_TRANSFORM_H_
+#ifndef TRANSFORM_H_
+#define TRANSFORM_H_
+
+#include <Rcpp.h>
 
 #include <string>
 #include <vector>
@@ -31,4 +33,4 @@ SEXP transform_bounds(const Rcpp::RObject &bbox,
                       int densify_pts,
                       bool traditional_gis_order);
 
-#endif  // SRC_TRANSFORM_H_
+#endif  // TRANSFORM_H_

--- a/src/vsifile.cpp
+++ b/src/vsifile.cpp
@@ -4,14 +4,18 @@
    Copyright (c) 2023-2025 gdalraster authors
 */
 
+#include "vsifile.h"
+
+#include <cpl_port.h>
+#include <cpl_conv.h>
+
 #include <cstdlib>
 #include <limits>
+#include <string>
 #include <vector>
 
-#include "cpl_port.h"
-#include "cpl_conv.h"
 #include "gdalraster.h"
-#include "vsifile.h"
+#include "rcpp_util.h"
 
 constexpr uint64_t VSI_L_OFFSET_MAX_R = 9223372036854775807;
 
@@ -145,7 +149,7 @@ SEXP VSIFile::read(Rcpp::NumericVector nbytes) {
         nbytes_in = static_cast<size_t>(Rcpp::fromInteger64(nbytes[0]));
     }
     else {
-        if (nbytes[0] > static_cast<double>(MAX_INT_AS_R_NUMERIC))
+        if (nbytes[0] > static_cast<double>(MAX_INT_AS_R_NUMERIC_))
             Rcpp::stop("'nbytes' given as type double is out of range");
         else
             nbytes_in = static_cast<size_t>(nbytes[0]);
@@ -292,9 +296,9 @@ int VSIFile::set_access(std::string access) {
 }
 
 void VSIFile::show() const {
-    Rcpp::Rcout << "C++ object of class VSIFile" << std::endl;
-    Rcpp::Rcout << " Filename : " << get_filename() << std::endl;
-    Rcpp::Rcout << " Access   : " << get_access() << std::endl;
+    Rcpp::Rcout << "C++ object of class VSIFile\n";
+    Rcpp::Rcout << " Filename : " << get_filename() << "\n";
+    Rcpp::Rcout << " Access   : " << get_access() << "\n";
 }
 
 RCPP_MODULE(mod_VSIFile) {

--- a/src/vsifile.h
+++ b/src/vsifile.h
@@ -22,15 +22,17 @@
     used with the interface here is 9223372036854775807.
 */
 
-#ifndef SRC_VSIFILE_H_
-#define SRC_VSIFILE_H_
+#ifndef VSIFILE_H_
+#define VSIFILE_H_
+
+#include <Rcpp.h>
+#include <RcppInt64>
+
+#include <cpl_vsi.h>
 
 #include <cstdint>
 #include <string>
-#include "Rcpp.h"
-#include "RcppInt64"
 
-#include "cpl_vsi.h"
 
 class VSIFile {
  public:
@@ -68,4 +70,4 @@ class VSIFile {
 // cppcheck-suppress unknownMacro
 RCPP_EXPOSED_CLASS(VSIFile)
 
-#endif  // SRC_VSIFILE_H_
+#endif  // VSIFILE_H_


### PR DESCRIPTION
* `#include <cstdint>` in gdalraster.cpp and remove `#include <limits>` as no longer needed
* remove C-style header <limits.h> and use `std::numeric_limits` instead in "rcpp_util.h"
* in  "rcpp_util.h", replace defines from the `bit64` package's src/integer64.h with `constexpr` defined using `std::numeric_limits<int64_t>` for the `integer64` constants (e.g., `NA_INTEGER64`)
* make include directive syntax consistent throughout, mainly some library includes needed angle brackets instead of double quotes
* add some missing includes indicated by `cpplint`, and some rearranging
* update header guard naming style for `cpplint`
* shorten some line lengths that were >80 characters