### PR TITLE
Add g_geom_count() and g_get_geom()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2290,6 +2290,16 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_geom_count <- function(geom, quiet = FALSE) {
+    .Call(`_gdalraster_g_geom_count`, geom, quiet)
+}
+
+#' @noRd
+.g_get_geom <- function(container, sub_geom_idx, as_iso, byte_order) {
+    .Call(`_gdalraster_g_get_geom`, container, sub_geom_idx, as_iso, byte_order)
+}
+
+#' @noRd
 .g_is_valid <- function(geom, quiet = FALSE) {
     .Call(`_gdalraster_g_is_valid`, geom, quiet)
 }

--- a/R/geom.R
+++ b/R/geom.R
@@ -259,9 +259,9 @@ bbox_transform <- function(bbox, srs_from, srs_to,
 #'
 #' @note
 #' With `as_iso = FALSE` (the default), geometries are exported as extended
-#' dimension (Z) WKB/WKT for types Point, LineString, Polygon, MultiPoint,
-#' MultiLineString, MultiPolygon and GeometryCollection. For other geometry
-#' types, it is equivalent to ISO.
+#' dimension (Z) WKB/WKT for types `Point`, `LineString`, `Polygon`,
+#' `MultiPoint`, `MultiLineString`, `MultiPolygon` and `GeometryCollection`.
+#' For other geometry types, it is equivalent to ISO.
 #'
 #' When the return value is a list of WKB raw vectors, an element in the
 #' returned list will contain `NULL` (and a warning emitted) if the
@@ -322,7 +322,7 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
     }
 }
 
-#' Create WKB/WKT geometries from vertices, and add sub-geometries
+#' Create WKB/WKT geometries from vertices, and add/get sub-geometries
 #'
 #' These functions create WKB/WKT geometries from input vertices, and build
 #' container geometry types from sub-geometries.
@@ -332,19 +332,24 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
 #'
 #' `g_create()` creates a geometry object from the given point(s) and returns
 #' a raw vector of WKB (the default) or a character string of WKT. Currently
-#' supports creating Point, MultiPoint, LineString, Polygon, and
-#' GeometryCollection.
-#' If multiple input points are given for creating Point type, then multiple
+#' supports creating `Point`, `MultiPoint`, `LineString`, `Polygon`, and
+#' `GeometryCollection.`
+#' If multiple input points are given for creating `Point` type, then multiple
 #' geometries will be returned as a list of WKB raw vectors, or character
 #' vector of WKT strings (if `as_wkb = FALSE`). Otherwise, a single geometry
-#' is created from the input points. Only an empty GeometryCollection can be
+#' is created from the input points. Only an empty `GeometryCollection` can be
 #' created with this function, for subsequent use with `g_add_geom()`.
 #'
 #' `g_add_geom()` adds a geometry to a geometry container, e.g.,
-#' Polygon to Polygon (to add an interior ring), Point to MultiPoint,
-#' LineString to MultiLineString, Polygon to MultiPolygon, or mixed
-#' geometry types to a GeometryCollection. Returns a new geometry, i.e,
+#' `Polygon` to `Polygon` (to add an interior ring), `Point` to `MultiPoint`,
+#' `LineString` to `MultiLineString`, `Polygon` to `MultiPolygon`, or mixed
+#' geometry types to a `GeometryCollection`. Returns a new geometry, i.e,
 #' the container geometry is not modified.
+#'
+#' `g_get_geom()` fetches a geometry from a geometry container (1-based
+#' indexing). For a polygon, requesting the first sub-geometry returns the
+#' exterior ring (`sub_geom_idx = 1`), and the interior rings are returned for
+#' `sub_geom_idx > 1`.
 #'
 #' @param geom_type Character string (case-insensitive), one of `"POINT"`,
 #' `"MULTIPOINT"`, `"LINESTRING"`, `"POLYGON"` (see Note) or
@@ -363,6 +368,8 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
 #' @param sub_geom Either a raw vector of WKB or a character string of WKT.
 #' @param container Either a raw vector of WKB or a character string of WKT for
 #' a container geometry type.
