### PR TITLE
mdim_as_classic(): add argument view_expr for array slicing or field access by name

### DIFF
--- a/man/mdim_as_classic.Rd
+++ b/man/mdim_as_classic.Rd
@@ -11,6 +11,7 @@ mdim_as_classic(
   idx_ydim,
   read_only = TRUE,
   group_name = NULL,
+  view_expr = NULL,
   allowed_drivers = NULL,
   open_options = NULL
 )
@@ -34,6 +35,9 @@ used as the Y/height axis (0-based).}
 \item{group_name}{Optional character string giving the fully qualified name
 of a group containing \code{array_name}.}
 
+\item{view_expr}{Optional character string giving an expression for basic
+array slicing and indexing, or field access (see section \verb{View Expressions}).}
+
 \item{allowed_drivers}{Optional character vector of driver short names that
 must be considered. By default, all known multidimensional raster drivers are
 considered.}
@@ -51,17 +55,74 @@ or more arrays are supported. In the case of > 2D arrays,additional
 dimensions will be represented as raster bands. Requires GDAL >= 3.2.
 }
 \note{
-The indexing of array dimensions is 0-based to be consistent with the
+The indexing of array dimensions is 0-based consistent with the
 \verb{<ARRAY-SPEC>} notation that may be used with GDAL CLI commands, e.g.,
-\code{gdal_usage("mdim convert")} (requires GDAL > 3.11.3).
+\code{gdal_usage("mdim convert")} (CLI bindings require GDAL > 3.11.3).
 See \url{https://gdal.org/en/stable/programs/gdal_mdim_convert.html}.
 
 Once the returned \code{GDALRaster} object has been closed, it cannot be re-opened
 with its \verb{$open()} method.
 }
+\section{View Expressions}{
+
+A character string can be passed in argument \code{view_expr} to specify array
+slicing or field access. The slice expression uses the same syntax as NumPy
+basic slicing and indexing (0-based), or it can use field access by name.
+See \url{https://numpy.org/doc/stable/user/basics.indexing.html}.
+
+GDAL support for view expression on an MDArray is documented for
+\code{GDALMDArray::GetView()} (see
+\url{https://gdal.org/en/stable/api/gdalmdarray_cpp.html}) and copied here:
+
+Multiple [] bracket elements can be concatenated, with a slice expression or
+field name inside each.
+
+For basic slicing and indexing, inside each [] bracket element, a list of
+indexes that apply to successive source dimensions, can be specified, using
+integer indexing (e.g. 1), range indexing (start:stop:step), ellipsis (...)
+or newaxis, using a comma separator.
+
+Example expressions with a 2-dimensional array whose content is
+\verb{[[0,1,2,3],[4,5,6,7]]}.
+\itemize{
+\item \code{"[1][2]"}: returns a 0-dimensional/scalar array with the value at
+index 1 in the first dimension, and index 2 in the second dimension from the
+source array. That is, \code{5}.
+\item \code{"[1,2]"}: same as above, but a bit more performant.
+\item \code{"[1]"}: returns a 1-dimensional array, sliced at index \code{1} in the
+first dimension. That is \verb{[4,5,6,7]}.
+\item \code{"[:,2]"}: returns a 1-dimensional array, sliced at index \code{2} in the
+second dimension. That is \verb{[2,6]}.
+\item \code{"[:,2:3:]"}: returns a 2-dimensional array, sliced at index \code{2} in
+the second dimension. That is \verb{[[2],[6]]}.
+\item \code{"[::,2]"}: Same as above.
+\item \code{"[...,2]"}: same as above, in that case, since the ellipsis only
+expands to one dimension here.
+\item \code{"[:,::2]"}: returns a 2-dimensional array, with even-indexed
+elements of the second dimension. That is \verb{[[0,2],[4,6]]}.
+\item \code{"[:,1::2]"}: returns a 2-dimensional array, with odd-indexed
+elements of the second dimension. That is \verb{[[1,3],[5,7]]}.
+\item \code{"[:,1:3:]"}: returns a 2-dimensional array, with elements of the
+second dimension with index in the range \verb{[1,3]}. That is \verb{[[1,2],[5,6]]}.
+\item \code{"[::-1,:]"}: returns a 2-dimensional array, with the values in
+first dimension reversed. That is \verb{[[4,5,6,7],[0,1,2,3]]}.
+\item \code{"[newaxis,...]"}: returns a 3-dimensional array, with an additional
+dimension of size \code{1} put at the beginning. That is
+\verb{[[[0,1,2,3],[4,5,6,7]]]}.
+}
+
+One difference with NumPy behavior is that ranges that would result in zero
+elements are not allowed (dimensions of size 0 not being allowed in the GDAL
+multidimensional model).
+
+For field access, the syntax to use is \code{"['field_name']"}. Multiple field
+specification is not supported currently. Both type of access can be
+combined, e.g. \code{"[1]['field_name']"}.
+}
+
 \examples{
 f <- system.file("extdata/byte.nc", package="gdalraster")
-mdim_info(f) |> writeLines()
+# mdim_info(f) |> writeLines()
 
 (ds <- mdim_as_classic(f, "Band1", 1, 0))
 

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -2357,8 +2357,9 @@ RCPP_MODULE(mod_GDALRaster) {
              (autoCreateWarpedVRT)
     // mdim_as_classic() object factory with 9 parameters
     .factory<const Rcpp::CharacterVector&, const std::string&, int, int, bool,
-             const std::string&, const Rcpp::Nullable<Rcpp::CharacterVector>&,
-             const Rcpp::Nullable<Rcpp::CharacterVector>&, bool>
+             const std::string&, const std::string&,
+             const Rcpp::Nullable<Rcpp::CharacterVector>&,
+             const Rcpp::Nullable<Rcpp::CharacterVector>&>
              (mdim_as_classic)
 
     // exposed read/write fields

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -412,9 +412,9 @@ Rcpp::IntegerMatrix createColorRamp(int start_index,
 GDALRaster *mdim_as_classic(
     const Rcpp::CharacterVector &filename, const std::string &array_name,
     int idx_xdim, int idx_ydim, bool read_only, const std::string &group_name,
+    const std::string &view_expr,
     const Rcpp::Nullable<Rcpp::CharacterVector> &allowed_drivers,
-    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options,
-    bool reserved);
+    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options);
 
 std::string mdim_info(
     const Rcpp::CharacterVector &filename, const std::string &array_name,

--- a/tests/testthat/test-gdal_mdim.R
+++ b/tests/testthat/test-gdal_mdim.R
@@ -14,7 +14,7 @@ test_that("mdim_as_classic works", {
     #   https://github.com/OSGeo/gdal/blob/a8f0531cc90bc1fb554da9f6a94d059dbb995f81/autotest/gdrivers/vrtmultidim.py#L1417
     #       ds = gdal.Open("data/vrt/arraysource_array.vrt")
     #       assert ds.GetRasterBand(1).Checksum() == 4855
-    # and:
+    # and Python:
     #   from osgeo import gdal
     #   f = 'byte.nc'
     #   ds = gdal.OpenEx(f, gdal.OF_MULTIDIM_RASTER)
@@ -28,6 +28,31 @@ test_that("mdim_as_classic works", {
     ds$close()
     # filename is not set / driver-less dataset:
     expect_error(ds$open(read_only = TRUE))
+
+    # view expressions
+    f2 <- tempfile(fileext = ".nc")
+    on.exit(unlink(f2), add = TRUE)
+    file.copy(f, f2, overwrite = TRUE)
+
+    ds <- mdim_as_classic(f2, "Band1", 1, 0, read_only = FALSE,
+                          view_expr = "[0:10,...]")
+
+    # https://github.com/OSGeo/gdal/blob/2b1c4d1fdb9377b62d821d70d022e7426940aec6/autotest/gdrivers/netcdf_multidim.py#L4036
+    expect_equal(ds$getStatistics(1, FALSE, TRUE),
+                 c(74.0, 255.0, 126.82, 26.729713803182),
+                 tolerance = 0.01)
+
+    ds$close()
+
+    ds <- mdim_as_classic(f2, "Band1", 1, 0, read_only = FALSE,
+                          view_expr = "[10:20,...]")
+
+    # https://github.com/OSGeo/gdal/blob/2b1c4d1fdb9377b62d821d70d022e7426940aec6/autotest/gdrivers/netcdf_multidim.py#L4042
+    expect_equal(ds$getStatistics(1, FALSE, TRUE),
+                 c(99.0, 206.0, 126.71, 18.356086184152),
+                 tolerance = 0.01)
+
+    ds$close()
 })
 
 test_that("mdim_info works", {


### PR DESCRIPTION
`@param view_expr` Optional character string giving an expression for basic array slicing and indexing, or field access (see section `View Expressions`).