### PR TITLE
Add g_normalize(), wrapper for OGR_G_Normalize()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2333,6 +2333,11 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_normalize <- function(geom, as_iso, byte_order, quiet) {
+    .Call(`_gdalraster_g_normalize`, geom, as_iso, byte_order, quiet)
+}
+
+#' @noRd
 .g_set_3D <- function(geom, is_3d, as_iso, byte_order, quiet) {
     .Call(`_gdalraster_g_set_3D`, geom, is_3d, as_iso, byte_order, quiet)
 }

--- a/R/geom.R
+++ b/R/geom.R
@@ -911,8 +911,8 @@ g_geom_count <- function(geom, quiet = FALSE) {
 #'
 #' `g_normalize()` organizes the elements, rings, and coordinate order of
 #' geometries in a consistent way, so that geometries that represent the same
-#' object can be easily compared. Requires GDAL >= 3.3. Normalization ensures
-#' the following:
+#' object can be easily compared. Wrapper of `OGR_G_Normalize()` in the GDAL
+#' API. Requires GDAL >= 3.3. Normalization ensures the following:
 #'
 #' * Lines are oriented to have smallest coordinate first (apart from duplicate
 #' endpoints)

--- a/R/geom.R
+++ b/R/geom.R
@@ -909,6 +909,17 @@ g_geom_count <- function(geom, quiet = FALSE) {
 #'   * `FALSE` (the default): collapses are converted to empty geometries
 #'   * `TRUE`: collapses are converted to a valid geometry of lower dimension
 #'
+#' `g_normalize()` organizes the elements, rings, and coordinate order of
+#' geometries in a consistent way, so that geometries that represent the same
+#' object can be easily compared. Requires GDAL >= 3.3. Normalization ensures
+#' the following:
+#'
+#' * Lines are oriented to have smallest coordinate first (apart from duplicate
+#' endpoints)
+#' * Rings start with their smallest coordinate (using XY ordering)
+#' * Polygon shell rings are oriented clockwise, and holes counter-clockwise
+#' * Collection elements are sorted by their first coordinate
+#'
 #' `g_set_3D()` adds or removes the explicit Z coordinate dimension. Removing
 #' the Z coordinate dimension of a geometry will remove any existing Z values.
 #' Adding the Z dimension to a geometry collection, a compound curve, a
@@ -951,7 +962,7 @@ g_geom_count <- function(geom, quiet = FALSE) {
 #' [g_is_valid()], [g_is_3D()], [g_is_measured()]
 #'
 #' @examples
-#' # g_make_valid() requires GEOS >= 3.8, otherwise is only a validity test
+#' ## g_make_valid() requires GEOS >= 3.8, otherwise is only a validity test
 #' geos_version()
 #'
 #' # valid
@@ -966,6 +977,13 @@ g_geom_count <- function(geom, quiet = FALSE) {
 #' wkt <- "LINESTRING (0 0)"
 #' g_make_valid(wkt)  # NULL
 #'
+#' ## g_normalize() requires GDAL >= 3.3
+#' if (gdal_version_num() >= gdal_compute_version(3, 3, 0)) {
+#'   g <- "POLYGON ((0 1,1 1,1 0,0 0,0 1))"
+#'   g_normalize(g) |> g_wk2wk()
+#' }
+#'
+#' ## set 3D / set measured
 #' pt_xyzm <- g_create("POINT", c(1, 9, 100, 2000))
 #'
 #' g_wk2wk(pt_xyzm, as_iso = TRUE)
@@ -974,6 +992,7 @@ g_geom_count <- function(geom, quiet = FALSE) {
 #'
 #' g_set_measured(pt_xyzm, is_measured = FALSE) |> g_wk2wk(as_iso = TRUE)
 #'
+#' ## swap XY
 #' g <- "GEOMETRYCOLLECTION(POINT(1 2),
 #'                          LINESTRING(1 2,2 3),
 #'                          POLYGON((0 0,0 1,1 1,0 0)))"
@@ -1032,6 +1051,57 @@ g_make_valid <- function(geom, method = "LINEWORK", keep_collapsed = FALSE,
         } else {
             wkb <- lapply(g_wk2wk(geom), .g_make_valid, method, keep_collapsed,
                           as_iso, byte_order, quiet)
+        }
+    } else {
+        stop("'geom' must be a character vector, raw vector, or list",
+             call. = FALSE)
+    }
+
+    if (as_wkb)
+        return(wkb)
+    else
+        return(g_wk2wk(wkb, as_iso))
+}
+
+#' @name g_util
+#' @export
+g_normalize <- function(geom, as_wkb = TRUE, as_iso = FALSE, byte_order = "LSB",
+                        quiet = FALSE) {
+
+    # as_wkb
+    if (is.null(as_wkb))
+        as_wkb <- TRUE
+    if (!is.logical(as_wkb) || length(as_wkb) > 1)
+        stop("'as_wkb' must be a single logical value", call. = FALSE)
+    # as_iso
+    if (is.null(as_iso))
+        as_iso <- FALSE
+    if (!is.logical(as_iso) || length(as_iso) > 1)
+        stop("'as_iso' must be a single logical value", call. = FALSE)
+    # byte_order
+    if (is.null(byte_order))
+        byte_order <- "LSB"
+    if (!is.character(byte_order) || length(byte_order) > 1)
+        stop("'byte_order' must be a character string", call. = FALSE)
+    byte_order <- toupper(byte_order)
+    if (byte_order != "LSB" && byte_order != "MSB")
+        stop("invalid 'byte_order'", call. = FALSE)
+    # quiet
+    if (is.null(quiet))
+        quiet <- FALSE
+    if (!is.logical(quiet) || length(quiet) > 1)
+        stop("'quiet' must be a single logical value", call. = FALSE)
+
+    wkb <- NULL
+    if (.is_raw_or_null(geom)) {
+        wkb <- .g_normalize(geom, as_iso, byte_order, quiet)
+    } else if (is.list(geom) && .is_raw_or_null(geom[[1]])) {
+        wkb <- lapply(geom, .g_normalize, as_iso, byte_order, quiet)
+    } else if (is.character(geom)) {
+        if (length(geom) == 1) {
+            wkb <- .g_normalize(g_wk2wk(geom), as_iso, byte_order, quiet)
+        } else {
+            wkb <- lapply(g_wk2wk(geom), .g_normalize, as_iso, byte_order, quiet)
         }
     } else {
         stop("'geom' must be a character vector, raw vector, or list",

--- a/man/g_util.Rd
+++ b/man/g_util.Rd
@@ -3,6 +3,7 @@
 \name{g_util}
 \alias{g_util}
 \alias{g_make_valid}
+\alias{g_normalize}
 \alias{g_set_3D}
 \alias{g_set_measured}
 \alias{g_swap_xy}
@@ -12,6 +13,14 @@ g_make_valid(
   geom,
   method = "LINEWORK",
   keep_collapsed = FALSE,
+  as_wkb = TRUE,
+  as_iso = FALSE,
+  byte_order = "LSB",
+  quiet = FALSE
+)
+
+g_normalize(
+  geom,
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB",
@@ -105,6 +114,18 @@ categorized.
 }
 }
 
+\code{g_normalize()} organizes the elements, rings, and coordinate order of
+geometries in a consistent way, so that geometries that represent the same
+object can be easily compared. Requires GDAL >= 3.3. Normalization ensures
+the following:
+\itemize{
+\item Lines are oriented to have smallest coordinate first (apart from duplicate
+endpoints)
+\item Rings start with their smallest coordinate (using XY ordering)
+\item Polygon shell rings are oriented clockwise, and holes counter-clockwise
+\item Collection elements are sorted by their first coordinate
+}
+
 \code{g_set_3D()} adds or removes the explicit Z coordinate dimension. Removing
 the Z coordinate dimension of a geometry will remove any existing Z values.
 Adding the Z dimension to a geometry collection, a compound curve, a
@@ -121,7 +142,7 @@ Wrapper of \code{OGR_G_SetMeasured()} in the GDAL API.
 Wrapper of \code{OGR_G_SwapXY()} in the GDAL API.
 }
 \examples{
-# g_make_valid() requires GEOS >= 3.8, otherwise is only a validity test
+## g_make_valid() requires GEOS >= 3.8, otherwise is only a validity test
 geos_version()
 
 # valid
@@ -136,6 +157,13 @@ g_make_valid(wkt, as_wkb = FALSE)
 wkt <- "LINESTRING (0 0)"
 g_make_valid(wkt)  # NULL
 
+## g_normalize() requires GDAL >= 3.3
+if (gdal_version_num() >= gdal_compute_version(3, 3, 0)) {
+  g <- "POLYGON ((0 1,1 1,1 0,0 0,0 1))"
+  g_normalize(g) |> g_wk2wk()
+}
+
+## set 3D / set measured
 pt_xyzm <- g_create("POINT", c(1, 9, 100, 2000))
 
 g_wk2wk(pt_xyzm, as_iso = TRUE)
@@ -144,6 +172,7 @@ g_set_3D(pt_xyzm, is_3d = FALSE) |> g_wk2wk(as_iso = TRUE)
 
 g_set_measured(pt_xyzm, is_measured = FALSE) |> g_wk2wk(as_iso = TRUE)
 
+## swap XY
 g <- "GEOMETRYCOLLECTION(POINT(1 2),
                          LINESTRING(1 2,2 3),
                          POLYGON((0 0,0 1,1 1,0 0)))"

--- a/man/g_util.Rd
+++ b/man/g_util.Rd
@@ -116,8 +116,8 @@ categorized.
 
 \code{g_normalize()} organizes the elements, rings, and coordinate order of
 geometries in a consistent way, so that geometries that represent the same
-object can be easily compared. Requires GDAL >= 3.3. Normalization ensures
-the following:
+object can be easily compared. Wrapper of \code{OGR_G_Normalize()} in the GDAL
+API. Requires GDAL >= 3.3. Normalization ensures the following:
 \itemize{
 \item Lines are oriented to have smallest coordinate first (apart from duplicate
 endpoints)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1190,6 +1190,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// g_normalize
+SEXP g_normalize(const Rcpp::RObject& geom, bool as_iso, const std::string& byte_order, bool quiet);
+RcppExport SEXP _gdalraster_g_normalize(SEXP geomSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type geom(geomSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_normalize(geom, as_iso, byte_order, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
 // g_set_3D
 SEXP g_set_3D(const Rcpp::RObject& geom, bool is_3d, bool as_iso, const std::string& byte_order, bool quiet);
 RcppExport SEXP _gdalraster_g_set_3D(SEXP geomSEXP, SEXP is_3dSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP, SEXP quietSEXP) {
@@ -2369,6 +2383,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_get_geom", (DL_FUNC) &_gdalraster_g_get_geom, 4},
     {"_gdalraster_g_is_valid", (DL_FUNC) &_gdalraster_g_is_valid, 2},
     {"_gdalraster_g_make_valid", (DL_FUNC) &_gdalraster_g_make_valid, 6},
+    {"_gdalraster_g_normalize", (DL_FUNC) &_gdalraster_g_normalize, 4},
     {"_gdalraster_g_set_3D", (DL_FUNC) &_gdalraster_g_set_3D, 5},
     {"_gdalraster_g_set_measured", (DL_FUNC) &_gdalraster_g_set_measured, 5},
     {"_gdalraster_g_swap_xy", (DL_FUNC) &_gdalraster_g_swap_xy, 4},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -50,6 +50,9 @@ SEXP g_make_valid(const Rcpp::RObject &geom, const std::string &method,
                   bool keep_collapsed, bool as_iso,
                   const std::string &byte_order, bool quiet);
 
+SEXP g_normalize(const Rcpp::RObject &geom, bool as_iso,
+                 const std::string &byte_order, bool quiet);
+
 SEXP g_set_3D(const Rcpp::RObject &geom, bool is_3d, bool as_iso,
               const std::string &byte_order, bool quiet);
 

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -1284,6 +1284,31 @@ test_that("make_valid works", {
     expect_true(g_equals(g_wk2wk(wkb_list[[4]]), expected_wkt4))
 })
 
+test_that("normalize works", {
+    g <- "POLYGON ((0 1,1 1,1 0,0 0,0 1))"
+    expect_no_error(g_normalize(g))
+    expect_no_error(g_normalize(g, as_wkb = NULL, as_iso = NULL,
+                              byte_order = NULL, quiet = NULL))
+    g_norm <- g_normalize(g, as_wkb = FALSE)
+    g_expect <- "POLYGON ((0 0,0 1,1 1,1 0,0 0))"
+    expect_equal(g_norm, g_expect)
+    # wkb input
+    g_norm <- g_normalize(g_wk2wk(g), as_wkb = FALSE)
+    expect_equal(g_norm, g_expect)
+    # vector/list input
+    g_expect <- c(g_expect, g_expect, NA)
+    # character vector of wkt input
+    expect_warning(g_norm <- g_normalize(c(g, g, NA), as_wkb = FALSE,
+                                         quiet = TRUE)) |>
+        expect_warning()  # for as_wkb = FALSE
+    expect_equal(g_norm, g_expect)
+    # list of wkb input
+    expect_warning(g_norm <- g_normalize(g_wk2wk(c(g, g, NA)), as_wkb = FALSE,
+                                         quiet = TRUE)) |>
+        expect_warning()  # for as_wkb = FALSE
+    expect_equal(g_norm, g_expect)
+})
+
 test_that("g_set_3D / g_set_measured work", {
     pt_xyzm <- g_create("POINT", c(1, 9, 100, 2000))
     expect_true(g_is_3D(pt_xyzm))

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -1285,6 +1285,8 @@ test_that("make_valid works", {
 })
 
 test_that("normalize works", {
+    skip_if(gdal_version_num() < gdal_compute_version(3, 3, 0))
+
     g <- "POLYGON ((0 1,1 1,1 0,0 0,0 1))"
     expect_no_error(g_normalize(g))
     expect_no_error(g_normalize(g, as_wkb = NULL, as_iso = NULL,


### PR DESCRIPTION
`g_normalize()` organizes the elements, rings, and coordinate order of
geometries in a consistent way, so that geometries that represent the same
object can be easily compared. Wrapper of `OGR_G_Normalize()` in the GDAL
API. Requires GDAL >= 3.3. Normalization ensures the following:
* Lines are oriented to have smallest coordinate first (apart from duplicate
endpoints)
* Rings start with their smallest coordinate (using XY ordering)
* Polygon shell rings are oriented clockwise, and holes counter-clockwise
* Collection elements are sorted by their first coordinate