+#' @param sub_geom_idx An integer value giving the 1-based index of a
+#' sub-geometry (numeric values will be coerced to integer by truncation).
 #' @return
 #' A geometry as WKB raw vector by default, or a WKT string if
 #' `as_wkb = FALSE`. In the case of multiple input points for creating Point
@@ -370,15 +377,15 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
 #' will be returned.
 #'
 #' @note
-#' A POLYGON can be created for a single ring which will be the
-#' exterior ring. Additional POLYGONs can be created and added to an
-#' existing POLYGON with `g_add_geom()`. These will become interior rings.
+#' A `POLYGON` can be created for a single ring which will be the
+#' exterior ring. Additional `POLYGON`s can be created and added to an
+#' existing `POLYGON` with `g_add_geom()`. These will become interior rings.
 #' Alternatively, an empty polygon can be created with `g_create("POLYGON")`,
-#' followed by creation and addition of POLYGONs as subgeometries. In that
-#' case, the first added POLYGON will be the exterior ring. The next ones will
+#' followed by creation and addition of `POLYGON`s as sub-geometries. In that
+#' case, the first added `POLYGON` will be the exterior ring. The next ones will
 #' be the interior rings.
 #'
-#' Only an empty GeometryCollection can be created with `g_create()`, which
+#' Only an empty `GeometryCollection` can be created with `g_create()`, which
 #' can then be used as a container with `g_add_geom()`. If given, input points
 #' will be ignored by `g_create()` if `geom_type = "GEOMETRYCOLLECTION"`.
 #'
@@ -393,7 +400,7 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
 #' g_create("POINT", c(1, 2)) |> g_wk2wk()
 #' g_create("POINT", c(1, 2), as_wkb = FALSE) |> g_wk2wk()
 #'
-#' # create multipoint from a matrix of xyz points
+#' # create MultiPoint from a matrix of xyz points
 #' x <- c(9, 1)
 #' y <- c(1, 9)
 #' z <- c(0, 10)
