### PR TITLE
Add g_unary_union(), wrapper for OGR_G_UnaryUnion()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2448,6 +2448,11 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_unary_union <- function(geom, as_iso, byte_order, quiet) {
+    .Call(`_gdalraster_g_unary_union`, geom, as_iso, byte_order, quiet)
+}
+
+#' @noRd
 .g_intersection <- function(this_geom, other_geom, as_iso = FALSE, byte_order = "LSB", quiet = FALSE) {
     .Call(`_gdalraster_g_intersection`, this_geom, other_geom, as_iso, byte_order, quiet)
 }
@@ -2543,7 +2548,6 @@ bbox_from_wkt <- function(wkt, extend_x = 0, extend_y = 0) {
 #' rectangle in both directions along the y-axis
 #' (results in `ymin = bbox[2] - extend_y`, `ymax = bbox[4] + extend_y`).
 #' @return Character string for an OGC WKT polygon.
-#' `NA` is returned if GDAL was built without the GEOS library.
 #'
 #' @seealso
 #' [bbox_from_wkt()], [g_buffer()]

--- a/man/bbox_to_wkt.Rd
+++ b/man/bbox_to_wkt.Rd
@@ -20,7 +20,6 @@ rectangle in both directions along the y-axis
 }
 \value{
 Character string for an OGC WKT polygon.
-\code{NA} is returned if GDAL was built without the GEOS library.
 }
 \description{
 \code{bbox_to_wkt()} returns a WKT POLYGON string for the given bounding box.

--- a/man/g_unary_op.Rd
+++ b/man/g_unary_op.Rd
@@ -7,6 +7,7 @@
 \alias{g_convex_hull}
 \alias{g_delaunay_triangulation}
 \alias{g_simplify}
+\alias{g_unary_union}
 \title{Unary operations on WKB or WKT geometries}
 \usage{
 g_buffer(
@@ -49,6 +50,14 @@ g_simplify(
   geom,
   tolerance,
   preserve_topology = TRUE,
+  as_wkb = TRUE,
+  as_iso = FALSE,
+  byte_order = "LSB",
+  quiet = FALSE
+)
+
+g_unary_union(
+  geom,
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB",
@@ -128,6 +137,11 @@ in the GDAL API. Requires GEOS >= 3.4.
 \code{g_simplify()} computes a simplified geometry. By default, it simplifies
 the input geometries while preserving topology (see Note). Wrapper of
 \code{OGR_G_Simplify()} / \code{OGR_G_SimplifyPreserveTopology()} in the GDAL API.
+
+\code{g_unary_union()} returns the union of all components of a single geometry.
+Usually used to convert a collection into the smallest set of polygons that
+cover the same area. See \url{https://postgis.net/docs/ST_UnaryUnion.html}
+for more details. Requires GDAL >= 3.7.
 }
 \note{
 Definitions of these operations are given in the GEOS documentation
@@ -187,4 +201,11 @@ g_delaunay_triangulation(g4, as_wkb = FALSE)
 
 g5 <- "LINESTRING(0 0,1 1,10 0)"
 g_simplify(g5, tolerance = 5, as_wkb = FALSE)
+
+# g_unary_union() requires GDAL >= 3.7
+if (gdal_version_num() >= gdal_compute_version(3, 7, 0)) {
+  g6 <- "GEOMETRYCOLLECTION(POINT(0.5 0.5), POLYGON((0 0,0 1,1 1,1 0,0 0)),
+         POLYGON((1 0,1 1,2 1,2 0,1 0)))"
+  g_unary_union(g6, as_wkb = FALSE)
+}
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1499,6 +1499,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// g_unary_union
+SEXP g_unary_union(const Rcpp::RObject& geom, bool as_iso, const std::string& byte_order, bool quiet);
+RcppExport SEXP _gdalraster_g_unary_union(SEXP geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_unary_union(geom, as_iso, byte_order, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
 // g_intersection
 SEXP g_intersection(const Rcpp::RObject& this_geom, const Rcpp::RObject& other_geom, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_intersection(SEXP this_geomSEXP, SEXP other_geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
@@ -2378,6 +2392,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_convex_hull", (DL_FUNC) &_gdalraster_g_convex_hull, 4},
     {"_gdalraster_g_delaunay_triangulation", (DL_FUNC) &_gdalraster_g_delaunay_triangulation, 6},
     {"_gdalraster_g_simplify", (DL_FUNC) &_gdalraster_g_simplify, 6},
+    {"_gdalraster_g_unary_union", (DL_FUNC) &_gdalraster_g_unary_union, 4},
     {"_gdalraster_g_intersection", (DL_FUNC) &_gdalraster_g_intersection, 5},
     {"_gdalraster_g_union", (DL_FUNC) &_gdalraster_g_union, 5},
     {"_gdalraster_g_difference", (DL_FUNC) &_gdalraster_g_difference, 5},

--- a/src/geom_api.cpp
+++ b/src/geom_api.cpp
@@ -649,8 +649,7 @@ Rcpp::LogicalVector g_is_valid(const Rcpp::RObject &geom,
                                bool quiet = false) {
 // Test if the geometry is valid.
 // This function is built on the GEOS library, check it for the definition
-// of the geometry operation. If OGR is built without the GEOS library,
-// this function will always return FALSE.
+// of the geometry operation.
 
     if (geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(geom))
         return Rcpp::LogicalVector::create(NA_LOGICAL);
@@ -689,9 +688,7 @@ SEXP g_make_valid(const Rcpp::RObject &geom,
 // Running OGRGeometryFactory::removeLowerDimensionSubGeoms() as a
 // post-processing step is often desired.
 // This function is built on the GEOS >= 3.8 library, check it for the
-// definition of the geometry operation. If OGR is built without GEOS >= 3.8,
-// this function will return a clone of the input geometry if it is valid, or
-// NULL if it is invalid
+// definition of the geometry operation.
 
     if (geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(geom))
         return R_NilValue;
@@ -1342,8 +1339,7 @@ Rcpp::LogicalVector g_disjoint(const Rcpp::RObject &this_geom,
 // of the input geometries, call g_is_valid() before, otherwise the result
 // might be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return Rcpp::LogicalVector::create(NA_LOGICAL);
@@ -1398,8 +1394,7 @@ Rcpp::LogicalVector g_touches(const Rcpp::RObject &this_geom,
 // of the input geometries, call g_is_valid() before, otherwise the result
 // might be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return Rcpp::LogicalVector::create(NA_LOGICAL);
@@ -1454,8 +1449,7 @@ Rcpp::LogicalVector g_contains(const Rcpp::RObject &this_geom,
 // of the input geometries, call g_is_valid() before, otherwise the result
 // might be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return Rcpp::LogicalVector::create(NA_LOGICAL);
@@ -1510,8 +1504,7 @@ Rcpp::LogicalVector g_within(const Rcpp::RObject &this_geom,
 // of the input geometries, call g_is_valid() before, otherwise the result
 // might be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return Rcpp::LogicalVector::create(NA_LOGICAL);
@@ -1566,8 +1559,7 @@ Rcpp::LogicalVector g_crosses(const Rcpp::RObject &this_geom,
 // of the input geometries, call g_is_valid() before, otherwise the result
 // might be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return Rcpp::LogicalVector::create(NA_LOGICAL);
@@ -1624,8 +1616,7 @@ Rcpp::LogicalVector g_overlaps(const Rcpp::RObject &this_geom,
 // of the input geometries, call g_is_valid() before, otherwise the result
 // might be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return Rcpp::LogicalVector::create(NA_LOGICAL);
@@ -1888,10 +1879,7 @@ SEXP g_delaunay_triangulation(const Rcpp::RObject &geom,
                               bool quiet = false) {
 // Return a Delaunay triangulation of the vertices of the geometry.
 //
-// This function is built on the GEOS library, v3.4 or above. If OGR is built
-// without the GEOS library, this function will always fail, issuing a
-// CPLE_NotSupported error.
-
+// This function is built on the GEOS library, v3.4 or above.
     std::vector<int> geos_ver = getGEOSVersion();
     int geos_maj_ver = geos_ver[0];
     int geos_min_ver = geos_ver[1];
@@ -2044,6 +2032,73 @@ SEXP g_simplify(const Rcpp::RObject &geom, double tolerance,
     return wkb;
 }
 
+//' @noRd
+// [[Rcpp::export(name = ".g_unary_union")]]
+SEXP g_unary_union(const Rcpp::RObject &geom, bool as_iso,
+                   const std::string &byte_order, bool quiet) {
+// Returns the union of all components of a single geometry. Usually used to
+// convert a collection into the smallest set of polygons that cover the same
+// area.
+//
+// See https://postgis.net/docs/ST_UnaryUnion.html for more details.
+//
+// Requires GDAL >= 3.7
+#if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3, 7, 0)
+    Rcpp::stop("g_unary_union() requires GDAL >= 3.7");
+
+#else
+    if (geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(geom))
+        return R_NilValue;
+
+    const Rcpp::RawVector geom_in(geom);
+    if (geom_in.size() == 0)
+        return R_NilValue;
+
+    OGRGeometryH hGeom = createGeomFromWkb(geom_in);
+    if (hGeom == nullptr) {
+        if (!quiet) {
+            Rcpp::warning(
+                "failed to create geometry object from WKB, NULL returned");
+        }
+        return R_NilValue;
+    }
+
+    OGRGeometryH hUnion = OGR_G_UnaryUnion(hGeom);
+
+    if (hUnion == nullptr) {
+        OGR_G_DestroyGeometry(hGeom);
+        if (!quiet) {
+            Rcpp::warning("OGR_G_UnaryUnion() gave NULL geometry");
+        }
+        return R_NilValue;
+    }
+
+    const int nWKBSize = OGR_G_WkbSize(hUnion);
+    if (!nWKBSize) {
+        OGR_G_DestroyGeometry(hGeom);
+        OGR_G_DestroyGeometry(hUnion);
+        if (!quiet) {
+            Rcpp::warning("failed to obtain WKB size of output geometry");
+        }
+        return R_NilValue;
+    }
+
+    Rcpp::RawVector wkb = Rcpp::no_init(nWKBSize);
+    bool result = exportGeomToWkb(hUnion, &wkb[0], as_iso, byte_order);
+    OGR_G_DestroyGeometry(hGeom);
+    OGR_G_DestroyGeometry(hUnion);
+    if (!result) {
+        if (!quiet) {
+           Rcpp::warning(
+                "failed to export WKB raw vector for output geometry");
+        }
+        return R_NilValue;
+    }
+
+    return wkb;
+#endif
+}
+
 
 // *** binary operations ***
 
@@ -2062,8 +2117,7 @@ SEXP g_intersection(const Rcpp::RObject &this_geom,
 // of the input geometries, call IsValid() before, otherwise the result might
 // be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return R_NilValue;
@@ -2152,8 +2206,7 @@ SEXP g_union(const Rcpp::RObject &this_geom,
 // of the input geometries, call IsValid() before, otherwise the result might
 // be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return R_NilValue;
@@ -2242,8 +2295,7 @@ SEXP g_difference(const Rcpp::RObject &this_geom,
 // of the input geometries, call IsValid() before, otherwise the result might
 // be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return R_NilValue;
@@ -2332,8 +2384,7 @@ SEXP g_sym_difference(const Rcpp::RObject &this_geom,
 // of the input geometries, call IsValid() before, otherwise the result might
 // be wrong.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (this_geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(this_geom))
         return R_NilValue;
@@ -2422,8 +2473,7 @@ double g_distance(const Rcpp::RObject &this_geom,
 // Returns the shortest distance between the two geometries. The distance is
 // expressed into the same unit as the coordinates of the geometries.
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     double ret = -1;
 
@@ -2670,8 +2720,7 @@ Rcpp::NumericVector g_centroid(const Rcpp::RObject &geom,
 // (polygons). SQL/MM-Part 3 defines the operation for surfaces and
 // multisurfaces (multipolygons).
 // This function is built on the GEOS library, check it for the definition of
-// the geometry operation. If OGR is built without the GEOS library, this
-// function will always fail, issuing a CPLE_NotSupported error.
+// the geometry operation.
 
     if (geom.isNULL() || !Rcpp::is<Rcpp::RawVector>(geom))
         return Rcpp::NumericVector::create(NA_REAL, NA_REAL);
@@ -2986,7 +3035,6 @@ Rcpp::NumericVector bbox_from_wkt(const std::string &wkt, double extend_x = 0,
 //' rectangle in both directions along the y-axis
 //' (results in `ymin = bbox[2] - extend_y`, `ymax = bbox[4] + extend_y`).
 //' @return Character string for an OGC WKT polygon.
-//' `NA` is returned if GDAL was built without the GEOS library.
 //'
 //' @seealso
 //' [bbox_from_wkt()], [g_buffer()]

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -117,6 +117,9 @@ SEXP g_simplify(const Rcpp::RObject &geom, double tolerance,
                 bool preserve_topology, bool as_iso,
                 const std::string &byte_order, bool quiet);
 
+SEXP g_unary_union(const Rcpp::RObject &geom, bool as_iso,
+                   const std::string &byte_order, bool quiet);
+
 SEXP g_intersection(const Rcpp::RObject &this_geom,
                     const Rcpp::RObject &other_geom,
                     bool as_iso, const std::string &byte_order,


### PR DESCRIPTION
`g_unary_union()` returns the union of all components of a single geometry. Usually used to convert a collection into the smallest set of polygons that cover the same area. See https://postgis.net/docs/ST_UnaryUnion.html for more details. Requires GDAL >= 3.7.