### PR TITLE
Fixes for ogr_ds_delete_field_domain(), and condition tests on GDAL 3.12

### DIFF
--- a/R/ogr_manage.R
+++ b/R/ogr_manage.R
@@ -552,7 +552,7 @@ ogr_ds_delete_field_domain <- function(dsn, domain_name) {
         stop("'domain_name' must be a length-1 character vector", call. = FALSE)
 
     if (ogr_ds_test_cap(dsn)$DeleteFieldDomain) {
-        return(ogr_ds_delete_field_domain(dsn, domain_name))
+        return(.ogr_ds_delete_field_domain(dsn, domain_name))
     } else {
         message("the dataset does not support DeleteFieldDomain")
         return(FALSE)

--- a/src/ogr_util.cpp
+++ b/src/ogr_util.cpp
@@ -1540,7 +1540,9 @@ bool ogr_ds_delete_field_domain(const std::string &dsn,
     const std::string dsn_in = Rcpp::as<std::string>(check_gdal_filename(dsn));
     GDALDatasetH hDS = nullptr;
 
-    hDS = GDALOpenEx(dsn_in.c_str(), GDAL_OF_VECTOR, nullptr, nullptr, nullptr);
+    hDS = GDALOpenEx(dsn_in.c_str(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr,
+                     nullptr, nullptr);
+
     if (hDS == nullptr) {
         Rcpp::warning("failed to open dataset");
         return false;

--- a/tests/testthat/test-GDALVector-class.R
+++ b/tests/testthat/test-GDALVector-class.R
@@ -1839,10 +1839,16 @@ test_that("delete field domain works", {
     f <- system.file("extdata/domains.gpkg", package="gdalraster")
     dsn <- file.path(tempdir(), basename(f))
     file.copy(f, dsn, overwrite = TRUE)
+    on.exit(unlink(dsn), add = TRUE)
 
-    # delete field domains not supported for GPKG
-    expect_false(ogr_ds_test_cap(dsn)$DeleteFieldDomain)
-    expect_false(ogr_ds_delete_field_domain(dsn, "glob_domain"))
+    # delete field domains supported for GPKG as of GDAL 3.12
+    if (gdal_version_num() < gdal_compute_version(3, 12, 0)) {
+        expect_false(ogr_ds_test_cap(dsn)$DeleteFieldDomain)
+        expect_false(ogr_ds_delete_field_domain(dsn, "glob_domain"))
+    } else {
+        expect_true(ogr_ds_test_cap(dsn)$DeleteFieldDomain)
+        expect_true(ogr_ds_delete_field_domain(dsn, "glob_domain"))
+    }
 
     # TODO: test on OpenFileGDB
 })


### PR DESCRIPTION
GDAL 3.12 implements UpdateFieldDomain() and DeleteFieldDomain() for the GPKG driver.

This PR updates tests for `ogr_ds_delete_field_domain()` for GDAL 3.12, and fixes a typo in the call to internal `.ogr_ds_delete_field_domain()` that caused an infinite recursion error.