### PR TITLE
Geom API: add g_build_collection(), build a collection-type geometry from a set of input geometries given as a list of WKB raw vectors or a character vector of WKT strings

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2725,6 +2725,11 @@ has_geos <- function() {
 }
 
 #' @noRd
+.g_build_collection <- function(geoms, coll_type, as_iso, byte_order) {
+    .Call(`_gdalraster_g_build_collection`, geoms, coll_type, as_iso, byte_order)
+}
+
+#' @noRd
 .g_build_polygon_from_edges <- function(lines, auto_close, tolerance, as_iso, byte_order) {
     .Call(`_gdalraster_g_build_polygon_from_edges`, lines, auto_close, tolerance, as_iso, byte_order)
 }

--- a/man/g_factory.Rd
+++ b/man/g_factory.Rd
@@ -5,8 +5,9 @@
 \alias{g_create}
 \alias{g_add_geom}
 \alias{g_get_geom}
+\alias{g_build_collection}
 \alias{g_build_polygon_from_edges}
-\title{Create WKB/WKT geometries from vertices, and add/get sub-geometries}
+\title{Geometry factory functions}
 \usage{
 g_create(
   geom_type,
@@ -27,6 +28,14 @@ g_add_geom(
 g_get_geom(
   container,
   sub_geom_idx,
+  as_wkb = TRUE,
+  as_iso = FALSE,
+  byte_order = "LSB"
+)
+
+g_build_collection(
+  geoms,
+  coll_type = "GEOMETRYCOLLECTION",
   as_wkb = TRUE,
   as_iso = FALSE,
   byte_order = "LSB"
@@ -69,38 +78,45 @@ a container geometry type.}
 \item{sub_geom_idx}{An integer value giving the 1-based index of a
 sub-geometry (numeric values will be coerced to integer by truncation).}
 
-\item{lines}{Either a raw vector of WKB or a character string of WKT for
-a GeometryCollection or MultiLineString.}
+\item{geoms}{Either a list of WKB raw vectors or character vector of WKT
+strings.}
 
-\item{auto_close}{A logical value, \code{TRUE} if the polygon should be closed
-when first and last points of the ring are the same (the default).}
+\item{coll_type}{A character string specifying a geometry collection type,
+e.g., \code{"GEOMETRYCOLLECTION"} (the default), \code{"MULTIPOINT"},
+\code{"MULTILINESTRING"}, \verb{"MULTIPOLYGON".}}
+
+\item{lines}{Either a raw vector of WKB or a character string of WKT
+specifying a \code{GeometryCollection} or \code{MultiLineString}, or a list of WKB raw
+vectors for \code{LineString}s, or a character vector of WKT strings.}
+
+\item{auto_close}{A logical value, \code{TRUE} (the default) if the polygon should
+be closed when first and last points of the ring are the same.}
 
 \item{tolerance}{A numeric value giving the tolerance into which two arcs are
 considered close enough to be joined.}
 }
 \value{
 A geometry as WKB raw vector by default, or a WKT string if
-\code{as_wkb = FALSE}. In the case of multiple input points for creating Point
-geometry type, a list of WKB raw vectors or character vector of WKT strings
-will be returned. \code{NULL} is returned with a warning if the an error occurs
+\code{as_wkb = FALSE}. In the case of multiple input points for creating \verb{Point`` geometry type, a list of WKB raw vectors or character vector of WKT strings will be returned. }NULL` is returned with a warning if the an error occurs
 in the geometry operation.
 }
 \description{
-These functions create WKB/WKT geometries from input vertices, and build
-container geometry types from sub-geometries.
+These functions create WKB/WKT geometries from input vertices or arcs, and
+build container geometry types from sub-geometries.
 }
 \details{
 These functions use the GEOS library via GDAL headers.
 
 \code{g_create()} creates a geometry object from the given point(s) and returns
 a raw vector of WKB (the default) or a character string of WKT. Currently
-supports creating \code{Point}, \code{MultiPoint}, \code{LineString}, \code{Polygon}, and
-\code{GeometryCollection.}
-If multiple input points are given for creating \code{Point} type, then multiple
+supports creating \code{Point}, \code{MultiPoint}, \code{LineString}, and \code{Polygon}
+(including \verb{25D}, \code{Z}, \code{M}, \code{ZM} variants).
+If multiple input points are given for creating \code{Point}, then multiple
 geometries will be returned as a list of WKB raw vectors, or character
-vector of WKT strings (if \code{as_wkb = FALSE}). Otherwise, a single geometry
-is created from the input points. Only an empty \code{GeometryCollection} can be
-created with this function, for subsequent use with \code{g_add_geom()}.
+vector of WKT strings if \code{as_wkb = FALSE}. Otherwise, a single geometry
+is created from the input points. Only an empty \code{GeometryCollection} /
+\code{MultiLineString} / \code{MultiPolygon} can be created with this function (for
+subsequent use with \code{g_add_geom()}).
 
 \code{g_add_geom()} adds a geometry to a geometry container, e.g.,
 \code{Polygon} to \code{Polygon} (to add an interior ring), \code{Point} to \code{MultiPoint},
@@ -113,8 +129,14 @@ indexing). For a polygon, requesting the first sub-geometry returns the
 exterior ring (\code{sub_geom_idx = 1}), and the interior rings are returned for
 \code{sub_geom_idx > 1}.
 
+\code{g_build_collection()} builds a collection / container type geometry, e.g.,
+\code{GeometryCollection}, \code{MultiPoint}, \code{MultiLineString}, \code{MultiPolygon}, from
+a set of input geometries given as a list of WKB raw vectors or a character
+vector of WKT strings.
+
 \code{g_build_polygon_from_edges()} builds a polygon from a set of arcs given
-in a \code{GeometryCollection} or \code{MultiLineString}.
+in a \code{GeometryCollection}, \code{MultiLineString}, list of WKB raw vectors, or
+character vector of WKT strings.
 }
 \note{
 A \code{POLYGON} can be created for a single ring which will be the
@@ -155,15 +177,18 @@ mp2 <- g_create("POINT", c(11, 2)) |> g_add_geom(mp2)
 mp2 <- g_create("POINT", c(12, 3)) |> g_add_geom(mp2)
 g_wk2wk(mp2)
 
-# get sub-geometry from container
-g_get_geom(mp2, 2, as_wkb = FALSE)
+# or build a container/collection type geometry from WKB list or WKT vector
+lines <- c("LINESTRING (0 0,3 0)",
+           "LINESTRING (3 0,3 4)",
+           "LINESTRING (3 4,0 0)")
+(multi_line <- g_build_collection(lines, "MULTILINESTRING", as_wkb = FALSE))
 
-# plot WKT strings or a list of WKB raw vectors
-pts <- c(0, 0,
-         3, 0,
-         3, 4,
-         0, 0)
-m <- matrix(pts, ncol = 2, byrow = TRUE)
-(g <- g_create("POLYGON", m, as_wkb = FALSE))
-plot_geom(g)
+# get sub-geometry from container
+g_get_geom(multi_line, 2, as_wkb = FALSE)
+
+# build a polygon from a set of arcs
+(poly <- g_build_polygon_from_edges(lines, as_wkb = FALSE))
+
+# plot a vector of WKT strings or list of WKB raw vectors
+plot_geom(poly)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1276,6 +1276,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// g_build_collection
+Rcpp::RawVector g_build_collection(const Rcpp::List& geoms, const std::string& coll_type, bool as_iso, const std::string& byte_order);
+RcppExport SEXP _gdalraster_g_build_collection(SEXP geomsSEXP, SEXP coll_typeSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const Rcpp::List& >::type geoms(geomsSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type coll_type(coll_typeSEXP);
+    Rcpp::traits::input_parameter< bool >::type as_iso(as_isoSEXP);
+    Rcpp::traits::input_parameter< const std::string& >::type byte_order(byte_orderSEXP);
+    rcpp_result_gen = Rcpp::wrap(g_build_collection(geoms, coll_type, as_iso, byte_order));
+    return rcpp_result_gen;
+END_RCPP
+}
 // g_build_polygon_from_edges
 SEXP g_build_polygon_from_edges(const Rcpp::RObject& lines, bool auto_close, double tolerance, bool as_iso, const std::string& byte_order);
 RcppExport SEXP _gdalraster_g_build_polygon_from_edges(SEXP linesSEXP, SEXP auto_closeSEXP, SEXP toleranceSEXP, SEXP as_isoSEXP, SEXP byte_orderSEXP) {
@@ -2613,6 +2627,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_g_add_geom", (DL_FUNC) &_gdalraster_g_add_geom, 4},
     {"_gdalraster_g_geom_count", (DL_FUNC) &_gdalraster_g_geom_count, 2},
     {"_gdalraster_g_get_geom", (DL_FUNC) &_gdalraster_g_get_geom, 4},
+    {"_gdalraster_g_build_collection", (DL_FUNC) &_gdalraster_g_build_collection, 4},
     {"_gdalraster_g_build_polygon_from_edges", (DL_FUNC) &_gdalraster_g_build_polygon_from_edges, 5},
     {"_gdalraster_g_is_valid", (DL_FUNC) &_gdalraster_g_is_valid, 2},
     {"_gdalraster_g_make_valid", (DL_FUNC) &_gdalraster_g_make_valid, 6},

--- a/src/geom_api.h
+++ b/src/geom_api.h
@@ -11,7 +11,7 @@
 
 #include <Rcpp.h>
 
-#include <ogr_geometry.h>
+#include <ogr_api.h>
 
 #include <string>
 #include <vector>
@@ -19,9 +19,9 @@
 std::vector<int> getGEOSVersion();
 bool has_geos();  // GDAL built against GEOS is required at gdalraster 1.10
 
-OGRGeometryH createGeomFromWkb(const Rcpp::RawVector &wkb);
-bool exportGeomToWkb(OGRGeometryH hGeom, unsigned char *wkb, bool as_iso,
-                     const std::string &byte_order);
+OGRGeometryH createGeomFromWkb_(const Rcpp::RawVector &wkb);
+bool exportGeomToWkb_(OGRGeometryH hGeom, unsigned char *wkb, bool as_iso,
+                      const std::string &byte_order);
 
 Rcpp::String g_wkb2wkt(const Rcpp::RObject &geom, bool as_iso);
 
@@ -44,6 +44,11 @@ Rcpp::RawVector g_add_geom(const Rcpp::RawVector &sub_geom,
 int g_geom_count(const Rcpp::RObject &geom, bool quiet);
 SEXP g_get_geom(const Rcpp::RObject &container, int sub_geom_idx,
                 bool as_iso, const std::string &byte_order);
+
+Rcpp::RawVector g_build_collection(const Rcpp::List &geoms,
+                                   const std::string &coll_type,
+                                   bool as_iso,
+                                   const std::string &byte_order);
 
 SEXP g_build_polygon_from_edges(const Rcpp::RObject &lines,
                                 bool auto_close, double tolerance,


### PR DESCRIPTION
This PR:
* adds `g_build_collection()`: build a collection/container geometry - e.g., `GeometryCollection`, `MultiPoint`, `MultiLineString`, `MultiPolygon` - from a set of input geometries given as a `list` of WKB `raw` vectors or a `character` vector of WKT strings
* `g_build_polygon_from_edges()` now uses `g_build_collection()` to accept the input `LineStrings` as a `list` of WKB or a `character` vector of WKT (in addition to a `GeometryCollection` or `MultiLineString`)
* also makes changes in `g_create()`, mainly if the requested geometry type is not supported for direct creation from vertices, an `EMPTY` geometry is returned in all cases, for possible subsequent use with `g_add_geom()` (e.g., `MultiLineString`, `MultiPolygon` - previously only did that for `GeometryCollection`)
* adds an underscore suffix to internal C++ function names in `src/geom_api.cpp` (now `createGeomFromWkb_()` and `exportGeomToWkb_()`) for consistency with other cpp files