### PR TITLE
Add srs_epsg_treats_as_lat_long() and srs_epsg_treats_as_northing_easting()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -3229,6 +3229,14 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #' `srs_get_axes()` returns a named list of the axis names and their
 #' orientations. Wrapper of `OSRGetAxis()` in the GDAL API.
 #'
+#' `srs_epsg_treats_as_lat_long()` returns `TRUE` if this geographic coordinate
+#' system should be treated as having latitude/longitude coordinate ordering.
+#' Wrapper of `OSREPSGTreatsAsLatLong()` in the GDAL API.
+#'
+#' `srs_epsg_treats_as_northing_easting()` returns `TRUE` if this geographic
+#' coordinate system should be treated as having northing/easting coordinate
+#' ordering. Wrapper of `OSREPSGTreatsAsNorthingEasting()` in the GDAL API.
+#'
 #' `srs_get_celestial_body_name()` returns the name of the celestial body of
 #' the SRS, e.g., `"Earth"` for an Earth SRS. Wrapper of
 #' `OSRGetCelestialBodyName()` in the GDAL API. Requires GDAL >= 3.12 and
@@ -3307,8 +3315,17 @@ srs_to_projjson <- function(srs, multiline = TRUE, indent_width = 2L, schema = N
 #' srs_get_axes_count("EPSG:4326")
 #' srs_get_axes_count("EPSG:4979")
 #'
-#' ## ordered list of axis names and their orientation
+#' # ordered list of axis names and their orientation
 #' srs_get_axes("EPSG:4326+5773")
+#'
+#' srs_epsg_treats_as_lat_long("WGS84")
+#'
+#' # NAD83 / Conus Albers:
+#' srs_epsg_treats_as_northing_easting("EPSG:5070")
+#' # WGS 84 / UPS North (N,E):
+#' srs_epsg_treats_as_northing_easting("EPSG:32661")
+#' # WGS 84 / UPS South (N,E):
+#' srs_epsg_treats_as_northing_easting("EPSG:32761")
 #'
 #' ## Requires GDAL >= 3.12 and PROJ >= 8.1
 #' # srs_get_celestial_body_name("EPSG:4326")
@@ -3430,6 +3447,16 @@ srs_get_axes_count <- function(srs) {
 #' @rdname srs_query
 srs_get_axes <- function(srs, target_key = NULL) {
     .Call(`_gdalraster_srs_get_axes`, srs, target_key)
+}
+
+#' @rdname srs_query
+srs_epsg_treats_as_lat_long <- function(srs) {
+    .Call(`_gdalraster_srs_epsg_treats_as_lat_long`, srs)
+}
+
+#' @rdname srs_query
+srs_epsg_treats_as_northing_easting <- function(srs) {
+    .Call(`_gdalraster_srs_epsg_treats_as_northing_easting`, srs)
 }
 
 #' @rdname srs_query

--- a/man/srs_query.Rd
+++ b/man/srs_query.Rd
@@ -21,6 +21,8 @@
 \alias{srs_get_area_of_use}
 \alias{srs_get_axes_count}
 \alias{srs_get_axes}
+\alias{srs_epsg_treats_as_lat_long}
+\alias{srs_epsg_treats_as_northing_easting}
 \alias{srs_get_celestial_body_name}
 \title{Obtain information about a spatial reference system}
 \usage{
@@ -67,6 +69,10 @@ srs_get_area_of_use(srs)
 srs_get_axes_count(srs)
 
 srs_get_axes(srs, target_key = NULL)
+
+srs_epsg_treats_as_lat_long(srs)
+
+srs_epsg_treats_as_northing_easting(srs)
 
 srs_get_celestial_body_name(srs)
 }
@@ -203,6 +209,14 @@ system of the SRS. Wrapper of \code{OSRGetAxesCount()} in the GDAL API.
 \code{srs_get_axes()} returns a named list of the axis names and their
 orientations. Wrapper of \code{OSRGetAxis()} in the GDAL API.
 
+\code{srs_epsg_treats_as_lat_long()} returns \code{TRUE} if this geographic coordinate
+system should be treated as having latitude/longitude coordinate ordering.
+Wrapper of \code{OSREPSGTreatsAsLatLong()} in the GDAL API.
+
+\code{srs_epsg_treats_as_northing_easting()} returns \code{TRUE} if this geographic
+coordinate system should be treated as having northing/easting coordinate
+ordering. Wrapper of \code{OSREPSGTreatsAsNorthingEasting()} in the GDAL API.
+
 \code{srs_get_celestial_body_name()} returns the name of the celestial body of
 the SRS, e.g., \code{"Earth"} for an Earth SRS. Wrapper of
 \code{OSRGetCelestialBodyName()} in the GDAL API. Requires GDAL >= 3.12 and
@@ -257,8 +271,17 @@ srs_get_area_of_use("EPSG:3976")
 srs_get_axes_count("EPSG:4326")
 srs_get_axes_count("EPSG:4979")
 
-## ordered list of axis names and their orientation
+# ordered list of axis names and their orientation
 srs_get_axes("EPSG:4326+5773")
+
+srs_epsg_treats_as_lat_long("WGS84")
+
+# NAD83 / Conus Albers:
+srs_epsg_treats_as_northing_easting("EPSG:5070")
+# WGS 84 / UPS North (N,E):
+srs_epsg_treats_as_northing_easting("EPSG:32661")
+# WGS 84 / UPS South (N,E):
+srs_epsg_treats_as_northing_easting("EPSG:32761")
 
 ## Requires GDAL >= 3.12 and PROJ >= 8.1
 # srs_get_celestial_body_name("EPSG:4326")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2330,6 +2330,28 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// srs_epsg_treats_as_lat_long
+bool srs_epsg_treats_as_lat_long(const std::string& srs);
+RcppExport SEXP _gdalraster_srs_epsg_treats_as_lat_long(SEXP srsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    rcpp_result_gen = Rcpp::wrap(srs_epsg_treats_as_lat_long(srs));
+    return rcpp_result_gen;
+END_RCPP
+}
+// srs_epsg_treats_as_northing_easting
+bool srs_epsg_treats_as_northing_easting(const std::string& srs);
+RcppExport SEXP _gdalraster_srs_epsg_treats_as_northing_easting(SEXP srsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::string& >::type srs(srsSEXP);
+    rcpp_result_gen = Rcpp::wrap(srs_epsg_treats_as_northing_easting(srs));
+    return rcpp_result_gen;
+END_RCPP
+}
 // srs_get_celestial_body_name
 std::string srs_get_celestial_body_name(const std::string& srs);
 RcppExport SEXP _gdalraster_srs_get_celestial_body_name(SEXP srsSEXP) {
@@ -2634,6 +2656,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_srs_get_area_of_use", (DL_FUNC) &_gdalraster_srs_get_area_of_use, 1},
     {"_gdalraster_srs_get_axes_count", (DL_FUNC) &_gdalraster_srs_get_axes_count, 1},
     {"_gdalraster_srs_get_axes", (DL_FUNC) &_gdalraster_srs_get_axes, 2},
+    {"_gdalraster_srs_epsg_treats_as_lat_long", (DL_FUNC) &_gdalraster_srs_epsg_treats_as_lat_long, 1},
+    {"_gdalraster_srs_epsg_treats_as_northing_easting", (DL_FUNC) &_gdalraster_srs_epsg_treats_as_northing_easting, 1},
     {"_gdalraster_srs_get_celestial_body_name", (DL_FUNC) &_gdalraster_srs_get_celestial_body_name, 1},
     {"_gdalraster_srs_info_from_db", (DL_FUNC) &_gdalraster_srs_info_from_db, 1},
     {"_gdalraster_getPROJVersion", (DL_FUNC) &_gdalraster_getPROJVersion, 0},

--- a/src/srs_api.h
+++ b/src/srs_api.h
@@ -39,6 +39,8 @@ SEXP srs_get_area_of_use(const std::string &srs);
 int srs_get_axes_count(const std::string &srs);
 SEXP srs_get_axes(const std::string &srs,
                   const Rcpp::Nullable<Rcpp::CharacterVector> &target_key);
+bool srs_epsg_treats_as_lat_long(const std::string &srs);
+bool srs_epsg_treats_as_northing_easting(const std::string &srs);
 std::string srs_get_celestial_body_name(const std::string &srs);
 
 Rcpp::DataFrame srs_info_from_db(std::string auth_name);

--- a/tests/testthat/test-srs_api.R
+++ b/tests/testthat/test-srs_api.R
@@ -91,6 +91,13 @@ test_that("srs functions work", {
     expect_equal(ax[[2]], "east")
     expect_equal(ax[[3]], "up")
 
+    expect_true(srs_epsg_treats_as_lat_long("WGS84"))
+    
+    # NAD83 / Conus Albers:
+    expect_false(srs_epsg_treats_as_northing_easting("EPSG:5070"))
+    # WGS 84 / UPS North (N,E):
+    expect_true(srs_epsg_treats_as_northing_easting("EPSG:32661"))
+
     epsg <- srs_info_from_db("EPSG")
     expect_true(is.data.frame(epsg))
     expect_true(nrow(epsg) > 1000)


### PR DESCRIPTION
`srs_epsg_treats_as_lat_long()` returns `TRUE` if this geographic coordinate system should be treated as having latitude/longitude coordinate ordering. Wrapper of `OSREPSGTreatsAsLatLong()` in the GDAL API.

`srs_epsg_treats_as_northing_easting()` returns `TRUE` if this geographic coordinate system should be treated as having northing/easting coordinate ordering. Wrapper of `OSREPSGTreatsAsNorthingEasting()` in the GDAL API.