### PR TITLE
progressbar: cleanup a previously interrupted one if it exists before creating a new one

### DIFF
--- a/src/progress_r.cpp
+++ b/src/progress_r.cpp
@@ -5,21 +5,26 @@
 static SEXP global_pb = R_NilValue;
 
 int CPL_STDCALL GDALTermProgressR(double dfComplete,
-                                 CPL_UNUSED const char *pszMessage,
-                                 CPL_UNUSED void *pProgressArg)
+                                  CPL_UNUSED const char *pszMessage,
+                                  CPL_UNUSED void *pProgressArg)
 {
-  if (dfComplete == 0 || Rf_isNull(global_pb)) {
-    R_ReleaseObject(global_pb);
-    global_pb = cli_progress_bar(1, NULL);
-    R_PreserveObject(global_pb);
-  } else if (dfComplete < 1) {
-    cli_progress_set(global_pb, dfComplete);
-  } else {
-    cli_progress_done(global_pb);
-    R_ReleaseObject(global_pb);
-    global_pb = R_NilValue;
-    R_PreserveObject(global_pb);
-  }
+    if (dfComplete == 0 || Rf_isNull(global_pb)) {
+        if (!Rf_isNull(global_pb))
+            cli_progress_done(global_pb);
 
-  return TRUE;
+        R_ReleaseObject(global_pb);
+        global_pb = cli_progress_bar(1, NULL);
+        R_PreserveObject(global_pb);
+    }
+    else if (dfComplete < 1) {
+        cli_progress_set(global_pb, dfComplete);
+    }
+    else {
+        cli_progress_done(global_pb);
+        R_ReleaseObject(global_pb);
+        global_pb = R_NilValue;
+        R_PreserveObject(global_pb);
+    }
+
+    return TRUE;
 }


### PR DESCRIPTION
* as described in https://github.com/firelab/gdalraster/pull/897#issuecomment-3900643345
* also reformats `src/progress_r.cpp` with 4-space indent as used throughout

