### PR TITLE
Add srs_get_axes(): return a list of the axis names and orientations for a spatial coordinate reference system

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -3226,6 +3226,9 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #' `srs_get_axes_count()` returns the integer number of axes of the coordinate
 #' system of the SRS. Wrapper of `OSRGetAxesCount()` in the GDAL API.
 #'
+#' `srs_get_axes()` returns a named list of the axis names and their
+#' orientations. Wrapper of `OSRGetAxis()` in the GDAL API.
+#'
 #' `srs_get_celestial_body_name()` returns the name of the celestial body of
 #' the SRS, e.g., `"Earth"` for an Earth SRS. Wrapper of
 #' `OSRGetCelestialBodyName()` in the GDAL API. Requires GDAL >= 3.12 and
@@ -3249,6 +3252,8 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #' in a data frame, including a confidence value (0-100) for each match. The
 #' default is `FALSE` which returns a character string in the form
 #' `"EPSG:<code>"` for the first match (highest confidence).
+#' @param target_key Optional character string giving the coordinate system
+#' part to query, either `"PROJCS"` or `"GEOGCS"` (case-insensitive)
 #'
 #' @seealso
 #' [srs_convert]
@@ -3301,6 +3306,9 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #'
 #' srs_get_axes_count("EPSG:4326")
 #' srs_get_axes_count("EPSG:4979")
+#'
+#' ## ordered list of axis names and their orientation
+#' srs_get_axes("EPSG:4326+5773")
 #'
 #' ## Requires GDAL >= 3.12 and PROJ >= 8.1
 #' # srs_get_celestial_body_name("EPSG:4326")
@@ -3417,6 +3425,11 @@ srs_get_area_of_use <- function(srs) {
 #' @rdname srs_query
 srs_get_axes_count <- function(srs) {
     .Call(`_gdalraster_srs_get_axes_count`, srs)
+}
+
+#' @rdname srs_query
+srs_get_axes <- function(srs, target_key = NULL) {
+    .Call(`_gdalraster_srs_get_axes`, srs, target_key)
 }
 
 #' @rdname srs_query

--- a/man/srs_query.Rd
+++ b/man/srs_query.Rd
@@ -20,6 +20,7 @@
 \alias{srs_get_axis_mapping_strategy}
 \alias{srs_get_area_of_use}
 \alias{srs_get_axes_count}
+\alias{srs_get_axes}
 \alias{srs_get_celestial_body_name}
 \title{Obtain information about a spatial reference system}
 \usage{
@@ -65,6 +66,8 @@ srs_get_area_of_use(srs)
 
 srs_get_axes_count(srs)
 
+srs_get_axes(srs, target_key = NULL)
+
 srs_get_celestial_body_name(srs)
 }
 \arguments{
@@ -91,6 +94,9 @@ in the GDAL Spatial Reference System API. Defaults to \code{NO}.}
 \item{ignore_coord_epoch}{Logical scalar. If \code{TRUE}, sets
 \code{IGNORE_COORDINATE_EPOCH=YES} in the call to \code{OSRIsSameEx()}
 in the GDAL Spatial Reference System API. Defaults to \code{NO}.}
+
+\item{target_key}{Optional character string giving the coordinate system
+part to query, either \code{"PROJCS"} or \code{"GEOGCS"} (case-insensitive)}
 }
 \description{
 Bindings to a subset of the GDAL Spatial Reference System API
@@ -194,6 +200,9 @@ the API call does not succeed):
 \code{srs_get_axes_count()} returns the integer number of axes of the coordinate
 system of the SRS. Wrapper of \code{OSRGetAxesCount()} in the GDAL API.
 
+\code{srs_get_axes()} returns a named list of the axis names and their
+orientations. Wrapper of \code{OSRGetAxis()} in the GDAL API.
+
 \code{srs_get_celestial_body_name()} returns the name of the celestial body of
 the SRS, e.g., \code{"Earth"} for an Earth SRS. Wrapper of
 \code{OSRGetCelestialBodyName()} in the GDAL API. Requires GDAL >= 3.12 and
@@ -247,6 +256,9 @@ srs_get_area_of_use("EPSG:3976")
 
 srs_get_axes_count("EPSG:4326")
 srs_get_axes_count("EPSG:4979")
