### PR TITLE
Pass progress message to cli_progress_bar

### DIFF
--- a/src/progress_r.cpp
+++ b/src/progress_r.cpp
@@ -10,10 +10,15 @@ int CPL_STDCALL GDALTermProgressR(double dfComplete,
                                  CPL_UNUSED void *pProgressArg)
 {
   if (dfComplete == 0 || Rf_isNull(global_pb)) {
-    std::string msg(pszMessage);
-    if (msg.length() > 23) {
-      msg = msg.substr(0, 10) + "..." +
-        msg.substr(msg.length() - 10, msg.length());
+    std::string msg;
+    if (pszMessage == NULL) {
+      msg = std::string("");
+    } else {
+      msg = std::string(pszMessage);
+      if (msg.length() > 23) {
+        msg = msg.substr(0, 10) + "..." +
+          msg.substr(msg.length() - 10, msg.length());
+      }
     }
     List args =
       List::create(Named("name", msg.c_str()),


### PR DESCRIPTION
Now includes message to progress bar. As everything has to fit on 1 line, the message is abbreviated to 23 characters.

I also added `CLI_SHOULD_TICK` to make sure the progress bar isn't updated unnecessarily. Don't think it was really necessary, but just in case...