### PR TITLE
gdal_usage(): replace [may be repeated] with packed values, repeated arg allowed or not

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to 'GDAL'
-Version: 2.5.0.9020
+Version: 2.5.0.9021
 Authors@R: c(
     person("Chris", "Toney", email = "jctoney@gmail.com",
             role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5734-6510")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 2.5.0.9020 (dev)
+# gdalraster 2.5.0.9021 (dev)
+
+* `gdal_usage()`: replace `[may be repeated]` with packed values, repeated arg allowed or not (#953) (2026-04-18)
 
 * add `northness()` and `eastness()`: convenience functions for transforming aspect degrees, and use in a new [CLI pipeline example](https://firelab.github.io/gdalraster/articles/use-gdal-cli-from-r.html#pipeline-examples) for `gdal raster calc` (2026-04-18)
 

--- a/R/gdal_cli.R
+++ b/R/gdal_cli.R
@@ -597,16 +597,28 @@ gdal_global_reg_names <- function() {
                 if (this_arg$min_count != 1)
                     cat("    [", this_arg$max_count, " values]\n", sep = "")
 
-            } else if (this_arg$min_count > 0 &&
+            } else if (this_arg$min_count >= 0 &&
                        this_arg$max_count < .Machine$integer.max) {
 
                 cat("    [", this_arg$min_count, "..", this_arg$max_count,
                     " values]\n", sep = "")
 
-            } else if (this_arg$min_count > 0) {
-                cat("    [", this_arg$min_count, "..", " values]\n", sep = "")
-            } else if (this_arg$max_count > 1) {
-                cat("    [may be repeated]\n")
+            } else if (this_arg$min_count >= 0) {
+                cat("    [", this_arg$min_count, " or more values]\n", sep = "")
+            }
+
+            if (this_arg$max_count > 1) {
+                if (this_arg$packed_values_allowed &&
+                    this_arg$repeated_arg_allowed) {
+                    cat("    [packed values allowed, repeated arg allowed]")
+                } else if (!this_arg$packed_values_allowed &&
+                           this_arg$repeated_arg_allowed) {
+                    cat("    [packed values not allowed, repeated arg allowed]")
+                } else if (this_arg$packed_values_allowed &&
+                           !this_arg$repeated_arg_allowed) {
+                    cat("    [packed values allowed, repeated arg not allowed]")
+                }
+                cat("\n")
             }
         }
 


### PR DESCRIPTION
```
gdal_usage("vector rasterize")

Usage: vector rasterize [OPTIONS] <INPUT> <OUTPUT>

Burns vector geometries into a raster. 

Positional arguments:
  -i, --input <INPUT>
    Input vector datasets
    [required]
  -o, --output <OUTPUT>
    Output raster dataset
    [required]

Common options:
  -q, --quiet
    Quiet mode (no progress bar or warning message)

Options:
  -f, --of, --format, --output-format <OUTPUT-FORMAT>
    Output format
  --co, --creation-option <KEY>=<VALUE>
    Creation option
    [0 or more values]
    [packed values not allowed, repeated arg allowed]
  --overwrite
    Whether overwriting existing output is allowed
    [default: FALSE]
  -b, --band <BAND>
    The band(s) to burn values into (1-based index)
    [0 or more values]
    [packed values allowed, repeated arg allowed]
  --invert
    Invert the rasterization
    [default: FALSE]
  --all-touched
    Enables the ALL_TOUCHED rasterization option
  --burn <BURN>
    Burn value
    [0 or more values]
    [packed values allowed, repeated arg allowed]
  -a, --attribute-name <ATTRIBUTE-NAME>
    Attribute name
  --3d
    Indicates that a burn value should be extracted from the Z values of the feature
  -l, --input-layer <INPUT-LAYER>
    Input layer name
    [mutually exclusive with --sql]
  --where <WHERE>
    SQL where clause
  --sql <SQL>
    SQL select statement
    [mutually exclusive with --input-layer]
  --dialect <DIALECT>
    SQL dialect
  --nodata <NODATA>
    Assign a specified nodata value to output bands
  --init <INIT>
    Pre-initialize output bands with specified value
    [0 or more values]
    [packed values allowed, repeated arg allowed]
  --crs <CRS>
    Override the projection for the output file
  --transformer-option <NAME>=<VALUE>
    Set a transformer option suitable to pass to GDALCreateGenImgProjTransformer2
    [0 or more values]
    [packed values allowed, repeated arg allowed]
  --extent <xmin>,<ymin>,<xmax>,<ymax>
    Set the target georeferenced extent
    [4 values]
    [packed values allowed, repeated arg not allowed]
  --resolution <xres>,<yres>
    Set the target resolution
    [2 values]
    [packed values allowed, repeated arg not allowed]
    [mutually exclusive with --size]
  --tap, --target-aligned-pixels
    (target aligned pixels) Align the coordinates of the extent of the output file to the values of the resolution
  --size <xsize>,<ysize>
    Set the target size in pixels and lines
    [2 values]
    [packed values allowed, repeated arg not allowed]
    [mutually exclusive with --resolution]
  --ot, --datatype, --output-data-type <OUTPUT-DATA-TYPE>
    Output data type
    [UInt8|Int8|UInt16|Int16|UInt32|Int32|UInt64|Int64|CInt16|CInt32|Float16|Float32|Float64|CFloat32|CFloat64]
  --optimization <OPTIMIZATION>
    Force the algorithm used (results are identical)
    [AUTO|RASTER|VECTOR]
    [default: AUTO]
  --add
    Add to existing raster
    [default: FALSE]
  --update
    Whether to open existing dataset in update mode
    [default: FALSE]

Advanced options:
  --oo, --open-option <KEY>=<VALUE>
    Open options
    [0 or more values]
    [packed values not allowed, repeated arg allowed]
  --if, --input-format <INPUT-FORMAT>
    Input formats
    [0 or more values]
    [packed values allowed, repeated arg allowed]

For more details: <https://gdal.org/programs/gdal_vector_rasterize.html>
```