### PR TITLE
SRS API: add srs_get_area_of_use(), srs_get_axes_count() and srs_get_celestial_body_name()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -3192,6 +3192,27 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #' axis.
 #' * `OAMS_CUSTOM`: custom-defined data axis
 #'
+#' `srs_get_area_of_use()` is a wrapper of `OSRGetAreaOfUse()` in the GDAL API.
+#' Returns a named list containing the following elements (or returns `NULL` if
+#' the API call does not succeed):
+#' * `AreaName`: the area of use
+#' * `WestLongitudeDeg`: the western-most longitude expressed in degree, or
+#' `NA` if the bounding box is unknown
+#' * `SouthLatitudeDeg`: the southern-most latitude expressed in degree, or
+#' `NA` if the bounding box is unknown
+#' * `EastLongitudeDeg`: the eastern-most longitude expressed in degree, or
+#' `NA` if the bounding box is unknown
+#' * `NorthLatitudeDeg`: the northern-most latitude expressed in degree, or
+#' `NA` if the bounding box is unknown
+#'
+#' `srs_get_axes_count()` returns the integer number of axes of the coordinate
+#' system of the SRS. Wrapper of `OSRGetAxesCount()` in the GDAL API.
+#'
+#' `srs_get_celestial_body_name()` returns the name of the celestial body of
+#' the SRS, e.g., `"Earth"` for an Earth SRS. Wrapper of
+#' `OSRGetCelestialBodyName()` in the GDAL API. Requires GDAL >= 3.12 and
+#' PROJ >= 8.1.
+#'
 #' @param srs Character string containing an SRS definition in various
 #' formats (e.g., WKT, PROJ.4 string, well known name such as NAD27, NAD83,
 #' WGS84, etc., see [srs_to_wkt()]).
@@ -3258,6 +3279,17 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #'
 #' srs_is_vertical("EPSG:5705")
 #'
+#' srs_get_area_of_use("EPSG:3976")
+#'
+#' srs_get_axes_count("EPSG:4326")
+#' srs_get_axes_count("EPSG:4979")
+#'
+#' ## Requires GDAL >= 3.12 and PROJ >= 8.1
+#' # srs_get_celestial_body_name("EPSG:4326")
+#' #> [1] "Earth"
+#' # srs_get_celestial_body_name("IAU_2015:30100")
+#' #> [1] "Moon"
+#'
 #' f <- system.file("extdata/storml_elev.tif", package="gdalraster")
 #' ds <- new(GDALRaster, f)
 #'
@@ -3272,7 +3304,7 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #'
 #' ds$close()
 #'
-#' # Requires GDAL >= 3.4
+#' ## Requires GDAL >= 3.4
 #' if (gdal_version_num() >= gdal_compute_version(3, 4, 0)) {
 #'   if (srs_is_dynamic("WGS84"))
 #'     print("WGS84 is dynamic")
