### PR TITLE
Update vector read benchmarks and hardware specs

### DIFF
--- a/vignettes/articles/vector-read-benchmarks.Rmd
+++ b/vignettes/articles/vector-read-benchmarks.Rmd
@@ -63,7 +63,7 @@ bench_program <- c("bench_gdalraster_fetch.R",
                    "bench_sf_read_sf.R",
                    "bench_sf_read_sf_use_stream.R")
 
-timing <- c(25.90, 5.90, 56.98, 176.56, 25.30)
+timing <- c(11.20, 2.87, 25.01, 77.24, 11.17)
 
 df_class <- c("OGRFeatureSet", "base data.frame", "sf", "sf", "sf")
 


### PR DESCRIPTION
ArrowStream on GPKG is fast AF

rendered https://firelab.github.io/gdalraster/articles/vector-read-benchmarks.html

Although from 2022 on unspecified older hardware, the timing to read the 3.3 million features in pure C++ using the traditional GetNextFeature() and related API from C - _not populating a data frame or other data structure_ - was 7.6 s, and 4.8 s using the GetArrowStream() API in C++, for comparison:
https://gdal.org/en/stable/development/rfc/rfc86_column_oriented_api.html#benchmarks

(the Windows CI fail is unrelated see #851)