### PR TITLE
Geom API: add g_build_polygon_from_edges(), wrapper of OGRBuildPolygonFromEdges()

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2633,6 +2633,11 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_build_polygon_from_edges <- function(lines, auto_close, tolerance, as_iso, byte_order) {
+    .Call(`_gdalraster_g_build_polygon_from_edges`, lines, auto_close, tolerance, as_iso, byte_order)
+}
+
+#' @noRd
 .g_is_valid <- function(geom, quiet = FALSE) {
     .Call(`_gdalraster_g_is_valid`, geom, quiet)
 }

--- a/man/g_factory.Rd
+++ b/man/g_factory.Rd
@@ -5,6 +5,7 @@
 \alias{g_create}
 \alias{g_add_geom}
 \alias{g_get_geom}
+\alias{g_build_polygon_from_edges}
 \title{Create WKB/WKT geometries from vertices, and add/get sub-geometries}
 \usage{
 g_create(
@@ -26,6 +27,15 @@ g_add_geom(
 g_get_geom(
   container,
   sub_geom_idx,
+  as_wkb = TRUE,
+  as_iso = FALSE,
+  byte_order = "LSB"
+)
+
+g_build_polygon_from_edges(
+  lines,
+  auto_close = TRUE,
+  tolerance = 0,
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB"
@@ -58,12 +68,22 @@ a container geometry type.}
 
 \item{sub_geom_idx}{An integer value giving the 1-based index of a
 sub-geometry (numeric values will be coerced to integer by truncation).}
+
+\item{lines}{Either a raw vector of WKB or a character string of WKT for
+a GeometryCollection or MultiLineString.}
+
+\item{auto_close}{A logical value, \code{TRUE} if the polygon should be closed
+when first and last points of the ring are the same (the default).}
+
+\item{tolerance}{A numeric value giving the tolerance into which two arcs are
+considered close enough to be joined.}
 }
 \value{
 A geometry as WKB raw vector by default, or a WKT string if
 \code{as_wkb = FALSE}. In the case of multiple input points for creating Point
 geometry type, a list of WKB raw vectors or character vector of WKT strings
-will be returned.
+will be returned. \code{NULL} is returned with a warning if the an error occurs
+in the geometry operation.
 }
 \description{
 These functions create WKB/WKT geometries from input vertices, and build
@@ -92,6 +112,9 @@ the container geometry is not modified.
 indexing). For a polygon, requesting the first sub-geometry returns the
 exterior ring (\code{sub_geom_idx = 1}), and the interior rings are returned for
 \code{sub_geom_idx > 1}.
+
+\code{g_build_polygon_from_edges()} builds a polygon from a set of arcs given
+in a \code{GeometryCollection} or \code{MultiLineString}.
 }
 \note{
 A \code{POLYGON} can be created for a single ring which will be the

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1240,16 +1240,31 @@ BEGIN_RCPP
 END_RCPP
 }
 // g_get_geom
-SEXP g_get_geom(const Rcpp::RawVector& container, int sub_geom_idx, bool as_iso, const std::string& byte_order);
+SEXP g_get_geom(const Rcpp::RObject& container, int sub_geom_idx, bool as_iso, const std::string& byte_order);
 RcppExport SEXP _gdalraster_g_get_geom(SEXP containerSEXP, SEXP sub_geom_idxSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const Rcpp::RawVector& >::type container(containerSEXP);
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type container(containerSEXP);
     Rcpp::traits::input_parameter< int >::type sub_geom_idx(sub_geom_idxSEXP);
     Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
     rcpp_result_gen = Rcpp::wrap(g_get_geom(container, sub_geom_idx, as_iso, byte_order));
+    return rcpp_result_gen;
+END_RCPP
+}
+// g_build_polygon_from_edges
+SEXP g_build_polygon_from_edges(const Rcpp::RObject& lines, bool auto_close, double tolerance, bool as_iso, const std::string& byte_order);
+RcppExport SEXP _gdalraster_g_build_polygon_from_edges(SEXP linesSEXP, SEXP auto_closeSEXP, SEXP toleranceSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::RObject& >::type lines(linesSEXP);
+    Rcpp::traits::input_parameter< bool >::type auto_close(auto_closeSEXP);
+    Rcpp::traits::input_parameter< double >::type tolerance(toleranceSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_build_polygon_from_edges(lines, auto_close, tolerance, as_iso, byte_order));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2573,6 +2588,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_add_geom", (DL_FUNC) &_gdalraster_g_add_geom, 4},
     {"_gdalraster_g_geom_count", (DL_FUNC) &_gdalraster_g_geom_count, 2},
     {"_gdalraster_g_get_geom", (DL_FUNC) &_gdalraster_g_get_geom, 4},
+    {"_gdalraster_g_build_polygon_from_edges", (DL_FUNC) &_gdalraster_g_build_polygon_from_edges, 5},
     {"_gdalraster_g_is_valid", (DL_FUNC) &_gdalraster_g_is_valid, 2},
     {"_gdalraster_g_make_valid", (DL_FUNC) &_gdalraster_g_make_valid, 6},
     {"_gdalraster_g_normalize", (DL_FUNC) &_gdalraster_g_normalize, 4},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -42,8 +42,12 @@ Rcpp::RawVector g_add_geom(const Rcpp::RawVector &sub_geom,
                            bool as_iso, const std::string &byte_order);
 
 int g_geom_count(const Rcpp::RObject &geom, bool quiet);
-SEXP g_get_geom(const Rcpp::RawVector &container, int sub_geom_idx,
+SEXP g_get_geom(const Rcpp::RObject &container, int sub_geom_idx,
                 bool as_iso, const std::string &byte_order);
+
+SEXP g_build_polygon_from_edges(const Rcpp::RObject &lines,
+                                bool auto_close, double tolerance,
+                                bool as_iso, const std::string &byte_order);
 
 Rcpp::LogicalVector g_is_valid(const Rcpp::RObject &geom, bool quiet);
 SEXP g_make_valid(const Rcpp::RObject &geom, const std::string &method,

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -521,6 +521,52 @@ test_that("g_factory functions work", {
     expect_error(g_add_geom(g_create("LINESTRING"), geom, as_iso = "ISO"))
     expect_no_error(g_add_geom(g_create("LINESTRING"), geom, byte_order = NULL))
     expect_error(g_add_geom(g_create("LINESTRING"), geom, byte_order = TRUE))
+
+    ## build polygon from edges
+    wkt_vector <- c(
+        "LINESTRING (-87.601595 30.999522,-87.599623 31.000059,-87.599219 31.00017)",
+        "LINESTRING (-87.601595 30.999522,-87.604349 30.999493,-87.606935 30.99952)",
+        "LINESTRING (-87.59966 31.000756,-87.599851 31.000805,-87.599992 31.000805,-87.600215 31.000761,-87.600279 31.000723,-87.600586 31.000624,-87.601256 31.000508,-87.602501 31.000447,-87.602801 31.000469,-87.603108 31.000579,-87.603331 31.000716,-87.603523 31.000909,-87.603766 31.001233,-87.603913 31.00136)",
+        "LINESTRING (-87.606134 31.000182,-87.605885 31.000325,-87.605343 31.000716,-87.60466 31.001117,-87.604468 31.0012,-87.603913 31.00136)",
+        "LINESTRING (-87.599219 31.00017,-87.599289 31.0003,-87.599398 31.000426,-87.599564 31.000547,-87.599609 31.000701,-87.59966 31.000756)",
+        "LINESTRING (-87.606935 30.99952,-87.606713 30.999799,-87.6064 30.999981,-87.606134 31.000182)"
+    )
+
+    # geometry collection of line strings
+    line_coll <- "GEOMETRYCOLLECTION EMPTY"
+    for (wkt in wkt_vector) {
+        line_coll <- g_add_geom(wkt, line_coll)
+    }
+
+    poly <- g_build_polygon_from_edges(line_coll)
+    expect_equal(g_name(poly), "POLYGON")
+    expect_true(g_is_valid(poly))
+
+    # multilinestring
+    line_coll <- "MULTILINESTRING EMPTY"
+    for (wkt in wkt_vector) {
+        line_coll <- g_add_geom(wkt, line_coll)
+    }
+
+    poly <- g_build_polygon_from_edges(line_coll)
+    expect_equal(g_name(poly), "POLYGON")
+    expect_true(g_is_valid(poly))
+
+    # invalid geometries
+    pt <- "POINT (0 1)"
+    expect_warning(poly <- g_build_polygon_from_edges(pt))
+    expect_true(is.null(poly))
+
+    coll <- "GEOMETRYCOLLECTION (LINESTRING(0 1,2 3),POINT(0 1),LINESTRING(0 1,-2 3),LINESTRING(-2 3,2 3))"
+    expect_warning(poly <- g_build_polygon_from_edges(pt))
+    expect_true(is.null(poly))
+
+    # errors/input validation
+    expect_error(g_build_polygon_from_edges(line_coll, auto_close = 0))
+    expect_error(g_build_polygon_from_edges(line_coll, tolerance = FALSE))
+    expect_error(g_build_polygon_from_edges(line_coll, as_wkb = "WKB"))
+    expect_error(g_build_polygon_from_edges(line_coll, as_iso = "ISO"))
+    expect_error(g_build_polygon_from_edges(line_coll, byte_order = TRUE))
 })
 
 test_that("WKB/WKT conversion functions work", {


### PR DESCRIPTION
`g_build_polygon_from_edges()` builds a polygon from a set of arcs given in a `GeometryCollection` or `MultiLineString`.