### PR TITLE
Suppress warning messages in the `show()` method for `GDALRaster` and `GDALVector`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to 'GDAL'
-Version: 2.5.0.9013
+Version: 2.5.0.9014
 Authors@R: c(
     person("Chris", "Toney", email = "jctoney@gmail.com",
             role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5734-6510")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 2.5.0.9013 (dev)
+# gdalraster 2.5.0.9014 (dev)
+
+* suppress warning messages in the `show()` method for `GDALRaster` and `GDALVector` (e.g., if no spatial reference is defined) (2026-04-03)
 
 * complete formatting console messages with **cli** (#942) (2026-04-02)
 

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -2714,7 +2714,10 @@ void GDALRaster::close() {
     }
 }
 
-void GDALRaster::show() const {
+void GDALRaster::show() {
+    bool quiet_reset = this->quiet;
+    this->quiet = true;
+
     GDALDriverH hDriver = nullptr;
     if (m_hDataset) {
         hDriver = GDALGetDatasetDriver(m_hDataset);
@@ -2728,9 +2731,12 @@ void GDALRaster::show() const {
     const int xsize = static_cast<int>(getRasterXSize());
     const int ysize = static_cast<int>(getRasterYSize());
 
-    Rcpp::Environment pkg = Rcpp::Environment::namespace_env("gdalraster");
-    Rcpp::Function fn = pkg[".get_crs_name"];
-    std::string crs_name = Rcpp::as<std::string>(fn(getProjection()));
+    std::string crs_name = "not set";
+    if (!getProjection().empty()) {
+        Rcpp::Environment pkg = Rcpp::Environment::namespace_env("gdalraster");
+        Rcpp::Function fn = pkg[".get_crs_name"];
+        crs_name = Rcpp::as<std::string>(fn(getProjection()));
+    }
 
     cli_text_("C++ object of class {.cls GDALRaster}");
     cli_ul_();
@@ -2751,6 +2757,8 @@ void GDALRaster::show() const {
             std::to_string(bbox()[1]) + ", " + std::to_string(bbox()[2]) +
             ", " + std::to_string(bbox()[3]));
     cli_end_();
+
+    this->quiet = quiet_reset;
 }
 
 // ****************************************************************************
@@ -3061,7 +3069,7 @@ RCPP_MODULE(mod_GDALRaster) {
         "Compute checksum for raster region")
     .method("close", &GDALRaster::close,
         "Close the GDAL dataset for proper cleanup")
-    .const_method("show", &GDALRaster::show,
+    .method("show", &GDALRaster::show,
         "S4 show()")
     .method("preserveRObject_", &GDALRaster::preserveRObject_,
         "For internal use only")

--- a/src/gdalraster.h
+++ b/src/gdalraster.h
@@ -180,7 +180,7 @@ class GDALRaster {
 
     void close();
 
-    void show() const;
+    void show();
 
     // internal methods exported to R
     bool preserveRObject_(SEXP robj);

--- a/src/gdalvector.cpp
+++ b/src/gdalvector.cpp
@@ -2447,7 +2447,10 @@ void GDALVector::OGRFeatureFromList_dumpReadble(
 #endif
 }
 
-void GDALVector::show() const {
+void GDALVector::show() {
+    bool quiet_reset = this->quiet;
+    this->quiet = true;
+
     std::string lyr_name = "";
     if (m_is_sql) {
         // the API call to OGR_L_GetName() returns only "SELECT" for SQL layer
@@ -2458,9 +2461,12 @@ void GDALVector::show() const {
         lyr_name = getName();
     }
 
-    Rcpp::Environment pkg = Rcpp::Environment::namespace_env("gdalraster");
-    Rcpp::Function fn = pkg[".get_crs_name"];
-    std::string crs_name = Rcpp::as<std::string>(fn(getSpatialRef()));
+    std::string crs_name = "not set";
+    if (!getSpatialRef().empty()) {
+        Rcpp::Environment pkg = Rcpp::Environment::namespace_env("gdalraster");
+        Rcpp::Function fn = pkg[".get_crs_name"];
+        crs_name = Rcpp::as<std::string>(fn(getSpatialRef()));
+    }
 
     cli_text_("C++ object of class {.cls GDALVector}");
     cli_ul_();
@@ -2471,6 +2477,8 @@ void GDALVector::show() const {
     cli_li_("{.emph CRS}: "s + crs_name);
     cli_li_("{.emph Geometry}: "s + getGeomType());
     cli_end_();
+
+    this->quiet = quiet_reset;
 }
 
 // ****************************************************************************
@@ -4120,7 +4128,7 @@ RCPP_MODULE(mod_GDALVector) {
     .const_method("OGRFeatureFromList_dumpReadble",
         &GDALVector::OGRFeatureFromList_dumpReadble,
         "Create an OGRFeature from list and dump to console in readable form")
-    .const_method("show", &GDALVector::show,
+    .method("show", &GDALVector::show,
         "S4 show()")
 
     ;

--- a/src/gdalvector.h
+++ b/src/gdalvector.h
@@ -161,7 +161,7 @@ class GDALVector {
 
     void OGRFeatureFromList_dumpReadble(const Rcpp::List &feat) const;
 
-    void show() const;
+    void show();
 
     // methods for internal use not exposed to R
     void checkAccess_(GDALAccess access_needed) const;


### PR DESCRIPTION
e.g., if no spatial reference is defined