### PR TITLE
Add GDALRaster::getSpatialRef() synonym

### DIFF
--- a/R/gdalraster.R
+++ b/R/gdalraster.R
@@ -82,6 +82,7 @@
 #'
 #' ds$getProjection()
 #' ds$getProjectionRef()
+#' ds$getSpatialRef()
 #' ds$setProjection(projection)
 #'
 #' ds$bbox()
@@ -316,6 +317,10 @@
 #' \code{projection} is a string in OGC WKT format.
 #' Returns logical \code{TRUE} on success or \code{FALSE} if the projection
 #' could not be set.
+#'
+#' \code{$getSpatialRef()}\cr
+#' Returns the coordinate reference system of the raster as an OGC WKT
+#' format string. Equivalent to \code{ds$getProjectionRef()}.
 #'
 #' \code{$bbox()}\cr
 #' Returns a numeric vector of length four containing the bounding box

--- a/man/GDALRaster-class.Rd
+++ b/man/GDALRaster-class.Rd
@@ -113,6 +113,7 @@ ds$setGeoTransform(transform)
 
 ds$getProjection()
 ds$getProjectionRef()
+ds$getSpatialRef()
 ds$setProjection(projection)
 
 ds$bbox()
@@ -352,6 +353,10 @@ Sets the projection reference for this dataset.
 \code{projection} is a string in OGC WKT format.
 Returns logical \code{TRUE} on success or \code{FALSE} if the projection
 could not be set.
+
+\code{$getSpatialRef()}\cr
+Returns the coordinate reference system of the raster as an OGC WKT
+format string. Equivalent to \code{ds$getProjectionRef()}.
 
 \code{$bbox()}\cr
 Returns a numeric vector of length four containing the bounding box

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -551,6 +551,10 @@ std::string GDALRaster::getProjectionRef() const {
     }
 }
 
+std::string GDALRaster::getSpatialRef() const {
+    return getProjectionRef();
+}
+
 bool GDALRaster::setProjection(const std::string &projection) {
     checkAccess_(GA_Update);
 
@@ -2657,6 +2661,8 @@ RCPP_MODULE(mod_GDALRaster) {
         "Return the projection (equivalent to getProjectionRef)")
     .const_method("getProjectionRef", &GDALRaster::getProjectionRef,
         "Return the projection definition for this dataset")
+    .const_method("getSpatialRef", &GDALRaster::getSpatialRef,
+        "Return the spatial reference (equivalent to getProjectionRef)")
     .method("setProjection", &GDALRaster::setProjection,
         "Set the projection reference string for this dataset")
     .const_method("bbox", &GDALRaster::bbox,

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -74,6 +74,7 @@ class GDALRaster {
 
     std::string getProjection() const;
     std::string getProjectionRef() const;
+    std::string getSpatialRef() const;
     bool setProjection(const std::string &projection);
 
     Rcpp::NumericVector bbox() const;

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -151,6 +151,8 @@ test_that("get/set metadata works", {
                   nbands=1, dataType="Int32", return_obj = TRUE)
 
     srs <- ds$getProjection()
+    expect_equal(ds$getProjectionRef(), srs)
+    expect_equal(ds$getSpatialRef(), srs)
     ds2$setProjection(srs)
     gt <- ds$getGeoTransform()
     ds2$setGeoTransform(gt)


### PR DESCRIPTION
Equivalent to `GDALRaster::getProjection()` and `GDALRaster::getProjectionRef()`. Added so that there is a consistent method call between classes `GDALRaster` and `GDALVector` to get the spatial ref. Also is consistent with the `osgeo.gdal` Python API to have these three synonymous methods in class `GDALRaster` that return the spatial ref as WKT string.