### PR TITLE
class GDALRaster: add a constructor with allowed_drivers argument

### DIFF
--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -30,6 +30,8 @@
 #' specifying dataset open options.
 #' @param shared Logical. `FALSE` to open the dataset without using shared
 #' mode. Default is `TRUE` (see Note).
+#' @param allowed_drivers Optional character vector of driver short names that
+#' must be considered. By default, all known raster drivers are considered.
 #' @returns An object of class `GDALRaster`, which contains a pointer to the
 #' opened dataset.
 #' Class methods that operate on the dataset are described in Details, along
@@ -48,6 +50,8 @@
 #' ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
 #' # to open without using shared mode:
 #' new(GDALRaster, filename, read_only, open_options, shared = FALSE)
+#' # to specify certain allowed driver(s):
+#' new(GDALRaster, filename, read_only, open_options, shared, allowed_drivers)
 #'
 #' ## Read/write fields (per-object settings)
 #' ds$infoOptions
@@ -156,6 +160,12 @@
 #' Alternate constructor for specifying the `shared` mode for dataset opening.
 #' The `shared` argument defaults to `TRUE` but can be set to `FALSE` with this
 #' constructor (see Note).
+#' All arguments are required with this form of the constructor, but
+#' `open_options` can be `NULL`. Returns an object of class `GDALRaster`.
+#'
+#' \code{new(GDALRaster, filename, read_only, open_options, shared, allowed_drivers)}\cr
+#' Alternate constructor for specifying the driver(s) allowed for dataset
+#' opening as a character vector of driver short names.
 #' All arguments are required with this form of the constructor, but
 #' `open_options` can be `NULL`. Returns an object of class `GDALRaster`.
 #'

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -23,6 +23,9 @@ specifying dataset open options.}
 
 \item{shared}{Logical. \code{FALSE} to open the dataset without using shared
 mode. Default is \code{TRUE} (see Note).}
+
+\item{allowed_drivers}{Optional character vector of driver short names that
+must be considered. By default, all known raster drivers are considered.}
 }
 \value{
 An object of class \code{GDALRaster}, which contains a pointer to the
@@ -78,6 +81,8 @@ ds <- new(GDALRaster, filename, read_only = FALSE)
 ds <- new(GDALRaster, filename, read_only = TRUE|FALSE, open_options)
 # to open without using shared mode:
 new(GDALRaster, filename, read_only, open_options, shared = FALSE)
+# to specify certain allowed driver(s):
+new(GDALRaster, filename, read_only, open_options, shared, allowed_drivers)
 
 ## Read/write fields (per-object settings)
 ds$infoOptions
@@ -189,6 +194,12 @@ Returns an object of class \code{GDALRaster}.
 Alternate constructor for specifying the \code{shared} mode for dataset opening.
 The \code{shared} argument defaults to \code{TRUE} but can be set to \code{FALSE} with this
 constructor (see Note).
+All arguments are required with this form of the constructor, but
+\code{open_options} can be \code{NULL}. Returns an object of class \code{GDALRaster}.
+
+\code{new(GDALRaster, filename, read_only, open_options, shared, allowed_drivers)}\cr
+Alternate constructor for specifying the driver(s) allowed for dataset
+opening as a character vector of driver short names.
 All arguments are required with this form of the constructor, but
 \code{open_options} can be \code{NULL}. Returns an object of class \code{GDALRaster}.
 }

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -87,6 +87,9 @@ class GDALRaster {
                bool read_only,
                const Rcpp::Nullable<Rcpp::CharacterVector> &open_options,
                bool shared);
+    GDALRaster(const Rcpp::CharacterVector &filename, bool read_only,
+               const Rcpp::Nullable<Rcpp::CharacterVector> &open_options,
+               bool shared, const Rcpp::CharacterVector &allowed_drivers);
     ~GDALRaster();
 
     // read/write fields exposed to R
@@ -213,8 +216,9 @@ class GDALRaster {
 
  private:
     std::string m_fname {};
-    Rcpp::CharacterVector m_open_options {};
+    Rcpp::CharacterVector m_open_options;
     bool m_shared;
+    Rcpp::CharacterVector m_allowed_drivers;
     GDALDatasetH m_hDataset {nullptr};
     GDALAccess m_eAccess {GA_ReadOnly};
 };

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -1,11 +1,17 @@
 # Tests for src/gdalraster.cpp
 test_that("class constructors work as expected", {
-    # TODO
+    # TODO: constructors are tested throughout, but add systematic tests here
     # ...
 
     # not recognized as being in a supported file format
     f <- system.file("extdata/doctype.xml", package="gdalraster")
     expect_error(ds <- new(GDALRaster, f))
+
+    # allowed drivers
+    evt_file <- system.file("extdata/storml_evt.tif", package="gdalraster")
+    expect_no_error(ds <- new(GDALRaster, evt_file, TRUE, NULL, TRUE, "GTiff"))
+    ds$close()
+    expect_error(ds <- new(GDALRaster, evt_file, TRUE, NULL, TRUE, "VRT"))
 })
 
 test_that("info() prints output to the console", {


### PR DESCRIPTION
Alternate constructor for specifying the driver(s) allowed for dataset opening as a character vector of driver short names.