@@ -402,17 +409,23 @@ g_wk2wk <- function(geom, as_iso = FALSE, byte_order = "LSB") {
 #' g_wk2wk(mp)
 #' g_wk2wk(mp, as_iso = TRUE)
 #'
-#' # create an empty container and add subgeometries
+#' # create an empty container and add sub-geometries
 #' mp2 <- g_create("MULTIPOINT")
 #' mp2 <- g_create("POINT", c(11, 2)) |> g_add_geom(mp2)
 #' mp2 <- g_create("POINT", c(12, 3)) |> g_add_geom(mp2)
 #' g_wk2wk(mp2)
 #'
-#' # plot WKT strings or a list of WKB raw vectors with wk::wk_plot()
-#' pts <- c(0, 0, 3, 0, 3, 4, 0, 0)
+#' # get sub-geometry from container
+#' g_get_geom(mp2, 2, as_wkb = FALSE)
+#'
+#' # plot WKT strings or a list of WKB raw vectors
+#' pts <- c(0, 0,
+#'          3, 0,
+#'          3, 4,
+#'          0, 0)
 #' m <- matrix(pts, ncol = 2, byrow = TRUE)
-#' g <- g_create("POLYGON", m, as_wkb = FALSE)
-#' wk::wkt(g) |> wk::wk_plot()
+#' (g <- g_create("POLYGON", m, as_wkb = FALSE))
+#' plot_geom(g)
 #' @export
 g_create <- function(geom_type, pts = NULL, as_wkb = TRUE, as_iso = FALSE,
                      byte_order = "LSB") {
@@ -465,6 +478,8 @@ g_create <- function(geom_type, pts = NULL, as_wkb = TRUE, as_iso = FALSE,
 g_add_geom <- function(sub_geom, container, as_wkb = TRUE, as_iso = FALSE,
                        byte_order = "LSB") {
 
+    if ((is.character(sub_geom) || is.list(sub_geom)) && length(sub_geom) > 1)
+        stop("'sub_geom' must be a single geometry", call. = FALSE)
     if (is.character(sub_geom))
         sub_geom <- g_wk2wk(sub_geom)
     if (!is.raw(sub_geom)) {
@@ -472,6 +487,11 @@ g_add_geom <- function(sub_geom, container, as_wkb = TRUE, as_iso = FALSE,
              call. = FALSE)
     }
 
+    if ((is.character(container) || is.list(container))
+        && length(container) > 1) {
+
+        stop("'sub_geom' must be a single geometry", call. = FALSE)
+    }
     if (is.character(container))
         container <- g_wk2wk(container)
     if (!is.raw(container)) {
@@ -507,6 +527,53 @@ g_add_geom <- function(sub_geom, container, as_wkb = TRUE, as_iso = FALSE,
 
 }
 
+#' @name g_factory
+#' @export
+g_get_geom <- function(container, sub_geom_idx, as_wkb = TRUE, as_iso = FALSE,
+                       byte_order = "LSB") {
+
+    if ((is.character(container) || is.list(container))
+        && length(container) > 1) {
+
+        stop("'sub_geom' must be a single geometry", call. = FALSE)
+    }
+    if (is.character(container))
+        container <- g_wk2wk(container)
+    if (!is.raw(container)) {
+        stop("'container' must be a raw vector or character string",
+             call. = FALSE)
+    }
+
+    if (!(is.numeric(sub_geom_idx) && length(sub_geom_idx) == 1))
+        stop("'sub_geom_idx' must be a single numeric value", call. = FALSE)
+
+    # as_wkb
+    if (is.null(as_wkb))
+        as_wkb <- TRUE
+    if (!is.logical(as_wkb) || length(as_wkb) > 1)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
+    # as_iso
+    if (is.null(as_iso))
+        as_iso <- FALSE
+    if (!is.logical(as_iso) || length(as_iso) > 1)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
+    # byte_order
+    if (is.null(byte_order))
+        byte_order <- "LSB"
+    if (!is.character(byte_order) || length(byte_order) > 1)
+        stop("'byte_order' must be a character string", call. = FALSE)
+    byte_order <- toupper(byte_order)
+    if (byte_order != "LSB" && byte_order != "MSB")
+        stop("invalid 'byte_order'", call. = FALSE)
+
+    wkb <- .g_get_geom(container, sub_geom_idx - 1, as_iso, byte_order)
+
+    if (as_wkb)
+        return(wkb)
+    else
+        return(g_wk2wk(wkb, as_iso))
+}
+
 #' Obtain information about WKB/WKT geometries
 #'
 #' These functions return information about WKB/WKT geometries. The input
@@ -539,6 +606,12 @@ g_add_geom <- function(sub_geom, container, as_wkb = TRUE, as_iso = FALSE,
 #' `g_summary()` returns text summaries of WKB/WKT geometries in a
 #' character vector of the same length as the number of input
 #' geometries. Requires GDAL >= 3.7.
+#'
+#' `g_geom_count()` returns the number of elements in a geometry or number of
+#' geometries in container. Only geometries of type `Polygon[25D]`,
+#' `MultiPoint[25D]`, `MultiLineString[25D]`, `MultiPolygon[25D]` or
+#' `GeometryCollection[25D]` may return a valid value. Other geometry types will
+#' silently return `0`.
 #'
 #' @param geom Either a raw vector of WKB or list of raw vectors, or a
 #' character vector containing one or more WKT strings.
@@ -582,6 +655,8 @@ g_add_geom <- function(sub_geom, container, as_wkb = TRUE, as_iso = FALSE,
 #'   feat_set <- lyr$fetch(5)
 #'   g_summary(feat_set$geom) |> print()
 #' }
+#'
+#' g_geom_count(feat$geom)
 #'
 #' lyr$close()
 #' @export
@@ -770,6 +845,34 @@ g_summary <- function(geom, quiet = FALSE) {
             ret <- .g_summary(g_wk2wk(geom), quiet)
         } else {
             ret <- sapply(g_wk2wk(geom), .g_summary, quiet)
+        }
+    } else {
+        stop("'geom' must be a character vector, raw vector, or list",
+             call. = FALSE)
+    }
+
+    return(ret)
+}
+
+#' @name g_query
+#' @export
+g_geom_count <- function(geom, quiet = FALSE) {
+    # quiet
+    if (is.null(quiet))
+        quiet <- FALSE
+    if (!is.logical(quiet) || length(quiet) > 1)
+        stop("'quiet' must be a single logical value", call. = FALSE)
+
+    ret <- NULL
+    if (.is_raw_or_null(geom)) {
+        ret <- .g_geom_count(geom, quiet)
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
+        ret <- sapply(geom, .g_geom_count, quiet)
+    } else if (is.character(geom)) {
+        if (length(geom) == 1) {
+            ret <- .g_geom_count(g_wk2wk(geom), quiet)
+        } else {
+            ret <- sapply(g_wk2wk(geom), .g_geom_count, quiet)
         }
     } else {
         stop("'geom' must be a character vector, raw vector, or list",
@@ -2525,13 +2628,13 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
 #'
 #' `g_boundary()` computes the "boundary" as defined by the DE9IM
 #' (\url{https://en.wikipedia.org/wiki/DE-9IM}):
-#' * the boundary of a Polygon is the set of linear rings dividing the
+#' * the boundary of a `Polygon` is the set of linear rings dividing the
 #' exterior from the interior
-#' * the boundary of a LineString is the two end points
-#' * the boundary of a Point/MultiPoint is defined as empty
+#' * the boundary of a `LineString` is the two end points
+#' * the boundary of a `Point`/`MultiPoint` is defined as empty
 #'
 #' `g_buffer()` always returns a polygonal result. The negative or
-#' zero-distance buffer of lines and points is always an empty Polygon.
+#' zero-distance buffer of lines and points is always an empty `Polygon`.
 #'
 #' `g_convex_hull()` uses the Graham Scan algorithm.
 #'
@@ -2541,7 +2644,7 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
 #' the same dimension and number of components as the input. The simplification
 #' uses a maximum distance difference algorithm similar to the one used in the
 #' Douglas-Peucker algorithm. In particular, if the input is an areal geometry
-#' (Polygon or MultiPolygon), the result has the same number of shells and
+#' (`Polygon` or `MultiPolygon`), the result has the same number of shells and
 #' holes (rings) as the input, in the same order. The result rings touch at no
 #' more than the number of touching point in the input (although they may touch
 #' at fewer points).
@@ -2551,10 +2654,11 @@ g_geodesic_length <- function(geom, srs, traditional_gis_order = TRUE,
 #' guaranteed to remain simple after simplification. Note that in general D-P
 #' does not preserve topology - e.g. polygons can be split, collapse to lines
 #' or disappear, holes can be created or disappear, and lines can cross. To
-#' simplify geometry while preserving topology use TopologyPreservingSimplifier.
-#' (However, using D-P is significantly faster).
+#' simplify geometry while preserving topology use
+#' `TopologyPreservingSimplifier`. (However, using D-P is significantly faster.)
 #'
-#' N.B., `preserve_topology = TRUE` does not preserve boundaries shared between
+#' @note
+#' `preserve_topology = TRUE` does not preserve boundaries shared between
 #' polygons.
 #'
 #' @examples

--- a/man/g_factory.Rd
+++ b/man/g_factory.Rd
@@ -4,7 +4,8 @@
 \alias{g_factory}
 \alias{g_create}
 \alias{g_add_geom}
-\title{Create WKB/WKT geometries from vertices, and add sub-geometries}
+\alias{g_get_geom}
+\title{Create WKB/WKT geometries from vertices, and add/get sub-geometries}
 \usage{
 g_create(
   geom_type,
@@ -17,6 +18,14 @@ g_create(
 g_add_geom(
   sub_geom,
   container,
+  as_wkb = TRUE,
+  as_iso = FALSE,
+  byte_order = "LSB"
+)
+
+g_get_geom(
+  container,
+  sub_geom_idx,
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB"
@@ -46,6 +55,9 @@ WKB. One of \code{"LSB"} (the default) or \code{"MSB"} (uncommon).}
 
 \item{container}{Either a raw vector of WKB or a character string of WKT for
 a container geometry type.}
+
+\item{sub_geom_idx}{An integer value giving the 1-based index of a
+sub-geometry (numeric values will be coerced to integer by truncation).}
 }
 \value{
 A geometry as WKB raw vector by default, or a WKT string if
@@ -62,30 +74,35 @@ These functions use the GEOS library via GDAL headers.
 
 \code{g_create()} creates a geometry object from the given point(s) and returns
 a raw vector of WKB (the default) or a character string of WKT. Currently
-supports creating Point, MultiPoint, LineString, Polygon, and
-GeometryCollection.
-If multiple input points are given for creating Point type, then multiple
+supports creating \code{Point}, \code{MultiPoint}, \code{LineString}, \code{Polygon}, and
+\code{GeometryCollection.}
+If multiple input points are given for creating \code{Point} type, then multiple
 geometries will be returned as a list of WKB raw vectors, or character
 vector of WKT strings (if \code{as_wkb = FALSE}). Otherwise, a single geometry
-is created from the input points. Only an empty GeometryCollection can be
+is created from the input points. Only an empty \code{GeometryCollection} can be
 created with this function, for subsequent use with \code{g_add_geom()}.
 
 \code{g_add_geom()} adds a geometry to a geometry container, e.g.,
-Polygon to Polygon (to add an interior ring), Point to MultiPoint,
-LineString to MultiLineString, Polygon to MultiPolygon, or mixed
-geometry types to a GeometryCollection. Returns a new geometry, i.e,
+\code{Polygon} to \code{Polygon} (to add an interior ring), \code{Point} to \code{MultiPoint},
+\code{LineString} to \code{MultiLineString}, \code{Polygon} to \code{MultiPolygon}, or mixed
+geometry types to a \code{GeometryCollection}. Returns a new geometry, i.e,
 the container geometry is not modified.
+
+\code{g_get_geom()} fetches a geometry from a geometry container (1-based
+indexing). For a polygon, requesting the first sub-geometry returns the
+exterior ring (\code{sub_geom_idx = 1}), and the interior rings are returned for
+\code{sub_geom_idx > 1}.
 }
 \note{
-A POLYGON can be created for a single ring which will be the
-exterior ring. Additional POLYGONs can be created and added to an
-existing POLYGON with \code{g_add_geom()}. These will become interior rings.
+A \code{POLYGON} can be created for a single ring which will be the
+exterior ring. Additional \code{POLYGON}s can be created and added to an
+existing \code{POLYGON} with \code{g_add_geom()}. These will become interior rings.
 Alternatively, an empty polygon can be created with \code{g_create("POLYGON")},
-followed by creation and addition of POLYGONs as subgeometries. In that
-case, the first added POLYGON will be the exterior ring. The next ones will
+followed by creation and addition of \code{POLYGON}s as sub-geometries. In that
+case, the first added \code{POLYGON} will be the exterior ring. The next ones will
 be the interior rings.
 
-Only an empty GeometryCollection can be created with \code{g_create()}, which
+Only an empty \code{GeometryCollection} can be created with \code{g_create()}, which
 can then be used as a container with \code{g_add_geom()}. If given, input points
 will be ignored by \code{g_create()} if \code{geom_type = "GEOMETRYCOLLECTION"}.
 }
@@ -100,7 +117,7 @@ g_create("POINT", c(1, 2), as_wkb = FALSE)
 g_create("POINT", c(1, 2)) |> g_wk2wk()
 g_create("POINT", c(1, 2), as_wkb = FALSE) |> g_wk2wk()
 
-# create multipoint from a matrix of xyz points
+# create MultiPoint from a matrix of xyz points
 x <- c(9, 1)
 y <- c(1, 9)
 z <- c(0, 10)
@@ -109,15 +126,21 @@ mp <- g_create("MULTIPOINT", pts)
 g_wk2wk(mp)
 g_wk2wk(mp, as_iso = TRUE)
 
-# create an empty container and add subgeometries
+# create an empty container and add sub-geometries
 mp2 <- g_create("MULTIPOINT")
 mp2 <- g_create("POINT", c(11, 2)) |> g_add_geom(mp2)
 mp2 <- g_create("POINT", c(12, 3)) |> g_add_geom(mp2)
 g_wk2wk(mp2)
 
-# plot WKT strings or a list of WKB raw vectors with wk::wk_plot()
-pts <- c(0, 0, 3, 0, 3, 4, 0, 0)
+# get sub-geometry from container
+g_get_geom(mp2, 2, as_wkb = FALSE)
+
+# plot WKT strings or a list of WKB raw vectors
+pts <- c(0, 0,
+         3, 0,
+         3, 4,
+         0, 0)
 m <- matrix(pts, ncol = 2, byrow = TRUE)
-g <- g_create("POLYGON", m, as_wkb = FALSE)
-wk::wkt(g) |> wk::wk_plot()
+(g <- g_create("POLYGON", m, as_wkb = FALSE))
+plot_geom(g)
 }

--- a/man/g_query.Rd
+++ b/man/g_query.Rd
@@ -9,6 +9,7 @@
 \alias{g_is_ring}
 \alias{g_name}
 \alias{g_summary}
+\alias{g_geom_count}
 \title{Obtain information about WKB/WKT geometries}
 \usage{
 g_is_empty(geom, quiet = FALSE)
@@ -24,6 +25,8 @@ g_is_ring(geom, quiet = FALSE)
 g_name(geom, quiet = FALSE)
 
 g_summary(geom, quiet = FALSE)
+
+g_geom_count(geom, quiet = FALSE)
 }
 \arguments{
 \item{geom}{Either a raw vector of WKB or list of raw vectors, or a
@@ -62,6 +65,12 @@ vector of the same length as the number of input geometries.
 \code{g_summary()} returns text summaries of WKB/WKT geometries in a
 character vector of the same length as the number of input
 geometries. Requires GDAL >= 3.7.
+
+\code{g_geom_count()} returns the number of elements in a geometry or number of
+geometries in container. Only geometries of type \verb{Polygon[25D]},
+\verb{MultiPoint[25D]}, \verb{MultiLineString[25D]}, \verb{MultiPolygon[25D]} or
+\verb{GeometryCollection[25D]} may return a valid value. Other geometry types will
+silently return \code{0}.
 }
 \examples{
 g1 <- "POLYGON ((0 0, 10 10, 10 0, 0 0))"
@@ -98,6 +107,8 @@ if (gdal_version_num() >= gdal_compute_version(3, 7, 0)) {
   feat_set <- lyr$fetch(5)
   g_summary(feat_set$geom) |> print()
 }
+
+g_geom_count(feat$geom)
 
 lyr$close()
 }

--- a/man/g_unary_op.Rd
+++ b/man/g_unary_op.Rd
@@ -137,14 +137,14 @@ copied here.
 \code{g_boundary()} computes the "boundary" as defined by the DE9IM
 (\url{https://en.wikipedia.org/wiki/DE-9IM}):
 \itemize{
-\item the boundary of a Polygon is the set of linear rings dividing the
+\item the boundary of a \code{Polygon} is the set of linear rings dividing the
 exterior from the interior
-\item the boundary of a LineString is the two end points
-\item the boundary of a Point/MultiPoint is defined as empty
+\item the boundary of a \code{LineString} is the two end points
+\item the boundary of a \code{Point}/\code{MultiPoint} is defined as empty
 }
 
 \code{g_buffer()} always returns a polygonal result. The negative or
-zero-distance buffer of lines and points is always an empty Polygon.
+zero-distance buffer of lines and points is always an empty \code{Polygon}.
 
 \code{g_convex_hull()} uses the Graham Scan algorithm.
 
@@ -155,7 +155,7 @@ Simplifies a geometry, ensuring that the result is a valid geometry having
 the same dimension and number of components as the input. The simplification
 uses a maximum distance difference algorithm similar to the one used in the
 Douglas-Peucker algorithm. In particular, if the input is an areal geometry
-(Polygon or MultiPolygon), the result has the same number of shells and
+(\code{Polygon} or \code{MultiPolygon}), the result has the same number of shells and
 holes (rings) as the input, in the same order. The result rings touch at no
 more than the number of touching point in the input (although they may touch
 at fewer points).
@@ -165,11 +165,11 @@ that any polygonal geometries returned are valid. Simple lines are not
 guaranteed to remain simple after simplification. Note that in general D-P
 does not preserve topology - e.g. polygons can be split, collapse to lines
 or disappear, holes can be created or disappear, and lines can cross. To
-simplify geometry while preserving topology use TopologyPreservingSimplifier.
-(However, using D-P is significantly faster).
+simplify geometry while preserving topology use
+\code{TopologyPreservingSimplifier}. (However, using D-P is significantly faster.)
 }
 
-N.B., \code{preserve_topology = TRUE} does not preserve boundaries shared between
+\code{preserve_topology = TRUE} does not preserve boundaries shared between
 polygons.
 }
 \examples{

--- a/man/g_wk2wk.Rd
+++ b/man/g_wk2wk.Rd
@@ -35,9 +35,9 @@ or a character vector of WKT strings.
 }
 \note{
 With \code{as_iso = FALSE} (the default), geometries are exported as extended
-dimension (Z) WKB/WKT for types Point, LineString, Polygon, MultiPoint,
-MultiLineString, MultiPolygon and GeometryCollection. For other geometry
-types, it is equivalent to ISO.
+dimension (Z) WKB/WKT for types \code{Point}, \code{LineString}, \code{Polygon},
+\code{MultiPoint}, \code{MultiLineString}, \code{MultiPolygon} and \code{GeometryCollection}.
+For other geometry types, it is equivalent to ISO.
 
 When the return value is a list of WKB raw vectors, an element in the
 returned list will contain \code{NULL} (and a warning emitted) if the

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1124,6 +1124,32 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// g_geom_count
+int g_geom_count(const Rcpp::RObject& geom, bool quiet);
+RcppExport SEXP _gdalraster_g_geom_count(SEXP geomSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_geom_count(geom, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
+// g_get_geom
+SEXP g_get_geom(const Rcpp::RawVector& container, int sub_geom_idx, bool as_iso, const std::string& byte_order);
+RcppExport SEXP _gdalraster_g_get_geom(SEXP containerSEXP, SEXP sub_geom_idxSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type container(containerSEXP);
+    Rcpp::traits::input_parameter< int >::type sub_geom_idx(sub_geom_idxSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_get_geom(container, sub_geom_idx, as_iso, byte_order));
+    return rcpp_result_gen;
+END_RCPP
+}
 // g_is_valid
 Rcpp::LogicalVector g_is_valid(const Rcpp::RObject& geom, bool quiet);
 RcppExport SEXP _gdalraster_g_is_valid(SEXP geomSEXP, SEXP quietSEXP) {
@@ -2312,6 +2338,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_wkt_vector2wkb", (DL_FUNC) &_gdalraster_g_wkt_vector2wkb, 3},
     {"_gdalraster_g_create", (DL_FUNC) &_gdalraster_g_create, 4},
     {"_gdalraster_g_add_geom", (DL_FUNC) &_gdalraster_g_add_geom, 4},
+    {"_gdalraster_g_geom_count", (DL_FUNC) &_gdalraster_g_geom_count, 2},
+    {"_gdalraster_g_get_geom", (DL_FUNC) &_gdalraster_g_get_geom, 4},
     {"_gdalraster_g_is_valid", (DL_FUNC) &_gdalraster_g_is_valid, 2},
     {"_gdalraster_g_make_valid", (DL_FUNC) &_gdalraster_g_make_valid, 6},
     {"_gdalraster_g_set_3D", (DL_FUNC) &_gdalraster_g_set_3D, 5},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -41,6 +41,10 @@ Rcpp::RawVector g_add_geom(const Rcpp::RawVector &sub_geom,
                            const Rcpp::RawVector &container,
                            bool as_iso, const std::string &byte_order);
 
+int g_geom_count(const Rcpp::RObject &geom, bool quiet);
+SEXP g_get_geom(const Rcpp::RawVector &container, int sub_geom_idx,
+                bool as_iso, const std::string &byte_order);
+
 Rcpp::LogicalVector g_is_valid(const Rcpp::RObject &geom, bool quiet);
 SEXP g_make_valid(const Rcpp::RObject &geom, const std::string &method,
                   bool keep_collapsed, bool as_iso,


### PR DESCRIPTION
`g_geom_count()` returns the number of elements in a geometry or number of geometries in container. Only geometries of type `Polygon[25D]`, `MultiPoint[25D]`, `MultiLineString[25D]`, `MultiPolygon[25D]` or `GeometryCollection[25D]` may return a valid value. Other geometry types will silently return `0`.

`g_get_geom()` fetches a geometry from a geometry container (1-based indexing). For a polygon, requesting the first sub-geometry returns the exterior ring (`sub_geom_idx = 1`), and the interior rings are returned for `sub_geom_idx > 1`.