@@ -3357,6 +3389,21 @@ srs_get_utm_zone <- function(srs) {
 #' @rdname srs_query
 srs_get_axis_mapping_strategy <- function(srs) {
     .Call(`_gdalraster_srs_get_axis_mapping_strategy`, srs)
+}
+
+#' @rdname srs_query
+srs_get_area_of_use <- function(srs) {
+    .Call(`_gdalraster_srs_get_area_of_use`, srs)
+}
+
+#' @rdname srs_query
+srs_get_axes_count <- function(srs) {
+    .Call(`_gdalraster_srs_get_axes_count`, srs)
+}
+
+#' @rdname srs_query
+srs_get_celestial_body_name <- function(srs) {
+    .Call(`_gdalraster_srs_get_celestial_body_name`, srs)
 }
 
 #' get PROJ version

--- a/man/srs_query.Rd
+++ b/man/srs_query.Rd
@@ -18,6 +18,9 @@
 \alias{srs_get_coord_epoch}
 \alias{srs_get_utm_zone}
 \alias{srs_get_axis_mapping_strategy}
+\alias{srs_get_area_of_use}
+\alias{srs_get_axes_count}
+\alias{srs_get_celestial_body_name}
 \title{Obtain information about a spatial reference system}
 \usage{
 srs_get_name(srs)
@@ -57,6 +60,12 @@ srs_get_coord_epoch(srs)
 srs_get_utm_zone(srs)
 
 srs_get_axis_mapping_strategy(srs)
+
+srs_get_area_of_use(srs)
+
+srs_get_axes_count(srs)
+
+srs_get_celestial_body_name(srs)
 }
 \arguments{
 \item{srs}{Character string containing an SRS definition in various
@@ -166,6 +175,29 @@ northing/easting order, the data will still be easting/northing ordered.
 axis.
 \item \code{OAMS_CUSTOM}: custom-defined data axis
 }
+
+\code{srs_get_area_of_use()} is a wrapper of \code{OSRGetAreaOfUse()} in the GDAL API.
+Returns a named list containing the following elements (or returns \code{NULL} if
+the API call does not succeed):
+\itemize{
+\item \code{AreaName}: the area of use
+\item \code{WestLongitudeDeg}: the western-most longitude expressed in degree, or
+\code{NA} if the bounding box is unknown
+\item \code{SouthLatitudeDeg}: the southern-most latitude expressed in degree, or
+\code{NA} if the bounding box is unknown
+\item \code{EastLongitudeDeg}: the eastern-most longitude expressed in degree, or
+\code{NA} if the bounding box is unknown
+\item \code{NorthLatitudeDeg}: the northern-most latitude expressed in degree, or
+\code{NA} if the bounding box is unknown
+}
+
+\code{srs_get_axes_count()} returns the integer number of axes of the coordinate
+system of the SRS. Wrapper of \code{OSRGetAxesCount()} in the GDAL API.
+
+\code{srs_get_celestial_body_name()} returns the name of the celestial body of
+the SRS, e.g., \code{"Earth"} for an Earth SRS. Wrapper of
+\code{OSRGetCelestialBodyName()} in the GDAL API. Requires GDAL >= 3.12 and
+PROJ >= 8.1.
 }
 \examples{
 wkt <- 'PROJCS["ETRS89 / UTM zone 32N (N-E)",
@@ -211,6 +243,17 @@ srs_is_geocentric("EPSG:7789")
 
 srs_is_vertical("EPSG:5705")
 
+srs_get_area_of_use("EPSG:3976")
+
+srs_get_axes_count("EPSG:4326")
+srs_get_axes_count("EPSG:4979")
+
+## Requires GDAL >= 3.12 and PROJ >= 8.1
+# srs_get_celestial_body_name("EPSG:4326")
+#> [1] "Earth"
+# srs_get_celestial_body_name("IAU_2015:30100")
+#> [1] "Moon"
+
 f <- system.file("extdata/storml_elev.tif", package="gdalraster")
 ds <- new(GDALRaster, f)
 
@@ -225,7 +268,7 @@ ds$getProjection() |> srs_is_same("NAD83")
 
 ds$close()
 
-# Requires GDAL >= 3.4
+## Requires GDAL >= 3.4
 if (gdal_version_num() >= gdal_compute_version(3, 4, 0)) {
   if (srs_is_dynamic("WGS84"))
     print("WGS84 is dynamic")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2296,6 +2296,39 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// srs_get_area_of_use
+SEXP srs_get_area_of_use(const std::string& srs);
+RcppExport SEXP _gdalraster_srs_get_area_of_use(SEXP srsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    rcpp_result_gen = Rcpp::wrap(srs_get_area_of_use(srs));
+    return rcpp_result_gen;
+END_RCPP
+}
+// srs_get_axes_count
+int srs_get_axes_count(const std::string& srs);
+RcppExport SEXP _gdalraster_srs_get_axes_count(SEXP srsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    rcpp_result_gen = Rcpp::wrap(srs_get_axes_count(srs));
+    return rcpp_result_gen;
+END_RCPP
+}
+// srs_get_celestial_body_name
+std::string srs_get_celestial_body_name(const std::string& srs);
+RcppExport SEXP _gdalraster_srs_get_celestial_body_name(SEXP srsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    rcpp_result_gen = Rcpp::wrap(srs_get_celestial_body_name(srs));
+    return rcpp_result_gen;
+END_RCPP
+}
 // getPROJVersion
 std::vector<int> getPROJVersion();
 RcppExport SEXP _gdalraster_getPROJVersion() {
@@ -2575,6 +2608,9 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_srs_get_coord_epoch", (DL_FUNC) &_gdalraster_srs_get_coord_epoch, 1},
     {"_gdalraster_srs_get_utm_zone", (DL_FUNC) &_gdalraster_srs_get_utm_zone, 1},
     {"_gdalraster_srs_get_axis_mapping_strategy", (DL_FUNC) &_gdalraster_srs_get_axis_mapping_strategy, 1},
+    {"_gdalraster_srs_get_area_of_use", (DL_FUNC) &_gdalraster_srs_get_area_of_use, 1},
+    {"_gdalraster_srs_get_axes_count", (DL_FUNC) &_gdalraster_srs_get_axes_count, 1},
+    {"_gdalraster_srs_get_celestial_body_name", (DL_FUNC) &_gdalraster_srs_get_celestial_body_name, 1},
     {"_gdalraster_getPROJVersion", (DL_FUNC) &_gdalraster_getPROJVersion, 0},
     {"_gdalraster_getPROJSearchPaths", (DL_FUNC) &_gdalraster_getPROJSearchPaths, 0},
     {"_gdalraster_setPROJSearchPaths", (DL_FUNC) &_gdalraster_setPROJSearchPaths, 1},

--- a/src/srs_api.h
+++ b/src/srs_api.h
@@ -35,5 +35,6 @@ SEXP srs_get_linear_units(const std::string &srs);
 double srs_get_coord_epoch(const std::string &srs);
 int srs_get_utm_zone(const std::string &srs);
 std::string srs_get_axis_mapping_strategy(const std::string &srs);
+SEXP srs_get_area_of_use(const std::string &srs);
 
 #endif  // SRS_API_H_

--- a/tests/testthat/test-srs_api.R
+++ b/tests/testthat/test-srs_api.R
@@ -67,6 +67,18 @@ test_that("srs functions work", {
     expect_equal(srs_get_axis_mapping_strategy("WGS84"),
                  "OAMS_AUTHORITY_COMPLIANT")
 
+    aou <- srs_get_area_of_use("EPSG:3976")
+    expect_true(is.list(aou))
+    expect_equal(length(aou), 5)
+    expect_true(is.character(aou$AreaName))
+    expect_equal(aou$WestLongitudeDeg, -180)
+    expect_equal(aou$SouthLatitudeDeg, -90)
+    expect_equal(aou$EastLongitudeDeg, 180)
+    expect_equal(aou$NorthLatitudeDeg, -60)
+
+    expect_equal(srs_get_axes_count("EPSG:4326"), 2)
+    expect_equal(srs_get_axes_count("EPSG:4979"), 3)
+
     # errors
     expect_error(epsg_to_wkt(-1))
     expect_equal(srs_to_wkt(""), "")
@@ -85,15 +97,25 @@ test_that("srs functions work", {
     expect_error(srs_get_linear_units("invalid"))
     expect_error(srs_get_utm_zone("invalid"))
     expect_error(srs_get_axis_mapping_strategy("invalid"))
-
+    expect_error(srs_get_area_of_use("invalid"))
+    expect_true(is.null(srs_get_area_of_use("")))
+    expect_error(srs_get_axes_count("invalid"))
+    expect_true(is.na(srs_get_axes_count("")))
 
     # dynamic srs GDAL >= 3.4
-    skip_if(gdal_version_num() < 3040000)
+    skip_if(gdal_version_num() < gdal_compute_version(3, 4, 0))
 
     expect_true(srs_is_dynamic("EPSG:4326"))
     expect_false(srs_is_dynamic("EPSG:4171"))
     expect_error(srs_is_dynamic("invalid"))
     expect_equal(srs_get_coord_epoch("WGS84"), 0.0)
     expect_error(srs_get_coord_epoch("invalid"))
-})
 
+    # celestial body name GDAL >= 3.12, PROJ >= 8.1
+    skip_if(gdal_version_num() < gdal_compute_version(3, 12, 0))
+    pv <- proj_version()
+    skip_if(pv$major < 8 || (pv$major == 8 && pv$minor < 1))
+    expect_equal(srs_get_celestial_body_name("EPSG:4326"), "Earth")
+    expect_error(srs_get_celestial_body_name("invalid"))
+    expect_equal(srs_get_celestial_body_name(""), "")
+})


### PR DESCRIPTION
Add to the GDAL Spatial Reference System API bindings.