### PR TITLE
 get_pixel_line(): treat points "exactly" on the right or bottom raster edge as inside

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -649,7 +649,10 @@ inv_geotransform <- function(gt) {
 }
 
 #' Raster pixel/line from geospatial x,y coordinates
-#' alternate version for GDALRaster input, with bounds checking
+#' alternate version for GDALRaster input, with raster bounds checking
+#' input coordinates exactly on the bottom or right edges are considered inside
+#' matches behavior in https://github.com/OSGeo/gdal/pull/12087
+#' also consistent with GDALRaster::pixel_extract()
 #' @noRd
 .get_pixel_line_ds <- function(xy, ds) {
     .Call(`_gdalraster_get_pixel_line_ds`, xy, ds)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -3202,6 +3202,11 @@ bbox_to_wkt <- function(bbox, extend_x = 0, extend_y = 0) {
 }
 
 #' @noRd
+.equal_within_ulps <- function(x, y, n = 4L) {
+    .Call(`_gdalraster_equal_within_ulps_r_`, x, y, n)
+}
+
+#' @noRd
 NULL
 
 #' Convert spatial reference definitions to OGC WKT or PROJJSON

--- a/R/gdal_helpers.R
+++ b/R/gdal_helpers.R
@@ -579,7 +579,8 @@ apply_geotransform <- function(col_row, gt) {
 #' raster extent and a warning emitted giving the number points that were
 #' outside. This latter case is equivalent to calling the
 #' \code{$get_pixel_line()} class method on the `GDALRaster` object (see
-#' Examples).
+#' Examples). Points exactly on the raster right or bottom edge are considered
+#' inside as of \pkg{gdalraster} 2.7.0.
 #'
 #' @seealso [`GDALRaster$getGeoTransform()`][GDALRaster], [inv_geotransform()]
 #'

--- a/man/get_pixel_line.Rd
+++ b/man/get_pixel_line.Rd
@@ -33,7 +33,8 @@ the raster x/y size). If \code{gt} is obtained from an object of class
 raster extent and a warning emitted giving the number points that were
 outside. This latter case is equivalent to calling the
 \code{$get_pixel_line()} class method on the \code{GDALRaster} object (see
-Examples).
+Examples). Points exactly on the raster right or bottom edge are considered
+inside as of \pkg{gdalraster} 2.7.0.
 }
 \examples{
 pt_file <- system.file("extdata/storml_pts.csv", package="gdalraster")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -2257,6 +2257,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// equal_within_ulps_r_
+bool equal_within_ulps_r_(double x, double y, int n);
+RcppExport SEXP _gdalraster_equal_within_ulps_r_(SEXP xSEXP, SEXP ySEXP, SEXP nSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< double >::type x(xSEXP);
+    Rcpp::traits::input_parameter< double >::type y(ySEXP);
+    Rcpp::traits::input_parameter< int >::type n(nSEXP);
+    rcpp_result_gen = Rcpp::wrap(equal_within_ulps_r_(x, y, n));
+    return rcpp_result_gen;
+END_RCPP
+}
 // epsg_to_wkt
 std::string epsg_to_wkt(int epsg, bool pretty);
 RcppExport SEXP _gdalraster_epsg_to_wkt(SEXP epsgSEXP, SEXP prettySEXP) {
@@ -2829,6 +2842,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_gdalraster_progress_bar_cleanup", (DL_FUNC) &_gdalraster_progress_bar_cleanup, 0},
     {"_gdalraster_rasterize_polygon", (DL_FUNC) &_gdalraster_rasterize_polygon, 8},
     {"_gdalraster_get_data_ptr", (DL_FUNC) &_gdalraster_get_data_ptr, 1},
+    {"_gdalraster_equal_within_ulps_r_", (DL_FUNC) &_gdalraster_equal_within_ulps_r_, 3},
     {"_gdalraster_epsg_to_wkt", (DL_FUNC) &_gdalraster_epsg_to_wkt, 2},
     {"_gdalraster_srs_to_wkt", (DL_FUNC) &_gdalraster_srs_to_wkt, 3},
     {"_gdalraster_srs_to_projjson", (DL_FUNC) &_gdalraster_srs_to_projjson, 4},

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -1229,11 +1229,12 @@ Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
     Rcpp::IntegerMatrix pixel_line = Rcpp::no_init(xy_in.nrow(), 2);
     uint64_t num_outside = 0;
 
-    // these GDALRaster class methods return doubles to be <numeric> values in R
-    // prevents integer overflow if they are multiplied in R
-    // but use them as int here
-    int num_cols = static_cast<int>(ds->getRasterXSize());
-    int num_rows = static_cast<int>(ds->getRasterYSize());
+    // GDALRaster class methods for raster X/Y size return double in order to be
+    // <numeric> values in R (prevents integer overflow if they are multiplied
+    // in R). Here we're using them as int.
+    const int num_cols = static_cast<int>(ds->getRasterXSize());
+    const int num_rows = static_cast<int>(ds->getRasterYSize());
+    const Rcpp::NumericVector bbox = ds->bbox();
 
     for (R_xlen_t i = 0; i < xy_in.nrow(); ++i) {
         if (na_in[i]) {
@@ -1241,23 +1242,18 @@ Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
             pixel_line(i, 1) = NA_INTEGER;
         }
         else {
-            double geo_x = xy_in(i, 0);
-            double geo_y = xy_in(i, 1);
+            const double geo_x = xy_in(i, 0);
+            const double geo_y = xy_in(i, 1);
 
             double grid_x = inv_gt[0] + inv_gt[1] * geo_x + inv_gt[2] * geo_y;
             double grid_y = inv_gt[3] + inv_gt[4] * geo_x + inv_gt[5] * geo_y;
 
-            // allow input coordinates exactly on the bottom or right edges
+            // allow input coordinates "exactly" on the right or bottom edges
             // match behavior in: https://github.com/OSGeo/gdal/pull/12087
             // https://github.com/OSGeo/gdal/pull/12080#discussion_r2028790673
-            const bool pt_is_on_right_edge =
-                equal_within_ulps_(grid_x, ds->getRasterXSize());
-            const bool pt_is_on_bottom_edge =
-                equal_within_ulps_(grid_y, ds->getRasterYSize());
-
-            if (pt_is_on_right_edge)
+            if (equal_within_ulps_(geo_x, bbox[2]))
                 grid_x -= 0.25;
-            if (pt_is_on_bottom_edge)
+            if (equal_within_ulps_(geo_y, bbox[1]))
                 grid_y -= 0.25;
 
             // column

--- a/src/gdal_exp.cpp
+++ b/src/gdal_exp.cpp
@@ -1205,7 +1205,10 @@ Rcpp::IntegerMatrix get_pixel_line_gt(const Rcpp::RObject &xy,
 
 
 //' Raster pixel/line from geospatial x,y coordinates
-//' alternate version for GDALRaster input, with bounds checking
+//' alternate version for GDALRaster input, with raster bounds checking
+//' input coordinates exactly on the bottom or right edges are considered inside
+//' matches behavior in https://github.com/OSGeo/gdal/pull/12087
+//' also consistent with GDALRaster::pixel_extract()
 //' @noRd
 // [[Rcpp::export(name = ".get_pixel_line_ds")]]
 Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
@@ -1214,7 +1217,7 @@ Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
     const Rcpp::NumericMatrix xy_in = xy_robject_to_matrix_(xy);
 
     if (xy_in.nrow() == 0)
-        Rcpp::stop("input matri cox is empty");
+        Rcpp::stop("input matrix is empty");
 
     const Rcpp::LogicalVector na_in =
         Rcpp::is_na(xy_in.column(0)) | Rcpp::is_na(xy_in.column(1));
@@ -1225,6 +1228,13 @@ Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
 
     Rcpp::IntegerMatrix pixel_line = Rcpp::no_init(xy_in.nrow(), 2);
     uint64_t num_outside = 0;
+
+    // these GDALRaster class methods return doubles to be <numeric> values in R
+    // prevents integer overflow if they are multiplied in R
+    // but use them as int here
+    int num_cols = static_cast<int>(ds->getRasterXSize());
+    int num_rows = static_cast<int>(ds->getRasterYSize());
+
     for (R_xlen_t i = 0; i < xy_in.nrow(); ++i) {
         if (na_in[i]) {
             pixel_line(i, 0) = NA_INTEGER;
@@ -1233,18 +1243,30 @@ Rcpp::IntegerMatrix get_pixel_line_ds(const Rcpp::RObject& xy,
         else {
             double geo_x = xy_in(i, 0);
             double geo_y = xy_in(i, 1);
+
+            double grid_x = inv_gt[0] + inv_gt[1] * geo_x + inv_gt[2] * geo_y;
+            double grid_y = inv_gt[3] + inv_gt[4] * geo_x + inv_gt[5] * geo_y;
+
+            // allow input coordinates exactly on the bottom or right edges
+            // match behavior in: https://github.com/OSGeo/gdal/pull/12087
+            // https://github.com/OSGeo/gdal/pull/12080#discussion_r2028790673
+            const bool pt_is_on_right_edge =
+                equal_within_ulps_(grid_x, ds->getRasterXSize());
+            const bool pt_is_on_bottom_edge =
+                equal_within_ulps_(grid_y, ds->getRasterYSize());
+
+            if (pt_is_on_right_edge)
+                grid_x -= 0.25;
+            if (pt_is_on_bottom_edge)
+                grid_y -= 0.25;
+
             // column
-            pixel_line(i, 0) = static_cast<int>(std::floor(inv_gt[0] +
-                                                inv_gt[1] * geo_x +
-                                                inv_gt[2] * geo_y));
+            pixel_line(i, 0) = static_cast<int>(std::floor(grid_x));
             // row
-            pixel_line(i, 1) = static_cast<int>(std::floor(inv_gt[3] +
-                                                inv_gt[4] * geo_x +
-                                                inv_gt[5] * geo_y));
+            pixel_line(i, 1) = static_cast<int>(std::floor(grid_y));
 
             if (pixel_line(i, 0) < 0 || pixel_line(i, 1) < 0 ||
-                    pixel_line(i, 0) >= ds->getRasterXSize() ||
-                    pixel_line(i, 1) >= ds->getRasterYSize()) {
+                pixel_line(i, 0) >= num_cols || pixel_line(i, 1) >= num_rows) {
 
                 num_outside += 1;
                 pixel_line(i, 0) = NA_INTEGER;

--- a/src/rcpp_util.cpp
+++ b/src/rcpp_util.cpp
@@ -338,3 +338,13 @@ void cli_cat_line_() {
     Rcpp::Function fn = pkg["cat_line"];
     fn();
 }
+
+// expose equal_within_ulps_() in R for unit tests
+//' @noRd
+// [[Rcpp::export(name = ".equal_within_ulps")]]
+bool equal_within_ulps_r_(double x, double y, int n = 4) {
+    if (n < 0)
+        Rcpp::stop("`n` must be >= 0");
+
+    return equal_within_ulps_(x, y, n);
+}

--- a/src/rcpp_util.h
+++ b/src/rcpp_util.h
@@ -105,7 +105,7 @@ struct _ci_less {
 // use machine epsilon to compare floating-point values
 template <class T>
 std::enable_if_t<not std::numeric_limits<T>::is_integer, bool>
-equal_within_ulps_(T x, T y, std::size_t n = 1)
+equal_within_ulps_(T x, T y, std::size_t n = 2)
 {
     // Since `epsilon()` is the gap size (ULP, unit in the last place)
     // of floating-point numbers in interval [1, 2), we can scale it to

--- a/src/rcpp_util.h
+++ b/src/rcpp_util.h
@@ -103,10 +103,17 @@ struct _ci_less {
 
 // https://en.cppreference.com/cpp/types/numeric_limits/epsilon
 // use machine epsilon to compare floating-point values
+// This works for `NaN` and therefore R `NA`.
+// The cppreference example was modified to handle infinities (with `x == y`).
+// NB: This will return TRUE for x = Inf, y = -Inf and is not expected to be
+// used where that could occur.
 template <class T>
-std::enable_if_t<not std::numeric_limits<T>::is_integer, bool>
-equal_within_ulps_(T x, T y, std::size_t n = 2)
+std::enable_if_t<!std::numeric_limits<T>::is_integer, bool>
+equal_within_ulps_(T x, T y, std::size_t n = 4)
 {
+    if (x == y)
+        return true;
+
     // Since `epsilon()` is the gap size (ULP, unit in the last place)
     // of floating-point numbers in interval [1, 2), we can scale it to
     // the gap size in interval [2^e, 2^{e+1}), where `e` is the exponent
@@ -118,9 +125,9 @@ equal_within_ulps_(T x, T y, std::size_t n = 2)
     const T m = std::min(std::fabs(x), std::fabs(y));
 
     // Subnormal numbers have fixed exponent, which is `min_exponent - 1`.
-    const int exp = m < std::numeric_limits<T>::min()
-                  ? std::numeric_limits<T>::min_exponent - 1
-                  : std::ilogb(m);
+    const int exp = m < std::numeric_limits<T>::min() ?
+                    std::numeric_limits<T>::min_exponent - 1
+                    : std::ilogb(m);
 
     // We consider `x` and `y` equal if the difference between them is
     // within `n` ULPs.

--- a/src/rcpp_util.h
+++ b/src/rcpp_util.h
@@ -18,9 +18,11 @@ std::string get_data_ptr(const Rcpp::RObject &x);
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <type_traits>
 
 constexpr int64_t MAX_INT_AS_R_NUMERIC_ = 9007199254740991;
 
@@ -98,5 +100,32 @@ struct _ci_less {
                                             nocase_compare());
     }
 };
+
+// https://en.cppreference.com/cpp/types/numeric_limits/epsilon
+// use machine epsilon to compare floating-point values
+template <class T>
+std::enable_if_t<not std::numeric_limits<T>::is_integer, bool>
+equal_within_ulps_(T x, T y, std::size_t n = 1)
+{
+    // Since `epsilon()` is the gap size (ULP, unit in the last place)
+    // of floating-point numbers in interval [1, 2), we can scale it to
+    // the gap size in interval [2^e, 2^{e+1}), where `e` is the exponent
+    // of `x` and `y`.
+
+    // If `x` and `y` have different gap sizes (which means they have
+    // different exponents), we take the smaller one. Taking the bigger
+    // one is also reasonable, I guess.
+    const T m = std::min(std::fabs(x), std::fabs(y));
+
+    // Subnormal numbers have fixed exponent, which is `min_exponent - 1`.
+    const int exp = m < std::numeric_limits<T>::min()
+                  ? std::numeric_limits<T>::min_exponent - 1
+                  : std::ilogb(m);
+
+    // We consider `x` and `y` equal if the difference between them is
+    // within `n` ULPs.
+    return std::fabs(x - y) <=
+        n * std::ldexp(std::numeric_limits<T>::epsilon(), exp);
+}
 
 #endif  // RCPP_UTIL_H_

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -180,8 +180,9 @@ test_that("get_pixel_line gives correct results", {
     pts <- read.csv(pt_file)
     pix_line <- c(39, 23, 1, 58, 74, 94, 68, 92, 141, 23, 57, 68, 58, 52, 90,
                   38, 31, 85, 20, 39)
-    raster_file <- system.file("extdata/storm_lake.lcp", package="gdalraster")
+    raster_file <- system.file("extdata/storml_elev.tif", package="gdalraster")
     ds <- new(GDALRaster, raster_file, read_only=TRUE)
+    on.exit(ds$close(), add = TRUE)
     gt <- ds$getGeoTransform()
     res <- get_pixel_line(as.matrix(pts[, -1]), gt)
     expect_equal(as.vector(res), pix_line)
@@ -190,23 +191,45 @@ test_that("get_pixel_line gives correct results", {
     res <- ds$get_pixel_line(pts[, -1])
     expect_equal(as.vector(res), pix_line)
 
-    pts[11, ] <- c(11, 323318, 5105104)
-    expect_warning(res2 <- ds$get_pixel_line(pts[, -1]))
-    res <- rbind(res, c(NA, NA))
+    # point on exactly right edge should be treated as inside
+    bb <- ds$bbox()
+    num_cols <- ds$getRasterXSize()
+    x <- bb[3]
+    y <- bb[4] - 0.1
+    pts[11, ] <- c(11, x, y)
+    # add point to res and use it as expected
+    res <- rbind(res, c(num_cols - 1, 0))
+    expect_no_error(res2 <- ds$get_pixel_line(pts[, -1]))
     expect_equal(res2, res)
 
-    # one coordinate as vector input
+    # point on exactly bottom edge should be treated as inside
+    num_rows <- ds$getRasterYSize()
+    x <- bb[1] + 0.1
+    y <- bb[2]
+    pts[12, ] <- c(12, x, y)
+    # add point to res and use it as expected
+    res <- rbind(res, c(0, num_rows - 1))
+    expect_no_error(res2 <- ds$get_pixel_line(pts[, -1]))
+    expect_equal(res2, res)
+
+    # point outside
+    x <- bb[3] + 0.0001
+    y <- bb[4] - 0.1
+    pts[13, ] <- c(13, x, y)
+    # add point to res and use it as expected
+    res <- rbind(res, c(NA, NA))
+    expect_warning(res2 <- ds$get_pixel_line(pts[, -1]))
+    expect_equal(res2, res)
+
+    # only one input coordinate, given as vector
     res <- get_pixel_line(c(pts[1, 2], pts[1, 3]), gt)  # col 2 x, col 3 y
     expect_equal(as.vector(res), c(pix_line[1], pix_line[11]))
 
     # NA input
     res <- get_pixel_line(c(NA, NA), gt)
     expect_true(all(is.na(res)))
-
     res <- ds$get_pixel_line(c(NA, NA))
     expect_true(all(is.na(res)))
-
-    ds$close()
 })
 
 test_that("fillNodata writes correct output", {

--- a/tests/testthat/test-gdal_exp.R
+++ b/tests/testthat/test-gdal_exp.R
@@ -193,22 +193,22 @@ test_that("get_pixel_line gives correct results", {
 
     # point on exactly right edge should be treated as inside
     bb <- ds$bbox()
-    num_cols <- ds$getRasterXSize()
+    num_cols <- as.integer(ds$getRasterXSize())
     x <- bb[3]
     y <- bb[4] - 0.1
     pts[11, ] <- c(11, x, y)
     # add point to res and use it as expected
-    res <- rbind(res, c(num_cols - 1, 0))
+    res <- rbind(res, c(num_cols - 1L, 0L))
     expect_no_error(res2 <- ds$get_pixel_line(pts[, -1]))
     expect_equal(res2, res)
 
     # point on exactly bottom edge should be treated as inside
-    num_rows <- ds$getRasterYSize()
+    num_rows <- as.integer(ds$getRasterYSize())
     x <- bb[1] + 0.1
     y <- bb[2]
     pts[12, ] <- c(12, x, y)
     # add point to res and use it as expected
-    res <- rbind(res, c(0, num_rows - 1))
+    res <- rbind(res, c(0L, num_rows - 1L))
     expect_no_error(res2 <- ds$get_pixel_line(pts[, -1]))
     expect_equal(res2, res)
 
@@ -217,7 +217,7 @@ test_that("get_pixel_line gives correct results", {
     y <- bb[4] - 0.1
     pts[13, ] <- c(13, x, y)
     # add point to res and use it as expected
-    res <- rbind(res, c(NA, NA))
+    res <- rbind(res, c(NA_integer_, NA_integer_))
     expect_warning(res2 <- ds$get_pixel_line(pts[, -1]))
     expect_equal(res2, res)
 

--- a/tests/testthat/test-rcpp_util.R
+++ b/tests/testthat/test-rcpp_util.R
@@ -1,0 +1,27 @@
+test_that("equal_within_ulps_ behaves as expected", {
+    expect_true(.equal_within_ulps(0, 0));
+    expect_false(.equal_within_ulps(0, 0.00001));
+    expect_false(.equal_within_ulps(0.00001, 0));
+    expect_true(.equal_within_ulps(1.0, 1.0));
+    expect_false(.equal_within_ulps(1.0, 0.99999));
+
+    expect_false(.equal_within_ulps(NaN, NaN))
+    expect_false(.equal_within_ulps(1, NaN))
+    expect_false(.equal_within_ulps(NaN, 1))
+
+    expect_false(.equal_within_ulps(NA, NA))
+    expect_false(.equal_within_ulps(1, NA))
+    expect_false(.equal_within_ulps(NA, 1))
+
+    expect_true(.equal_within_ulps(Inf, Inf))
+    expect_true(.equal_within_ulps(-Inf, -Inf))
+
+    expect_true(.equal_within_ulps(.Machine$double.xmax,
+                                   .Machine$double.xmax))
+    expect_true(.equal_within_ulps(.Machine$double.xmin,
+                                   .Machine$double.xmin))
+    expect_false(.equal_within_ulps(.Machine$double.xmax, Inf))
+
+    skip_on_cran()
+    expect_true(.equal_within_ulps(1.0, 0.99999999999999999));
+})


### PR DESCRIPTION
* makes `get_pixel_line()` consistent with `GDALRaster::pixel_extract()`
* that implementation was intended to match behavior in https://github.com/OSGeo/gdal/pull/12087
* discussion: https://github.com/OSGeo/gdal/pull/12080#discussion_r2028790673
* adds `equal_within_ulps_()` to replace using the non-public `ARE_REAL_EQUAL()` in GDAL's gcore/gdal_cpp_functions.h