### PR TITLE
Add vsi_stat_exists(), vsi_stat_type() and vsi_stat_size()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2092,31 +2092,47 @@ vsi_unlink_batch <- function(filenames) {
 
 #' Get filesystem object info
 #'
-#' `vsi_stat()` fetches status information about a filesystem object (file,
-#' directory, etc).
-#' This function goes through the GDAL `VSIFileHandler` virtualization and may
-#' work on unusual filesystems such as in memory.
-#' It is a wrapper for `VSIStatExL()` in the GDAL Common Portability Library.
-#' Analog of the POSIX `stat()` function.
+#' These functions work on GDAL virtual file systems such as in-memory
+#' (/vsimem/), URLs (/vsicurl/), cloud storage services (e.g., /vsis3/,
+#' /vsigs/, /vsiaz/, etc.), compressed archives (e.g., /vsizip, /vsitar/,
+#' /vsi7z/, /vsigzip/, etc.), and others including "standard" file systems.
+#' See \url{https://gdal.org/en/stable/user/virtual_file_systems.html}.
+#'
+#' @name vsi_stat
+#'
+#' @details
+#' `vsi_stat()` fetches status information about a single filesystem object
+#' (file, directory, etc). It is a wrapper for `VSIStatExL()` in the GDAL
+#' Common Portability Library. Analog of the POSIX `stat()` function.
+#'
+#' `vsi_stat_exists()`, `vsi_stat_type()` and `vsi_stat_size()` are
+#' specializations operating on a vector of potentially multiple file system
+#' object names, returning, respectfully, a logical vector, a character vector,
+#' and a numeric vector carrying the `bit64::integer64` class attribute.
 #'
 #' @param filename Character string. The path of the filesystem object to be
 #' queried.
 #' @param info Character string. The type of information to fetch, one of
 #' `"exists"` (the default), `"type"` or `"size"`.
-#' @returns If `info = "exists"`, returns logical `TRUE` if the file system
+#' @param filenames Character vector of filesystem objects to query.
+#' @returns
+#' If `info = "exists"`, `vsi_stat()` returns logical `TRUE` if the file system
 #' object exists, otherwise `FALSE`. If `info = "type"`, returns a character
 #' string with one of `"file"` (regular file), `"dir"` (directory),
 #' `"symlink"` (symbolic link), or empty string (`""`). If `info = "size"`,
 #' returns the file size in bytes (as `bit64::integer64` type), or `-1` if an
 #' error occurs.
+#' `vsi_stat_exists()` returns a logical vector. `vsi_stat_type()` returns a
+#' character vector. `vsi_stat_size()` returns a numeric vector carrying the
+#' `bit64::integer64` class attribute.
 #'
 #' @note
 #' For portability, `vsi_stat()` supports a subset of `stat()`-type
 #' information for filesystem objects. This function is primarily intended
 #' for use with GDAL virtual file systems (e.g., URLs, cloud storage systems,
-#' ZIP/GZip/7z/RAR archives, in-memory files).
-#' The base R function `utils::file_test()` could be used instead for file
-#' tests on regular local filesystems.
+#' ZIP/GZip/7z/RAR archives, in-memory files), but can also be used on
+#' "standard" file systems (e.g., in the / hierarchy on Unix-like systems or
+#' in C:, D:, etc. drives on Windows).
 #'
 #' @seealso
 #' GDAL Virtual File Systems:\cr
@@ -2140,6 +2156,11 @@ vsi_unlink_batch <- function(filenames) {
 #' vsi_stat(nonexistent, "type")
 #' vsi_stat(nonexistent, "size")
 #'
+#' fs_objects <- c(data_dir, elev_file, nonexistent)
+#' vsi_stat_exists(fs_objects)
+#' vsi_stat_type(fs_objects)
+#' vsi_stat_size(fs_objects)
+#'
 #' # /vsicurl/ file system handler
 #' base_url <- "https://raw.githubusercontent.com/usdaforestservice/"
 #' f <- "gdalraster/main/sample-data/landsat_c2ard_sr_mt_hood_jul2022_utm.tif"
@@ -2154,6 +2175,21 @@ vsi_unlink_batch <- function(filenames) {
 #' vsi_stat(url_file, "size")
 vsi_stat <- function(filename, info = "exists") {
     .Call(`_gdalraster_vsi_stat`, filename, info)
+}
+
+#' @rdname vsi_stat
+vsi_stat_exists <- function(filenames) {
+    .Call(`_gdalraster_vsi_stat_exists`, filenames)
+}
+
+#' @rdname vsi_stat
+vsi_stat_type <- function(filenames) {
+    .Call(`_gdalraster_vsi_stat_type`, filenames)
+}
+
+#' @rdname vsi_stat
+vsi_stat_size <- function(filenames) {
+    .Call(`_gdalraster_vsi_stat_size`, filenames)
 }
 
 #' Rename a file

--- a/man/vsi_stat.Rd
+++ b/man/vsi_stat.Rd
@@ -2,9 +2,18 @@
 % Please edit documentation in R/RcppExports.R
 \name{vsi_stat}
 \alias{vsi_stat}
+\alias{vsi_stat_exists}
+\alias{vsi_stat_type}
+\alias{vsi_stat_size}
 \title{Get filesystem object info}
 \usage{
 vsi_stat(filename, info = "exists")
+
+vsi_stat_exists(filenames)
+
+vsi_stat_type(filenames)
+
+vsi_stat_size(filenames)
 }
 \arguments{
 \item{filename}{Character string. The path of the filesystem object to be
@@ -12,30 +21,44 @@ queried.}
 
 \item{info}{Character string. The type of information to fetch, one of
 \code{"exists"} (the default), \code{"type"} or \code{"size"}.}
+
+\item{filenames}{Character vector of filesystem objects to query.}
 }
 \value{
-If \code{info = "exists"}, returns logical \code{TRUE} if the file system
+If \code{info = "exists"}, \code{vsi_stat()} returns logical \code{TRUE} if the file system
 object exists, otherwise \code{FALSE}. If \code{info = "type"}, returns a character
 string with one of \code{"file"} (regular file), \code{"dir"} (directory),
 \code{"symlink"} (symbolic link), or empty string (\code{""}). If \code{info = "size"},
 returns the file size in bytes (as \code{bit64::integer64} type), or \code{-1} if an
 error occurs.
+\code{vsi_stat_exists()} returns a logical vector. \code{vsi_stat_type()} returns a
+character vector. \code{vsi_stat_size()} returns a numeric vector carrying the
+\code{bit64::integer64} class attribute.
 }
 \description{
-\code{vsi_stat()} fetches status information about a filesystem object (file,
-directory, etc).
-This function goes through the GDAL \code{VSIFileHandler} virtualization and may
-work on unusual filesystems such as in memory.
-It is a wrapper for \code{VSIStatExL()} in the GDAL Common Portability Library.
-Analog of the POSIX \code{stat()} function.
+These functions work on GDAL virtual file systems such as in-memory
+(/vsimem/), URLs (/vsicurl/), cloud storage services (e.g., /vsis3/,
+/vsigs/, /vsiaz/, etc.), compressed archives (e.g., /vsizip, /vsitar/,
+/vsi7z/, /vsigzip/, etc.), and others including "standard" file systems.
+See \url{https://gdal.org/en/stable/user/virtual_file_systems.html}.
+}
+\details{
+\code{vsi_stat()} fetches status information about a single filesystem object
+(file, directory, etc). It is a wrapper for \code{VSIStatExL()} in the GDAL
+Common Portability Library. Analog of the POSIX \code{stat()} function.
+
+\code{vsi_stat_exists()}, \code{vsi_stat_type()} and \code{vsi_stat_size()} are
+specializations operating on a vector of potentially multiple file system
+object names, returning, respectfully, a logical vector, a character vector,
+and a numeric vector carrying the \code{bit64::integer64} class attribute.
 }
 \note{
 For portability, \code{vsi_stat()} supports a subset of \code{stat()}-type
 information for filesystem objects. This function is primarily intended
 for use with GDAL virtual file systems (e.g., URLs, cloud storage systems,
-ZIP/GZip/7z/RAR archives, in-memory files).
-The base R function \code{utils::file_test()} could be used instead for file
-tests on regular local filesystems.
+ZIP/GZip/7z/RAR archives, in-memory files), but can also be used on
+"standard" file systems (e.g., in the / hierarchy on Unix-like systems or
+in C:, D:, etc. drives on Windows).
 }
 \examples{
 data_dir <- system.file("extdata", package="gdalraster")
@@ -54,6 +77,11 @@ nonexistent <- file.path(data_dir, "nonexistent.tif")
 vsi_stat(nonexistent)
 vsi_stat(nonexistent, "type")
 vsi_stat(nonexistent, "size")
+
+fs_objects <- c(data_dir, elev_file, nonexistent)
+vsi_stat_exists(fs_objects)
+vsi_stat_type(fs_objects)
+vsi_stat_size(fs_objects)
 
 # /vsicurl/ file system handler
 base_url <- "https://raw.githubusercontent.com/usdaforestservice/"

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -937,6 +937,39 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// vsi_stat_exists
+Rcpp::LogicalVector vsi_stat_exists(const Rcpp::CharacterVector& filenames);
+RcppExport SEXP _gdalraster_vsi_stat_exists(SEXP filenamesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::CharacterVector& >::type filenames(filenamesSEXP);
+    rcpp_result_gen = Rcpp::wrap(vsi_stat_exists(filenames));
+    return rcpp_result_gen;
+END_RCPP
+}
+// vsi_stat_type
+Rcpp::CharacterVector vsi_stat_type(const Rcpp::CharacterVector& filenames);
+RcppExport SEXP _gdalraster_vsi_stat_type(SEXP filenamesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::CharacterVector& >::type filenames(filenamesSEXP);
+    rcpp_result_gen = Rcpp::wrap(vsi_stat_type(filenames));
+    return rcpp_result_gen;
+END_RCPP
+}
+// vsi_stat_size
+Rcpp::NumericVector vsi_stat_size(const Rcpp::CharacterVector& filenames);
+RcppExport SEXP _gdalraster_vsi_stat_size(SEXP filenamesSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::CharacterVector& >::type filenames(filenamesSEXP);
+    rcpp_result_gen = Rcpp::wrap(vsi_stat_size(filenames));
+    return rcpp_result_gen;
+END_RCPP
+}
 // vsi_rename
 int vsi_rename(const Rcpp::CharacterVector& oldpath, const Rcpp::CharacterVector& newpath);
 RcppExport SEXP _gdalraster_vsi_rename(SEXP oldpathSEXP, SEXP newpathSEXP) {
@@ -2435,6 +2468,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_vsi_unlink", (DL_FUNC) &_gdalraster_vsi_unlink, 1},
     {"_gdalraster_vsi_unlink_batch", (DL_FUNC) &_gdalraster_vsi_unlink_batch, 1},
     {"_gdalraster_vsi_stat", (DL_FUNC) &_gdalraster_vsi_stat, 2},
+    {"_gdalraster_vsi_stat_exists", (DL_FUNC) &_gdalraster_vsi_stat_exists, 1},
+    {"_gdalraster_vsi_stat_type", (DL_FUNC) &_gdalraster_vsi_stat_type, 1},
+    {"_gdalraster_vsi_stat_size", (DL_FUNC) &_gdalraster_vsi_stat_size, 1},
     {"_gdalraster_vsi_rename", (DL_FUNC) &_gdalraster_vsi_rename, 2},
     {"_gdalraster_vsi_get_fs_prefixes", (DL_FUNC) &_gdalraster_vsi_get_fs_prefixes, 0},
     {"_gdalraster_vsi_get_fs_options_", (DL_FUNC) &_gdalraster_vsi_get_fs_options_, 1},

--- a/src/gdal_vsi.cpp
+++ b/src/gdal_vsi.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "gdalraster.h"
+#include "rcpp_util.h"
 
 
 //' Copy a source file to a target filename
@@ -549,31 +550,47 @@ SEXP vsi_unlink_batch(const Rcpp::CharacterVector &filenames) {
 
 //' Get filesystem object info
 //'
-//' `vsi_stat()` fetches status information about a filesystem object (file,
-//' directory, etc).
-//' This function goes through the GDAL `VSIFileHandler` virtualization and may
-//' work on unusual filesystems such as in memory.
-//' It is a wrapper for `VSIStatExL()` in the GDAL Common Portability Library.
-//' Analog of the POSIX `stat()` function.
+//' These functions work on GDAL virtual file systems such as in-memory
+//' (/vsimem/), URLs (/vsicurl/), cloud storage services (e.g., /vsis3/,
+//' /vsigs/, /vsiaz/, etc.), compressed archives (e.g., /vsizip, /vsitar/,
+//' /vsi7z/, /vsigzip/, etc.), and others including "standard" file systems.
+//' See \url{https://gdal.org/en/stable/user/virtual_file_systems.html}.
+//'
+//' @name vsi_stat
+//'
+//' @details
+//' `vsi_stat()` fetches status information about a single filesystem object
+//' (file, directory, etc). It is a wrapper for `VSIStatExL()` in the GDAL
+//' Common Portability Library. Analog of the POSIX `stat()` function.
+//'
+//' `vsi_stat_exists()`, `vsi_stat_type()` and `vsi_stat_size()` are
+//' specializations operating on a vector of potentially multiple file system
+//' object names, returning, respectfully, a logical vector, a character vector,
+//' and a numeric vector carrying the `bit64::integer64` class attribute.
 //'
 //' @param filename Character string. The path of the filesystem object to be
 //' queried.
 //' @param info Character string. The type of information to fetch, one of
 //' `"exists"` (the default), `"type"` or `"size"`.
-//' @returns If `info = "exists"`, returns logical `TRUE` if the file system
+//' @param filenames Character vector of filesystem objects to query.
+//' @returns
+//' If `info = "exists"`, `vsi_stat()` returns logical `TRUE` if the file system
 //' object exists, otherwise `FALSE`. If `info = "type"`, returns a character
 //' string with one of `"file"` (regular file), `"dir"` (directory),
 //' `"symlink"` (symbolic link), or empty string (`""`). If `info = "size"`,
 //' returns the file size in bytes (as `bit64::integer64` type), or `-1` if an
 //' error occurs.
+//' `vsi_stat_exists()` returns a logical vector. `vsi_stat_type()` returns a
+//' character vector. `vsi_stat_size()` returns a numeric vector carrying the
+//' `bit64::integer64` class attribute.
 //'
 //' @note
 //' For portability, `vsi_stat()` supports a subset of `stat()`-type
 //' information for filesystem objects. This function is primarily intended
 //' for use with GDAL virtual file systems (e.g., URLs, cloud storage systems,
-//' ZIP/GZip/7z/RAR archives, in-memory files).
-//' The base R function `utils::file_test()` could be used instead for file
-//' tests on regular local filesystems.
+//' ZIP/GZip/7z/RAR archives, in-memory files), but can also be used on
+//' "standard" file systems (e.g., in the / hierarchy on Unix-like systems or
+//' in C:, D:, etc. drives on Windows).
 //'
 //' @seealso
 //' GDAL Virtual File Systems:\cr
@@ -596,6 +613,11 @@ SEXP vsi_unlink_batch(const Rcpp::CharacterVector &filenames) {
 //' vsi_stat(nonexistent)
 //' vsi_stat(nonexistent, "type")
 //' vsi_stat(nonexistent, "size")
+//'
+//' fs_objects <- c(data_dir, elev_file, nonexistent)
+//' vsi_stat_exists(fs_objects)
+//' vsi_stat_type(fs_objects)
+//' vsi_stat_size(fs_objects)
 //'
 //' # /vsicurl/ file system handler
 //' base_url <- "https://raw.githubusercontent.com/usdaforestservice/"
@@ -629,28 +651,82 @@ SEXP vsi_stat(const Rcpp::CharacterVector &filename,
     else if (EQUAL(info.c_str(), "type")) {
         std::string ret = "unknown";
         if (VSIStatExL(fn, &sStat, VSI_STAT_NATURE_FLAG) == 0) {
-            if (VSI_ISDIR(sStat.st_mode))
+            if (VSI_ISREG(sStat.st_mode))
+                ret = "file";
+            else if (VSI_ISDIR(sStat.st_mode))
                 ret = "dir";
             else if (VSI_ISLNK(sStat.st_mode))
                 ret = "symlink";
-            else if (VSI_ISREG(sStat.st_mode))
-                ret = "file";
         }
 
         return Rcpp::CharacterVector(ret);
     }
     else if (EQUAL(info.c_str(), "size")) {
-        std::vector<int64_t> ret(1);
+        std::vector<int64_t> ret = {-1};
         if (VSIStatExL(fn, &sStat, VSI_STAT_SIZE_FLAG) == 0)
             ret[0] = static_cast<int64_t>(sStat.st_size);
-        else
-            ret[0] = -1;
 
         return Rcpp::wrap(ret);
     }
 
     Rcpp::Rcout << "invalid value for 'info'\n";
     return R_NilValue;
+}
+
+//' @rdname vsi_stat
+// [[Rcpp::export]]
+Rcpp::LogicalVector vsi_stat_exists(const Rcpp::CharacterVector &filenames) {
+    Rcpp::CharacterVector filenames_in = enc_to_utf8_(filenames);
+    Rcpp::LogicalVector ret(filenames_in.size(), NA_LOGICAL);
+    VSIStatBufL sStat;
+
+    for (int i = 0; i < filenames_in.size(); ++i) {
+        const Rcpp::String &fn = filenames_in[i];
+        if (VSIStatExL(fn.get_cstring() , &sStat, VSI_STAT_EXISTS_FLAG) == 0)
+            ret[i] = TRUE;
+        else
+            ret[i] = FALSE;
+    }
+
+    return ret;
+}
+
+//' @rdname vsi_stat
+// [[Rcpp::export]]
+Rcpp::CharacterVector vsi_stat_type(const Rcpp::CharacterVector &filenames) {
+    Rcpp::CharacterVector filenames_in = enc_to_utf8_(filenames);
+    Rcpp::CharacterVector ret(filenames_in.size(), "unknown");
+    VSIStatBufL sStat;
+
+    for (int i = 0; i < filenames_in.size(); ++i) {
+        const Rcpp::String &fn = filenames_in[i];
+        if (VSIStatExL(fn.get_cstring(), &sStat, VSI_STAT_NATURE_FLAG) == 0) {
+            if (VSI_ISREG(sStat.st_mode))
+                ret[i] = "file";
+            else if (VSI_ISDIR(sStat.st_mode))
+                ret[i] = "dir";
+            else if (VSI_ISLNK(sStat.st_mode))
+                ret[i] = "symlink";
+        }
+    }
+
+    return ret;
+}
+
+//' @rdname vsi_stat
+// [[Rcpp::export]]
+Rcpp::NumericVector vsi_stat_size(const Rcpp::CharacterVector &filenames) {
+    Rcpp::CharacterVector filenames_in = enc_to_utf8_(filenames);
+    std::vector<int64_t> ret(filenames_in.size(), -1);
+    VSIStatBufL sStat;
+
+    for (int i = 0; i < filenames_in.size(); ++i) {
+        const Rcpp::String &fn = filenames_in[i];
+        if (VSIStatExL(fn.get_cstring(), &sStat, VSI_STAT_SIZE_FLAG) == 0)
+            ret[i] = static_cast<int64_t>(sStat.st_size);
+    }
+
+    return Rcpp::wrap(ret);
 }
 
 

--- a/src/gdal_vsi.h
+++ b/src/gdal_vsi.h
@@ -34,6 +34,9 @@ int vsi_rmdir(const Rcpp::CharacterVector &path, bool recursive);
 int vsi_unlink(const Rcpp::CharacterVector &filename);
 SEXP vsi_unlink_batch(const Rcpp::CharacterVector &filenames);
 SEXP vsi_stat(const Rcpp::CharacterVector &filename, const std::string &info);
+Rcpp::LogicalVector vsi_stat_exists(const Rcpp::CharacterVector &filenames);
+Rcpp::CharacterVector vsi_stat_type(const Rcpp::CharacterVector &filenames);
+Rcpp::NumericVector vsi_stat_size(const Rcpp::CharacterVector &filenames);
 int vsi_rename(const Rcpp::CharacterVector &oldpath,
                const Rcpp::CharacterVector &newpath);
 

--- a/tests/testthat/test-gdal_vsi.R
+++ b/tests/testthat/test-gdal_vsi.R
@@ -13,6 +13,12 @@ test_that("vsi_stat works", {
     expect_equal(vsi_stat(nonexistent, "type"), "unknown")
     expect_equal(vsi_stat(nonexistent, "size"), bit64::as.integer64(-1))
     expect_true(is.null(vsi_stat(elev_file, "invalid")))
+
+    fs_objects <- c(data_dir, elev_file, nonexistent)
+    expect_equal(vsi_stat_exists(fs_objects), c(TRUE, TRUE, FALSE))
+    expect_equal(vsi_stat_type(fs_objects), c("dir", "file", "unknown"))
+    expect_vector(vsi_stat_size(fs_objects), ptype = bit64::integer64(),
+                  size = 3)
 })
 
 test_that("vsi_read_dir works", {


### PR DESCRIPTION
Adds specializations of `vsi_stat()` operating on a vector of potentially multiple file system object names. `vsi_stat_exists()` returns a logical vector. `vsi_stat_type()` returns a character vector. `vsi_stat_size()` returns a numeric vector carrying the `bit64::integer64` class attribute.

Fixes #817 