### PR TITLE
Redirect /vsistdout/ to the compliant R output stream via Rcpp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gdalraster
 Title: Bindings to 'GDAL'
-Version: 2.5.0.9102
+Version: 2.5.0.9103
 Authors@R: c(
     person("Chris", "Toney", email = "jctoney@gmail.com",
             role = c("aut", "cre"), comment = c(ORCID = "0000-0001-5734-6510")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# gdalraster 2.5.0.9102 (dev)
+# gdalraster 2.5.0.9103 (dev)
+
+* redirect `/vsistdout/` to the compliant output stream to allow using GDAL standard output streaming in the R terminal (#963) (2026-04-29)
 
 * `GDALRaster$addBand()`: accept an R vector to add a MEM band from data pointer without copying (#960) (2026-04-27)
 

--- a/src/gdalraster.cpp
+++ b/src/gdalraster.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <cstdio>
 #include <map>
 #include <string>
 #include <utility>
@@ -77,12 +78,25 @@ void gdal_silent_errors_r(CPLErr err_class, int err_no, const char *msg) {
     }
 }
 
+// VSIWriteFunction for VSIStdoutSetRedirection()
+static size_t gdal_vsistdout_redirect(
+    const void *ptr, size_t size, size_t nmemb, FILE *stream) {
+
+    if (!ptr || size == 0 || nmemb == 0)
+        return 0;
+
+    std::string out(reinterpret_cast<const char*>(ptr), size * nmemb);
+    Rcpp::Rcout << out;
+    return nmemb;
+}
+
 // [[Rcpp::init]]
 void gdal_init(DllInfo *dll) {
     CPLSetErrorHandler((CPLErrorHandler) gdal_silent_errors_r);
     GDALAllRegister();
     CPLSetErrorHandler((CPLErrorHandler) gdal_error_handler_r);
     CPLSetConfigOption("OGR_CT_FORCE_TRADITIONAL_GIS_ORDER", "YES");
+    VSIStdoutSetRedirection(gdal_vsistdout_redirect, nullptr);
 }
 
 // Map certain GDAL enums to string names for use in R

--- a/tests/testthat/test-GDALRaster-class.R
+++ b/tests/testthat/test-GDALRaster-class.R
@@ -1416,3 +1416,35 @@ test_that("read to nativeRaster works", {
     expect_true(attr(r4, "channels") == 3)
     ds$close()
 })
+
+test_that("/vsistdout/ redirection works", {
+    f <- system.file("extdata/ynp_features.zip", package = "gdalraster")
+    zf_gpkg <- file.path("/vsizip", f, "ynp_features.gpkg")
+
+    expected_output <- 'X,Y,poiname,poitype,createdate,editdate
+-110.692921344,44.7390491040001,Norris Campground Loop C Comfort Station,Flush Toilet,2024/02/23,2024/02/23
+-110.157825952,44.4784871940001,Sylvan Lake Picnic Area Vault Toilet,Vault Toilet,2024/02/23,2024/02/23
+-110.182290061,44.324319185,"5E1",Campsite,2015/12/30,2018/06/13
+-110.386556517,44.8907427240001,Tower Fall Parking Area Northern End Vault Toilet,Vault Toilet,2024/02/23,2024/02/23
+-110.826393985,44.5316894210001,,Parking Lot,2016/02/22,2020/09/21
+-110.570605761,44.41759791,Big Cone,Geyser,2016/02/17,2018/06/13
+-110.450915693,44.948928046,,Parking Lot,2016/02/22,2020/09/21
+-110.860329219,44.61843165,Firehole Canyon Swimming Area Vault Toilet,Vault Toilet,2024/02/23,2024/02/23
+-110.800428191,44.535760318,Surprise Pool,Geyser,2016/09/13,2018/06/13
+-110.235181696,44.6354910580001,The Mudkettles,Geyser,2015/11/27,2018/06/13'
+
+    expect_output(
+        ogr2ogr(zf_gpkg, "/vsistdout/", "points_of_interest",
+                c("-f", "CSV", "-lco", "GEOMETRY=AS_XY", "-limit", 10)),
+        expected_output)
+
+    skip_if(gdal_version_num() < gdal_compute_version(3, 11, 3))
+
+    expected_output <- 'admn_type,state_fips,state_name,sub_region
+"Park, monument, etc.",56,Wyoming,Mtn'
+
+    expect_output(
+        gdal_run_piped(zf_gpkg, "vector sql", "/vsistdout/", "CSV",
+                       list(sql = "SELECT * FROM ynp_bnd")),
+        expected_output)
+})


### PR DESCRIPTION
Allows to use GDAL `/vsistdout/` (standard output streaming) in R.