### PR TITLE
mdim_info(): add argument cout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to 'GDAL'
-Version: 2.2.1.9030
+Version: 2.2.1.9031
 Authors@R: c(
     person("Chris", "Toney", email = "jctoney@gmail.com",
             role = c("aut", "cre"), comment = "R interface/additional functionality"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# gdalraster 2.2.1.9030 (dev)
+# gdalraster 2.2.1.9031 (dev)
 
-* add `mdim_translate()`: convert multidimensional data between different formats, and subset, interface to `gdalmdimtranslate` utility (2025-09-25)
+* `mdim_info()`: add argument `cout` to control printing output to the console, with the info string returned invisibly (2025-09-25)
+
+* add `mdim_translate()`: convert multidimensional data between different formats, and subset, interface to `gdalmdimtranslate` utility (#803) (2025-09-25)
 
 * `mdim_as_classic()`: add argument `view_expr` for array slicing or field access by name (#802) (2025-09-22)
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -1492,17 +1492,20 @@ gdal_get_driver_md <- function(format, mdi_name = "") {
 #' fails to select the appropriate driver.
 #' @param open_options Optional character vector of format-specific dataset
 #' openoptions as `"NAME=VALUE"` pairs.
-#' @returns A JSON string containing information about the multidimensional
-#' raster dataset.
+#' @param cout Logical value, `TRUE` to print info to the console (the
+#' default), or `FALSE` to suppress console output.
+#' @returns Invisibly, a JSON string containing information about the
+#' multidimensional raster dataset. By default, the info string is also printed
+#' to the console unless `cout` is set to `FALSE`.
 #'
 #' @seealso
 #' [mdim_as_classic()], [mdim_translate()]
 #'
 #' @examplesIf gdal_version_num() >= gdal_compute_version(3, 2, 0) && isTRUE(gdal_formats("netCDF")$multidim_raster)
 #' f <- system.file("extdata/byte.nc", package="gdalraster")
-#' mdim_info(f) |> writeLines()
-mdim_info <- function(dsn, array_name = "", pretty = TRUE, detailed = FALSE, limit = -1L, stats = FALSE, array_options = NULL, allowed_drivers = NULL, open_options = NULL) {
-    .Call(`_gdalraster_mdim_info`, dsn, array_name, pretty, detailed, limit, stats, array_options, allowed_drivers, open_options)
+#' mdim_info(f)
+mdim_info <- function(dsn, array_name = "", pretty = TRUE, detailed = FALSE, limit = -1L, stats = FALSE, array_options = NULL, allowed_drivers = NULL, open_options = NULL, cout = TRUE) {
+    invisible(.Call(`_gdalraster_mdim_info`, dsn, array_name, pretty, detailed, limit, stats, array_options, allowed_drivers, open_options, cout))
 }
 
 #' Convert multidimensional data between different formats, and subset

--- a/R/gdal_mdim.R
+++ b/R/gdal_mdim.R
@@ -97,7 +97,7 @@
 #'
 #' @examplesIf gdal_version_num() >= gdal_compute_version(3, 2, 0) && isTRUE(gdal_formats("netCDF")$multidim_raster)
 #' f <- system.file("extdata/byte.nc", package="gdalraster")
-#' # mdim_info(f) |> writeLines()
+#' # mdim_info(f)
 #'
 #' (ds <- mdim_as_classic(f, "Band1", 1, 0))
 #'

--- a/man/mdim_as_classic.Rd
+++ b/man/mdim_as_classic.Rd
@@ -123,7 +123,7 @@ combined, e.g. \code{"[1]['field_name']"}.
 \examples{
 \dontshow{if (gdal_version_num() >= gdal_compute_version(3, 2, 0) && isTRUE(gdal_formats("netCDF")$multidim_raster)) withAutoprint(\{ # examplesIf}
 f <- system.file("extdata/byte.nc", package="gdalraster")
-# mdim_info(f) |> writeLines()
+# mdim_info(f)
 
 (ds <- mdim_as_classic(f, "Band1", 1, 0))
 

--- a/man/mdim_info.Rd
+++ b/man/mdim_info.Rd
@@ -13,7 +13,8 @@ mdim_info(
   stats = FALSE,
   array_options = NULL,
   allowed_drivers = NULL,
-  open_options = NULL
+  open_options = NULL,
+  cout = TRUE
 )
 }
 \arguments{
@@ -48,10 +49,14 @@ fails to select the appropriate driver.}
 
 \item{open_options}{Optional character vector of format-specific dataset
 openoptions as \code{"NAME=VALUE"} pairs.}
+
+\item{cout}{Logical value, \code{TRUE} to print info to the console (the
+default), or \code{FALSE} to suppress console output.}
 }
 \value{
-A JSON string containing information about the multidimensional
-raster dataset.
+Invisibly, a JSON string containing information about the
+multidimensional raster dataset. By default, the info string is also printed
+to the console unless \code{cout} is set to \code{FALSE}.
 }
 \description{
 \code{mdim_info()} is an interface to the \command{gdalmdiminfo} command-line
@@ -64,7 +69,7 @@ Requires GDAL >= 3.2.
 \examples{
 \dontshow{if (gdal_version_num() >= gdal_compute_version(3, 2, 0) && isTRUE(gdal_formats("netCDF")$multidim_raster)) withAutoprint(\{ # examplesIf}
 f <- system.file("extdata/byte.nc", package="gdalraster")
-mdim_info(f) |> writeLines()
+mdim_info(f)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -768,8 +768,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // mdim_info
-std::string mdim_info(const Rcpp::CharacterVector& dsn, const std::string& array_name, bool pretty, bool detailed, int limit, bool stats, const Rcpp::Nullable<Rcpp::CharacterVector>& array_options, const Rcpp::Nullable<Rcpp::CharacterVector>& allowed_drivers, const Rcpp::Nullable<Rcpp::CharacterVector>& open_options);
-RcppExport SEXP _gdalraster_mdim_info(SEXP dsnSEXP, SEXP array_nameSEXP, SEXP prettySEXP, SEXP detailedSEXP, SEXP limitSEXP, SEXP statsSEXP, SEXP array_optionsSEXP, SEXP allowed_driversSEXP, SEXP open_optionsSEXP) {
+std::string mdim_info(const Rcpp::CharacterVector& dsn, const std::string& array_name, bool pretty, bool detailed, int limit, bool stats, const Rcpp::Nullable<Rcpp::CharacterVector>& array_options, const Rcpp::Nullable<Rcpp::CharacterVector>& allowed_drivers, const Rcpp::Nullable<Rcpp::CharacterVector>& open_options, bool cout);
+RcppExport SEXP _gdalraster_mdim_info(SEXP dsnSEXP, SEXP array_nameSEXP, SEXP prettySEXP, SEXP detailedSEXP, SEXP limitSEXP, SEXP statsSEXP, SEXP array_optionsSEXP, SEXP allowed_driversSEXP, SEXP open_optionsSEXP, SEXP coutSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -782,7 +782,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const Rcpp::Nullable<Rcpp::CharacterVector>& >::type array_options(array_optionsSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<Rcpp::CharacterVector>& >::type allowed_drivers(allowed_driversSEXP);
     Rcpp::traits::input_parameter< const Rcpp::Nullable<Rcpp::CharacterVector>& >::type open_options(open_optionsSEXP);
-    rcpp_result_gen = Rcpp::wrap(mdim_info(dsn, array_name, pretty, detailed, limit, stats, array_options, allowed_drivers, open_options));
+    Rcpp::traits::input_parameter< bool >::type cout(coutSEXP);
+    rcpp_result_gen = Rcpp::wrap(mdim_info(dsn, array_name, pretty, detailed, limit, stats, array_options, allowed_drivers, open_options, cout));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2389,7 +2390,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_validateCreationOptions", (DL_FUNC) &_gdalraster_validateCreationOptions, 2},
     {"_gdalraster_gdal_get_driver_md", (DL_FUNC) &_gdalraster_gdal_get_driver_md, 2},
     {"_gdalraster_addFileInZip", (DL_FUNC) &_gdalraster_addFileInZip, 6},
-    {"_gdalraster_mdim_info", (DL_FUNC) &_gdalraster_mdim_info, 9},
+    {"_gdalraster_mdim_info", (DL_FUNC) &_gdalraster_mdim_info, 10},
     {"_gdalraster_mdim_translate", (DL_FUNC) &_gdalraster_mdim_translate, 12},
     {"_gdalraster_vsi_copy_file", (DL_FUNC) &_gdalraster_vsi_copy_file, 3},
     {"_gdalraster_vsi_curl_clear_cache", (DL_FUNC) &_gdalraster_vsi_curl_clear_cache, 3},

--- a/src/gdal_mdim.cpp
+++ b/src/gdal_mdim.cpp
@@ -174,16 +174,19 @@ GDALRaster *mdim_as_classic(
 //' fails to select the appropriate driver.
 //' @param open_options Optional character vector of format-specific dataset
 //' openoptions as `"NAME=VALUE"` pairs.
-//' @returns A JSON string containing information about the multidimensional
-//' raster dataset.
+//' @param cout Logical value, `TRUE` to print info to the console (the
+//' default), or `FALSE` to suppress console output.
+//' @returns Invisibly, a JSON string containing information about the
+//' multidimensional raster dataset. By default, the info string is also printed
+//' to the console unless `cout` is set to `FALSE`.
 //'
 //' @seealso
 //' [mdim_as_classic()], [mdim_translate()]
 //'
 //' @examplesIf gdal_version_num() >= gdal_compute_version(3, 2, 0) && isTRUE(gdal_formats("netCDF")$multidim_raster)
 //' f <- system.file("extdata/byte.nc", package="gdalraster")
-//' mdim_info(f) |> writeLines()
-// [[Rcpp::export()]]
+//' mdim_info(f)
+// [[Rcpp::export(invisible = true)]]
 std::string mdim_info(
     const Rcpp::CharacterVector &dsn,
     const std::string &array_name = "",
@@ -193,7 +196,8 @@ std::string mdim_info(
     bool stats = false,
     const Rcpp::Nullable<Rcpp::CharacterVector> &array_options = R_NilValue,
     const Rcpp::Nullable<Rcpp::CharacterVector> &allowed_drivers = R_NilValue,
-    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options = R_NilValue) {
+    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options = R_NilValue,
+    bool cout = true) {
 
 #if GDAL_VERSION_NUM < GDAL_COMPUTE_VERSION(3, 2, 0)
     Rcpp::stop("mdim_info() requires GDAL >= 3.2");
@@ -289,6 +293,9 @@ std::string mdim_info(
     GDALMultiDimInfoOptionsFree(psOptions);
 
     GDALReleaseDataset(hDS);
+
+    if (cout)
+        Rcpp::Rcout << info_out.c_str() << "\n";
 
     return info_out;
 #endif

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -421,7 +421,8 @@ std::string mdim_info(
     bool pretty, bool detailed, int limit, bool stats,
     const Rcpp::Nullable<Rcpp::CharacterVector> &array_options,
     const Rcpp::Nullable<Rcpp::CharacterVector> &allowed_drivers,
-    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options);
+    const Rcpp::Nullable<Rcpp::CharacterVector> &open_options,
+    bool cout);
 
 bool mdim_translate(
     const Rcpp::CharacterVector &src_dsn, const Rcpp::CharacterVector &dst_dsn,

--- a/tests/testthat/test-gdal_mdim.R
+++ b/tests/testthat/test-gdal_mdim.R
@@ -59,6 +59,10 @@ test_that("mdim_as_classic works", {
 
 test_that("mdim_info works", {
     f <- system.file("extdata/byte.nc", package="gdalraster")
+
+    expect_output(mdim_info(f))
+    expect_silent(mdim_info(f, cout = FALSE))
+    
     expect_no_error(info <- mdim_info(f, array_options = "SHOW_ALL=YES"))
     expect_vector(info, ptype = character(), size = 1)
     expect_true(startsWith(info, "{"))


### PR DESCRIPTION
`cout = TRUE` by default, controls printing output to the console. The info string is returned invisibly. Avoids needing `writeLines()` or something similar for nicely formatted output.