+
+## ordered list of axis names and their orientation
+srs_get_axes("EPSG:4326+5773")
 
 ## Requires GDAL >= 3.12 and PROJ >= 8.1
 # srs_get_celestial_body_name("EPSG:4326")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2318,6 +2318,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// srs_get_axes
+SEXP srs_get_axes(const std::string& srs, const Rcpp::Nullable<Rcpp::CharacterVector>& target_key);
+RcppExport SEXP _gdalraster_srs_get_axes(SEXP srsSEXP, SEXP target_keySEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::Nullable<Rcpp::CharacterVector>& >::type target_key(target_keySEXP);
+    rcpp_result_gen = Rcpp::wrap(srs_get_axes(srs, target_key));
+    return rcpp_result_gen;
+END_RCPP
+}
 // srs_get_celestial_body_name
 std::string srs_get_celestial_body_name(const std::string& srs);
 RcppExport SEXP _gdalraster_srs_get_celestial_body_name(SEXP srsSEXP) {
@@ -2621,6 +2633,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_srs_get_axis_mapping_strategy", (DL_FUNC) &_gdalraster_srs_get_axis_mapping_strategy, 1},
     {"_gdalraster_srs_get_area_of_use", (DL_FUNC) &_gdalraster_srs_get_area_of_use, 1},
     {"_gdalraster_srs_get_axes_count", (DL_FUNC) &_gdalraster_srs_get_axes_count, 1},
+    {"_gdalraster_srs_get_axes", (DL_FUNC) &_gdalraster_srs_get_axes, 2},
     {"_gdalraster_srs_get_celestial_body_name", (DL_FUNC) &_gdalraster_srs_get_celestial_body_name, 1},
     {"_gdalraster_srs_info_from_db", (DL_FUNC) &_gdalraster_srs_info_from_db, 1},
     {"_gdalraster_getPROJVersion", (DL_FUNC) &_gdalraster_getPROJVersion, 0},

--- a/src/srs_api.h
+++ b/src/srs_api.h
@@ -36,6 +36,10 @@ double srs_get_coord_epoch(const std::string &srs);
 int srs_get_utm_zone(const std::string &srs);
 std::string srs_get_axis_mapping_strategy(const std::string &srs);
 SEXP srs_get_area_of_use(const std::string &srs);
+int srs_get_axes_count(const std::string &srs);
+SEXP srs_get_axes(const std::string &srs,
+                  const Rcpp::Nullable<Rcpp::CharacterVector> &target_key);
+std::string srs_get_celestial_body_name(const std::string &srs);
 
 Rcpp::DataFrame srs_info_from_db(std::string auth_name);
 

--- a/tests/testthat/test-srs_api.R
+++ b/tests/testthat/test-srs_api.R
@@ -79,6 +79,18 @@ test_that("srs functions work", {
     expect_equal(srs_get_axes_count("EPSG:4326"), 2)
     expect_equal(srs_get_axes_count("EPSG:4979"), 3)
 
+    ax <- srs_get_axes("EPSG:4326", "GEOGCS")
+    expect_equal(names(ax), c("Geodetic latitude", "Geodetic longitude"))
+    expect_equal(ax[[1]], "north")
+    expect_equal(ax[[2]], "east")
+
+    ax <- srs_get_axes("EPSG:4326+5773")
+    expect_equal(names(ax), c("Geodetic latitude", "Geodetic longitude",
+                              "Gravity-related height"))
+    expect_equal(ax[[1]], "north")
+    expect_equal(ax[[2]], "east")
+    expect_equal(ax[[3]], "up")
+
     epsg <- srs_info_from_db("EPSG")
     expect_true(is.data.frame(epsg))
     expect_true(nrow(epsg) > 1000)
@@ -109,6 +121,9 @@ test_that("srs functions work", {
     expect_true(is.null(srs_get_area_of_use("")))
     expect_error(srs_get_axes_count("invalid"))
     expect_true(is.na(srs_get_axes_count("")))
+    expect_error(srs_get_axes("invalid"))
+    expect_error(srs_get_axes("EPSG:4326", "invalid"))
+    expect_true(is.null(srs_get_axes("")))
 
     # dynamic srs GDAL >= 3.4
     skip_if(gdal_version_num() < gdal_compute_version(3, 4, 0))


### PR DESCRIPTION
`srs_get_axes()` returns a named list of the axis names and their  orientations. Wrapper of `OSRGetAxis()` in the GDAL API.