### PR TITLE
VSIFile: add a test using options in the constructor, and update documentation for options as of GDAL 3.10

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to 'GDAL'
-Version: 2.4.0.9072
+Version: 2.4.0.9073
 Authors@R: c(
     person("Chris", "Toney", email = "jctoney@gmail.com",
             role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5734-6510")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# gdalraster 2.4.0.9072 (dev)
+# gdalraster 2.4.0.9073 (dev)
 
 * class `VSIFile`: fix crash when using file open options due to incorrectly sized buffer, and add const correctness (#883, thanks to @pepijn-devries) (2026-01-27)
 

--- a/R/vsifile.R
+++ b/R/vsifile.R
@@ -46,7 +46,8 @@ SEEK_END <- "SEEK_END"
 #'  `"w+"`     \tab create file for read/write  \tab destroy contents
 #' }
 #' @param options Optional character vector of `NAME=VALUE` pairs specifying
-#' filesystem-dependent options (GDAL >= 3.3, see Details).
+#' filesystem-dependent options. These are the options provided by
+#' `VSIFOpenEx2L()` in the GDAL API (GDAL >= 3.3, see Details).
 #' @returns An object of class `VSIFile` which contains a pointer to a
 #' `VSIVirtualHandle`, and methods that operate on the file as described in
 #' Details.
@@ -96,7 +97,7 @@ SEEK_END <- "SEEK_END"
 #' required, GDAL >= 3.3 required for `options` support).
 #'
 #' The `options` argument is highly file system dependent. Supported options
-#' as of GDAL 3.9 include:
+#' as of GDAL 3.10 include:
 #' * MIME headers such as Content-Type and Content-Encoding are supported for
 #' the /vsis3/, /vsigs/, /vsiaz/, /vsiadls/ file systems.
 #' * DISABLE_READDIR_ON_OPEN=YES/NO (GDAL >= 3.6) for /vsicurl/ and other
@@ -106,6 +107,23 @@ SEEK_END <- "SEEK_END"
 #' FILE_FLAG_WRITE_THROUGH flag to the `CreateFile()` function. In that mode,
 #' the data are written to the system cache but are flushed to disk without
 #' delay.
+#'
+#' Options specific to /vsis3/, /vsigs/, /vsioss/ and /vsiaz/:
+#' * CACHE=YES/NO (GDAL >= 3.10) whether file metadata and content that is read
+#' from the network should be kept cached in memory, after file handle closing.
+#' Default is YES, unless the filename is set in CPL_VSIL_CURL_NON_CACHED.
+#' * CHUNK_SIZE=val in MiB (GDAL >= 3.10) for "w" mode. Size of a block. Default
+#' is 50 MiB. For /vsis3/, /vsigz/, /vsioss/, it can be up to 5000 MiB.
+#' For /vsiaz/, only taken into account when BLOB_TYPE=BLOCK. It can be up to
+#' 4000 MiB.
+#'
+#' Options specific to /vsiaz/ in "w" mode:
+#' * BLOB_TYPE=APPEND/BLOCK (GDAL >= 3.10) type of blob. Defaults to APPEND.
+#' Append blocks are limited to 195 GiB (however if the file size is below
+#' 4 MiB, a block blob will be created in a single PUT operation).
+#'
+#' See the GDAL documentation for `VSIFOpenEx2L()` for the most current set of
+#' available options (\url{https://gdal.org/en/stable/api/cpl.html}).
 #'
 #' ## Methods
 #'

--- a/man/VSIFile-class.Rd
+++ b/man/VSIFile-class.Rd
@@ -23,7 +23,8 @@ and the "b" does not need to be included in \code{access}.
 }}
 
 \item{options}{Optional character vector of \code{NAME=VALUE} pairs specifying
-filesystem-dependent options (GDAL >= 3.3, see Details).}
+filesystem-dependent options. These are the options provided by
+\code{VSIFOpenEx2L()} in the GDAL API (GDAL >= 3.3, see Details).}
 }
 \value{
 An object of class \code{VSIFile} which contains a pointer to a
@@ -113,7 +114,7 @@ Alternate constructor for passing \code{access} as a character string, and
 required, GDAL >= 3.3 required for \code{options} support).
 
 The \code{options} argument is highly file system dependent. Supported options
-as of GDAL 3.9 include:
+as of GDAL 3.10 include:
 \itemize{
 \item MIME headers such as Content-Type and Content-Encoding are supported for
 the /vsis3/, /vsigs/, /vsiaz/, /vsiadls/ file systems.
@@ -125,6 +126,27 @@ FILE_FLAG_WRITE_THROUGH flag to the \code{CreateFile()} function. In that mode,
 the data are written to the system cache but are flushed to disk without
 delay.
 }
+
+Options specific to /vsis3/, /vsigs/, /vsioss/ and /vsiaz/:
+\itemize{
+\item CACHE=YES/NO (GDAL >= 3.10) whether file metadata and content that is read
+from the network should be kept cached in memory, after file handle closing.
+Default is YES, unless the filename is set in CPL_VSIL_CURL_NON_CACHED.
+\item CHUNK_SIZE=val in MiB (GDAL >= 3.10) for "w" mode. Size of a block. Default
+is 50 MiB. For /vsis3/, /vsigz/, /vsioss/, it can be up to 5000 MiB.
+For /vsiaz/, only taken into account when BLOB_TYPE=BLOCK. It can be up to
+4000 MiB.
+}
+
+Options specific to /vsiaz/ in "w" mode:
+\itemize{
+\item BLOB_TYPE=APPEND/BLOCK (GDAL >= 3.10) type of blob. Defaults to APPEND.
+Append blocks are limited to 195 GiB (however if the file size is below
+4 MiB, a block blob will be created in a single PUT operation).
+}
+
+See the GDAL documentation for \code{VSIFOpenEx2L()} for the most current set of
+available options (\url{https://gdal.org/en/stable/api/cpl.html}).
 }
 
 \subsection{Methods}{

--- a/tests/testthat/test-VSIFile-class.R
+++ b/tests/testthat/test-VSIFile-class.R
@@ -1,7 +1,6 @@
-test_that("VSIFile works", {
+test_that("VSIFile constructors work", {
     lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
 
-    ## Constructors
     # default constructor, no file
     expect_no_error(vf <- new(VSIFile))
     expect_true(is(vf, "Rcpp_VSIFile"))
@@ -40,9 +39,21 @@ test_that("VSIFile works", {
     # url <- paste0(url, "lf_elev_220_mt_hood_utm.tif")
     # expect_error(vf <- new(VSIFile, url, "r", "INAVLID_OPTION=YES"))
 
-    ## Methods
+    # at least test that passing options does not crash to avoid the issue in:
+    # https://github.com/firelab/gdalraster/issues/883
 
-    # function to identify LCP file
+    skip_if(gdal_version_num() < gdal_compute_version(3, 10, 0))
+    skip_on_cran()
+
+    f_invalid <- "/vsis3/eodata/Sentinel-1/_invalid-file-name_.tif"
+    opt <- c("DISABLE_READDIR_ON_OPEN=YES", "CACHE=NO")
+    expect_error(vf <- new(VSIFile, f_invalid, "r", opt))
+})
+
+test_that("VSIFile methods work", {
+    lcp_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
+
+    # function to identify an LCP file
     is_lcp <- function(bytes) {
         values <- readBin(bytes, "integer", 3)
         if ((values[1] == 20 || values[1] == 21) &&


### PR DESCRIPTION
follow on to issue #883 and PR #884