### PR TITLE
synchronize as_raw and readByteAsRaw

### DIFF
--- a/R/gdalraster_proc.R
+++ b/R/gdalraster_proc.R
@@ -257,7 +257,11 @@ read_ds <- function(ds, bands = NULL, xoff = 0, yoff = 0,
     for (b in bands) {
         dtype <- dt_union(dtype, ds$getDataTypeName(b))
     }
-
+    # sync as_raw with object property for Byte data
+    if (!as_raw && ds$readByteAsRaw && dtype == "Byte") {
+      as_raw <- TRUE
+    }
+    
     if (as_list) {
         r <- list()
     } else {

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -334,6 +334,12 @@ test_that("Byte I/O works", {
     ds$readByteAsRaw <- TRUE
     expect_warning(r_raw1 <- read_ds(ds, as_raw = TRUE))
 
+    ## read as raw via field only (no as_raw argument)
+    ds$readByteAsRaw <- TRUE
+    r_raw2 <- read_ds(ds)
+    expect_type(r_raw2, "raw")
+    ds$readByteAsRaw <- FALSE
+    
     deleteDataset(f)
 
     expect_type(r_int, "integer")


### PR DESCRIPTION
fixes #872 

as_raw and `$readByteAsRaw` were not correctly behaving in `read_ds`

```R
library(gdalraster)
dsn <- system.file("img", "Rlogo.png", package="png")

ds <- new(GDALRaster, dsn)
ds$readByteAsRaw <- TRUE
d <- read_ds(ds)
```